### PR TITLE
Add language picker to settings

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -138,9 +138,58 @@ fun AccountScreen(vm: SpotifyViewModel) {
             modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
         )
 
+        val audioContext = androidx.compose.ui.platform.LocalContext.current
+
+        // Language picker
+        val appLanguage by vm.appLanguage.collectAsState()
+        var showLanguagePicker by remember { mutableStateOf(false) }
+        val languages = listOf(
+            "system" to "System Default",
+            "en" to "English",
+            "de" to "Deutsch",
+            "ru" to "Русский",
+            "gsw" to "Schwiizerdütsch"
+        )
+        val currentLanguageLabel = languages.find { it.first == appLanguage }?.second ?: "System Default"
+        ListItem(
+            headlineContent = { Text("Language", color = SpotifyWhite) },
+            supportingContent = { Text(currentLanguageLabel, color = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Default.Language, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showLanguagePicker = true }
+        )
+        if (showLanguagePicker) {
+            AlertDialog(
+                onDismissRequest = { showLanguagePicker = false },
+                title = { Text("Language", color = SpotifyWhite) },
+                text = {
+                    Column {
+                        languages.forEach { (code, label) ->
+                            Row(
+                                Modifier.fillMaxWidth().clickable {
+                                    vm.setAppLanguage(code, audioContext)
+                                    showLanguagePicker = false
+                                }.padding(vertical = 12.dp, horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(selected = appLanguage == code, onClick = {
+                                    vm.setAppLanguage(code, audioContext)
+                                    showLanguagePicker = false
+                                }, colors = RadioButtonDefaults.colors(selectedColor = animatedPrimary, unselectedColor = SpotifyLightGray))
+                                Spacer(Modifier.width(8.dp))
+                                Text(label, color = SpotifyWhite, fontSize = 15.sp)
+                            }
+                        }
+                    }
+                },
+                containerColor = SpotifyGray, confirmButton = {},
+                dismissButton = { TextButton(onClick = { showLanguagePicker = false }) { Text("Cancel", color = SpotifyLightGray) } }
+            )
+        }
+
         // Audio settings
         val audioSource by vm.preferredAudioSource.collectAsState()
-        val audioContext = androidx.compose.ui.platform.LocalContext.current
         val isLossless = audioSource == "tidal" || audioSource == "qobuz"
 
         // Lossless toggle

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -151,6 +151,8 @@ class SpotifyViewModel : ViewModel() {
     val preferredAudioSource = MutableStateFlow<String?>(null)
     // Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"
     val lyricsAnimDirection = MutableStateFlow("vertical")
+    // Language preference: "system", "en", "de", "ru", "gsw"
+    val appLanguage = MutableStateFlow("system")
     // Notification button preferences: "like", "shuffle", "repeat"
     val notificationLeftButton = MutableStateFlow("repeat")
     val notificationRightButton = MutableStateFlow("like")
@@ -1046,6 +1048,26 @@ class SpotifyViewModel : ViewModel() {
             .edit().putString("lyrics_anim_direction", direction).apply()
     }
 
+    fun setAppLanguage(language: String, context: Context) {
+        appLanguage.value = language
+        context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
+            .edit().putString("app_language", language).apply()
+        // Apply locale change
+        val locale = if (language == "system") {
+            java.util.Locale.getDefault()
+        } else if (language == "gsw") {
+            java.util.Locale.Builder().setLanguageTag("gsw").build()
+        } else {
+            java.util.Locale(language)
+        }
+        val config = context.resources.configuration
+        config.setLocale(locale)
+        @Suppress("DEPRECATION")
+        context.resources.updateConfiguration(config, context.resources.displayMetrics)
+        // Restart activity to apply
+        (context as? android.app.Activity)?.recreate()
+    }
+
     fun loadPreferences(context: Context) {
         val prefs = context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
         val savedSource = prefs.getString("audio_source", null)
@@ -1055,6 +1077,16 @@ class SpotifyViewModel : ViewModel() {
             prefs.edit().remove("audio_source").apply()
         }
         lyricsAnimDirection.value = prefs.getString("lyrics_anim_direction", "vertical") ?: "vertical"
+        appLanguage.value = prefs.getString("app_language", "system") ?: "system"
+        // Apply saved language on startup
+        val lang = appLanguage.value
+        if (lang != "system") {
+            val locale = if (lang == "gsw") java.util.Locale.Builder().setLanguageTag("gsw").build() else java.util.Locale(lang)
+            val config = context.resources.configuration
+            config.setLocale(locale)
+            @Suppress("DEPRECATION")
+            context.resources.updateConfiguration(config, context.resources.displayMetrics)
+        }
         canvasEnabled.value = prefs.getBoolean("canvas_enabled", false)
         contentRegion.value = prefs.getString("content_region", "US") ?: "US"
         notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"


### PR DESCRIPTION
## Summary
- Add language picker in Account → Settings
- Options: System Default, English, Deutsch, Русский, Schwiizerdütsch
- Saves preference and applies locale immediately (recreates activity)
- Loads saved language on app startup

Closes #121