### PR TITLE
Custom notification control buttons (like, shuffle, repeat)

### DIFF
--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -57,6 +57,8 @@
                 <action android:name="ch.snepilatch.app.PREV" />
                 <action android:name="ch.snepilatch.app.PLAY_PAUSE" />
                 <action android:name="ch.snepilatch.app.NEXT" />
+                <action android:name="ch.snepilatch.app.LEFT_ACTION" />
+                <action android:name="ch.snepilatch.app.RIGHT_ACTION" />
             </intent-filter>
         </receiver>
     </application>

--- a/src/app/src/main/java/ch/snepilatch/app/MediaActionReceiver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MediaActionReceiver.kt
@@ -18,6 +18,20 @@ class MediaActionReceiver : BroadcastReceiver() {
                 }
             }
             "ch.snepilatch.app.NEXT" -> svc.onSkipNext?.invoke()
+            "ch.snepilatch.app.LEFT_ACTION" -> {
+                when (svc.notificationLeftButton) {
+                    "like" -> svc.onLikeToggle?.invoke()
+                    "shuffle" -> svc.onShuffleToggle?.invoke()
+                    "repeat" -> svc.onRepeatToggle?.invoke()
+                }
+            }
+            "ch.snepilatch.app.RIGHT_ACTION" -> {
+                when (svc.notificationRightButton) {
+                    "like" -> svc.onLikeToggle?.invoke()
+                    "shuffle" -> svc.onShuffleToggle?.invoke()
+                    "repeat" -> svc.onRepeatToggle?.invoke()
+                }
+            }
         }
     }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MusicPlaybackService.kt
@@ -70,6 +70,17 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     var onTrackTransition: (() -> Unit)? = null
     var onPlaybackError: ((String) -> Unit)? = null
     var onPlaybackEnded: (() -> Unit)? = null
+    var onLikeToggle: (() -> Unit)? = null
+    var onShuffleToggle: (() -> Unit)? = null
+    var onRepeatToggle: (() -> Unit)? = null
+
+    // Notification custom button state
+    var isLiked: Boolean = false
+    var isShuffling: Boolean = false
+    var repeatMode: String = "off"  // "off", "context", "track"
+    // Which extra buttons to show: "like", "shuffle", "repeat"
+    var notificationLeftButton: String = "repeat"
+    var notificationRightButton: String = "like"
 
     override fun onCreate() {
         super.onCreate()
@@ -203,6 +214,19 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                     player.stop()
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     stopSelf()
+                }
+
+                override fun onCustomAction(action: String?, extras: Bundle?) {
+                    val buttonType = when (action) {
+                        "LEFT_ACTION" -> notificationLeftButton
+                        "RIGHT_ACTION" -> notificationRightButton
+                        else -> return
+                    }
+                    when (buttonType) {
+                        "like" -> onLikeToggle?.invoke()
+                        "shuffle" -> onShuffleToggle?.invoke()
+                        "repeat" -> onRepeatToggle?.invoke()
+                    }
                 }
             })
             isActive = true
@@ -418,7 +442,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             player.playWhenReady -> PlaybackStateCompat.STATE_PAUSED
             else -> PlaybackStateCompat.STATE_PAUSED
         }
-        val playbackState = PlaybackStateCompat.Builder()
+        val builder = PlaybackStateCompat.Builder()
             .setActions(
                 PlaybackStateCompat.ACTION_PLAY or
                 PlaybackStateCompat.ACTION_PAUSE or
@@ -429,11 +453,35 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                 PlaybackStateCompat.ACTION_STOP
             )
             .setState(state, player.currentPosition, 1f)
-            .build()
-        mediaSession?.setPlaybackState(playbackState)
+
+        // Add custom actions for left and right buttons
+        fun addButtonAction(type: String, actionName: String) {
+            when (type) {
+                "like" -> {
+                    val icon = if (isLiked) R.drawable.ic_heart_filled else R.drawable.ic_heart_outline
+                    builder.addCustomAction(actionName, if (isLiked) "Unlike" else "Like", icon)
+                }
+                "shuffle" -> {
+                    val icon = if (isShuffling) R.drawable.ic_shuffle_on else R.drawable.ic_shuffle_off
+                    builder.addCustomAction(actionName, "Shuffle", icon)
+                }
+                "repeat" -> {
+                    val icon = when (repeatMode) {
+                        "track" -> R.drawable.ic_repeat_one
+                        "context" -> R.drawable.ic_repeat_on
+                        else -> R.drawable.ic_repeat_off
+                    }
+                    builder.addCustomAction(actionName, "Repeat", icon)
+                }
+            }
+        }
+        addButtonAction(notificationLeftButton, "LEFT_ACTION")
+        addButtonAction(notificationRightButton, "RIGHT_ACTION")
+
+        mediaSession?.setPlaybackState(builder.build())
     }
 
-    private fun updateNotification() {
+    fun updateNotification() {
         updatePlaybackState()
         updateMediaSessionMetadata()
         val nm = getSystemService(NotificationManager::class.java)
@@ -459,28 +507,58 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             Intent("ch.snepilatch.app.NEXT"),
             PendingIntent.FLAG_IMMUTABLE
         )
+        val leftIntent = PendingIntent.getBroadcast(
+            this, 3,
+            Intent("ch.snepilatch.app.LEFT_ACTION"),
+            PendingIntent.FLAG_IMMUTABLE
+        )
+        val rightIntent = PendingIntent.getBroadcast(
+            this, 4,
+            Intent("ch.snepilatch.app.RIGHT_ACTION"),
+            PendingIntent.FLAG_IMMUTABLE
+        )
 
         val playPauseIcon = if (isPlaying)
             android.R.drawable.ic_media_pause
         else
             android.R.drawable.ic_media_play
 
+        fun buttonIcon(type: String) = when (type) {
+            "like" -> if (isLiked) R.drawable.ic_heart_filled else R.drawable.ic_heart_outline
+            "shuffle" -> if (isShuffling) R.drawable.ic_shuffle_on else R.drawable.ic_shuffle_off
+            "repeat" -> when (repeatMode) {
+                "track" -> R.drawable.ic_repeat_one
+                "context" -> R.drawable.ic_repeat_on
+                else -> R.drawable.ic_repeat_off
+            }
+            else -> R.drawable.ic_heart_outline
+        }
+        fun buttonLabel(type: String) = when (type) {
+            "like" -> if (isLiked) "Unlike" else "Like"
+            "shuffle" -> "Shuffle"
+            "repeat" -> "Repeat"
+            else -> "Like"
+        }
+
         val sessionToken = mediaSession?.sessionToken
 
+        // Layout: [left] [prev] [play/pause] [next] [right]
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setSmallIcon(android.R.drawable.ic_media_play)
-            .setContentTitle(currentTitle.ifEmpty { "Kotify" })
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle(currentTitle.ifEmpty { "Snepilatch" })
             .setContentText(currentArtist)
             .setLargeIcon(currentArt)
             .setOngoing(isPlaying)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .addAction(buttonIcon(notificationLeftButton), buttonLabel(notificationLeftButton), leftIntent)
             .addAction(android.R.drawable.ic_media_previous, "Previous", prevIntent)
             .addAction(playPauseIcon, if (isPlaying) "Pause" else "Play", playPauseIntent)
             .addAction(android.R.drawable.ic_media_next, "Next", nextIntent)
+            .addAction(buttonIcon(notificationRightButton), buttonLabel(notificationRightButton), rightIntent)
             .setStyle(
                 androidx.media.app.NotificationCompat.MediaStyle()
                     .setMediaSession(sessionToken)
-                    .setShowActionsInCompactView(0, 1, 2)
+                    .setShowActionsInCompactView(1, 2, 3)
             )
             .setContentIntent(mediaSession?.controller?.sessionActivity)
             .build()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -325,6 +325,101 @@ fun AccountScreen(vm: SpotifyViewModel) {
             )
         }
 
+        // Notification button options
+        val buttonOptions = listOf(
+            "like" to "Like / Unlike" to "Toggle liked state",
+            "shuffle" to "Shuffle" to "Toggle shuffle mode",
+            "repeat" to "Repeat" to "Cycle repeat (off → all → one)"
+        )
+        fun buttonLabel(type: String) = when (type) {
+            "like" -> "Like / Unlike"
+            "shuffle" -> "Shuffle"
+            "repeat" -> "Repeat"
+            else -> type
+        }
+
+        // Left notification button
+        val leftButton by vm.notificationLeftButton.collectAsState()
+        var showLeftPicker by remember { mutableStateOf(false) }
+        ListItem(
+            headlineContent = { Text("Notification Left Button", color = SpotifyWhite) },
+            supportingContent = { Text(buttonLabel(leftButton), color = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Default.Notifications, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showLeftPicker = true }
+        )
+        if (showLeftPicker) {
+            AlertDialog(
+                onDismissRequest = { showLeftPicker = false },
+                title = { Text("Left Button", color = SpotifyWhite) },
+                text = {
+                    Column {
+                        buttonOptions.forEach { (pair, desc) ->
+                            val (value, label) = pair
+                            Row(
+                                Modifier.fillMaxWidth().clickable {
+                                    vm.setNotificationLeftButton(value, audioContext)
+                                    showLeftPicker = false
+                                }.padding(vertical = 12.dp, horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(selected = leftButton == value, onClick = {
+                                    vm.setNotificationLeftButton(value, audioContext)
+                                    showLeftPicker = false
+                                }, colors = RadioButtonDefaults.colors(selectedColor = animatedPrimary, unselectedColor = SpotifyLightGray))
+                                Spacer(Modifier.width(8.dp))
+                                Column { Text(label, color = SpotifyWhite, fontSize = 15.sp); Text(desc, color = SpotifyLightGray, fontSize = 12.sp) }
+                            }
+                        }
+                    }
+                },
+                containerColor = SpotifyGray, confirmButton = {},
+                dismissButton = { TextButton(onClick = { showLeftPicker = false }) { Text("Cancel", color = SpotifyLightGray) } }
+            )
+        }
+
+        // Right notification button
+        val rightButton by vm.notificationRightButton.collectAsState()
+        var showRightPicker by remember { mutableStateOf(false) }
+        ListItem(
+            headlineContent = { Text("Notification Right Button", color = SpotifyWhite) },
+            supportingContent = { Text(buttonLabel(rightButton), color = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Default.Notifications, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showRightPicker = true }
+        )
+        if (showRightPicker) {
+            AlertDialog(
+                onDismissRequest = { showRightPicker = false },
+                title = { Text("Right Button", color = SpotifyWhite) },
+                text = {
+                    Column {
+                        buttonOptions.forEach { (pair, desc) ->
+                            val (value, label) = pair
+                            Row(
+                                Modifier.fillMaxWidth().clickable {
+                                    vm.setNotificationRightButton(value, audioContext)
+                                    showRightPicker = false
+                                }.padding(vertical = 12.dp, horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(selected = rightButton == value, onClick = {
+                                    vm.setNotificationRightButton(value, audioContext)
+                                    showRightPicker = false
+                                }, colors = RadioButtonDefaults.colors(selectedColor = animatedPrimary, unselectedColor = SpotifyLightGray))
+                                Spacer(Modifier.width(8.dp))
+                                Column { Text(label, color = SpotifyWhite, fontSize = 15.sp); Text(desc, color = SpotifyLightGray, fontSize = 12.sp) }
+                            }
+                        }
+                    }
+                },
+                containerColor = SpotifyGray, confirmButton = {},
+                dismissButton = { TextButton(onClick = { showRightPicker = false }) { Text("Cancel", color = SpotifyLightGray) } }
+            )
+        }
+
         ListItem(
             headlineContent = { Text("Connect to a device", color = SpotifyWhite) },
             leadingContent = { Icon(Icons.Default.Devices, null, tint = SpotifyLightGray) },

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -151,6 +151,9 @@ class SpotifyViewModel : ViewModel() {
     val preferredAudioSource = MutableStateFlow<String?>(null)
     // Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"
     val lyricsAnimDirection = MutableStateFlow("vertical")
+    // Notification button preferences: "like", "shuffle", "repeat"
+    val notificationLeftButton = MutableStateFlow("repeat")
+    val notificationRightButton = MutableStateFlow("like")
     // Canvas background
     val canvasEnabled = MutableStateFlow(false)
     val canvasUrl = MutableStateFlow<String?>(null)
@@ -475,6 +478,13 @@ class SpotifyViewModel : ViewModel() {
             startPositionTicker()
         } else {
             positionJob?.cancel()
+        }
+
+        // Sync notification button states
+        MusicPlaybackService.instance?.let { svc ->
+            svc.isLiked = currentTrackLiked.value
+            svc.isShuffling = state.is_shuffling
+            svc.repeatMode = state.repeat_mode
         }
 
         // Update active device indicator from state
@@ -987,6 +997,28 @@ class SpotifyViewModel : ViewModel() {
         }
         lyricsAnimDirection.value = prefs.getString("lyrics_anim_direction", "vertical") ?: "vertical"
         canvasEnabled.value = prefs.getBoolean("canvas_enabled", false)
+        notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"
+        notificationRightButton.value = prefs.getString("notification_right_button", "like") ?: "like"
+    }
+
+    fun setNotificationLeftButton(button: String, context: Context) {
+        notificationLeftButton.value = button
+        context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
+            .edit().putString("notification_left_button", button).apply()
+        MusicPlaybackService.instance?.let { svc ->
+            svc.notificationLeftButton = button
+            svc.updateNotification()
+        }
+    }
+
+    fun setNotificationRightButton(button: String, context: Context) {
+        notificationRightButton.value = button
+        context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
+            .edit().putString("notification_right_button", button).apply()
+        MusicPlaybackService.instance?.let { svc ->
+            svc.notificationRightButton = button
+            svc.updateNotification()
+        }
     }
 
     fun setCanvasEnabled(enabled: Boolean, context: Context) {
@@ -1070,6 +1102,41 @@ class SpotifyViewModel : ViewModel() {
                 try { player?.seek(posMs.toInt()) }
                 catch (e: CancellationException) { throw e }
                 catch (e: Exception) { LokiLogger.e(TAG, "svc seek", e) }
+            }
+        }
+        // Load notification button preference
+        val prefs = svc.getSharedPreferences("kotify_prefs", android.content.Context.MODE_PRIVATE)
+        svc.notificationLeftButton = prefs.getString("notification_left_button", "repeat") ?: "repeat"
+        svc.notificationRightButton = prefs.getString("notification_right_button", "like") ?: "like"
+
+        svc.onLikeToggle = lambda@{
+            val track = _playback.value.track ?: return@lambda
+            val trackId = track.uri.removePrefix("spotify:track:")
+            if (currentTrackLiked.value) {
+                unlikeSong(trackId)
+            } else {
+                likeSong(trackId)
+            }
+            viewModelScope.launch {
+                kotlinx.coroutines.delay(300)
+                svc.isLiked = currentTrackLiked.value
+                svc.updateNotification()
+            }
+        }
+        svc.onShuffleToggle = {
+            toggleShuffle()
+            viewModelScope.launch {
+                kotlinx.coroutines.delay(300)
+                svc.isShuffling = _playback.value.isShuffling
+                svc.updateNotification()
+            }
+        }
+        svc.onRepeatToggle = {
+            cycleRepeat()
+            viewModelScope.launch {
+                kotlinx.coroutines.delay(300)
+                svc.repeatMode = _playback.value.repeatMode
+                svc.updateNotification()
             }
         }
         svc.onTrackTransition = {

--- a/src/app/src/main/res/drawable/ic_heart_filled.xml
+++ b/src/app/src/main/res/drawable/ic_heart_filled.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1DB954"
+        android:pathData="M20.84,4.61a5.5,5.5 0,0 0,-7.78 0L12,5.67l-1.06,-1.06a5.5,5.5 0,0 0,-7.78 7.78l1.06,1.06L12,21.23l7.78,-7.78 1.06,-1.06a5.5,5.5 0,0 0,0 -7.78z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_heart_outline.xml
+++ b/src/app/src/main/res/drawable/ic_heart_outline.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="2"
+        android:pathData="M20.84,4.61a5.5,5.5 0,0 0,-7.78 0L12,5.67l-1.06,-1.06a5.5,5.5 0,0 0,-7.78 7.78l1.06,1.06L12,21.23l7.78,-7.78 1.06,-1.06a5.5,5.5 0,0 0,0 -7.78z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_notification.xml
+++ b/src/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,41 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!-- Headphone band -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.8"
+        android:pathData="M4,14 C4,8.5 7.5,4 12,4 C16.5,4 20,8.5 20,14" />
+    <!-- Left earpiece -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M2,12.5 C2,11.7 2.7,11 3.5,11 L4.5,11 C5.3,11 6,11.7 6,12.5 L6,18.5 C6,19.3 5.3,20 4.5,20 L3.5,20 C2.7,20 2,19.3 2,18.5 Z" />
+    <!-- Right earpiece -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M18,12.5 C18,11.7 18.7,11 19.5,11 L20.5,11 C21.3,11 22,11.7 22,12.5 L22,18.5 C22,19.3 21.3,20 20.5,20 L19.5,20 C18.7,20 18,19.3 18,18.5 Z" />
+    <!-- Sound wave 1 -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.2"
+        android:strokeLineCap="round"
+        android:pathData="M10,14 C10.8,13 10.8,17 10,16" />
+    <!-- Sound wave 2 -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.2"
+        android:strokeLineCap="round"
+        android:pathData="M12.5,12 C14,10.5 14,19.5 12.5,18" />
+    <!-- Sound wave 3 -->
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.2"
+        android:strokeLineCap="round"
+        android:pathData="M15,10 C17.5,7.5 17.5,22.5 15,20" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_repeat_off.xml
+++ b/src/app/src/main/res/drawable/ic_repeat_off.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.5"
+        android:pathData="M7,7h10v3l4,-4 -4,-4v3H5v6h2V7zM17,17H7v-3l-4,4 4,4v-3h12v-6h-2v4z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_repeat_on.xml
+++ b/src/app/src/main/res/drawable/ic_repeat_on.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1DB954"
+        android:pathData="M7,7h10v3l4,-4 -4,-4v3H5v6h2V7zM17,17H7v-3l-4,4 4,4v-3h12v-6h-2v4z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_repeat_one.xml
+++ b/src/app/src/main/res/drawable/ic_repeat_one.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1DB954"
+        android:pathData="M7,7h10v3l4,-4 -4,-4v3H5v6h2V7zM17,17H7v-3l-4,4 4,4v-3h12v-6h-2v4z" />
+    <path
+        android:fillColor="#1DB954"
+        android:pathData="M13,15V9h-1l-2,1v1h1.5v4z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_shuffle_off.xml
+++ b/src/app/src/main/res/drawable/ic_shuffle_off.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.5"
+        android:pathData="M10.59,9.17L5.41,4 4,5.41l5.17,5.17 1.42,-1.41zM14.5,4l2.04,2.04L4,18.59 5.41,20 17.96,7.46 20,9.5L20,4h-5.5zM14.83,13.41l-1.41,1.41 3.13,3.13L14.5,20L20,20v-5.5l-2.04,2.04 -3.13,-3.13z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_shuffle_on.xml
+++ b/src/app/src/main/res/drawable/ic_shuffle_on.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#1DB954"
+        android:pathData="M10.59,9.17L5.41,4 4,5.41l5.17,5.17 1.42,-1.41zM14.5,4l2.04,2.04L4,18.59 5.41,20 17.96,7.46 20,9.5L20,4h-5.5zM14.83,13.41l-1.41,1.41 3.13,3.13L14.5,20L20,20v-5.5l-2.04,2.04 -3.13,-3.13z" />
+</vector>


### PR DESCRIPTION
## Summary
- Add configurable extra button in notification controls (like, shuffle, or repeat)
- Add **Notification Button** setting in Account screen to choose which button appears
- Replace generic play icon with monochrome app icon (headphones) in notification
- Like button toggles liked state for current track
- Shuffle button toggles shuffle mode
- Repeat button cycles through off → all → one
- Button state syncs from WebSocket updates

Requested by Cinnabar (Jake) on Discord.

Closes #89