### PR TITLE
Show audio output device on player pill

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -450,6 +450,17 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                         val activeDevice by vm.activeDeviceName.collectAsState()
                         val provider by vm.streamProvider.collectAsState()
                         val streaming by vm.isStreaming.collectAsState()
+                        val audioOutput by vm.audioOutputName.collectAsState()
+                        val audioType by vm.audioOutputType.collectAsState()
+                        // Refresh audio output info
+                        val audioCtx = LocalContext.current
+                        LaunchedEffect(streaming) { vm.updateAudioOutput(audioCtx) }
+                        val audioIcon = when (audioType) {
+                            "bluetooth" -> Icons.Default.Bluetooth
+                            "wired" -> Icons.Default.Headphones
+                            "usb" -> Icons.Default.Usb
+                            else -> Icons.Default.Speaker
+                        }
                         Row(
                             Modifier.fillMaxWidth(),
                             horizontalArrangement = Arrangement.SpaceBetween,
@@ -467,10 +478,10 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                         .clickable { vm.loadDevices(); vm.showDevices.value = true },
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    Icon(Icons.Default.Devices, "Devices", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                    Icon(audioIcon, "Audio Output", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                                 }
                                 Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                    activeDevice?.let { InfoPill(Icons.Default.Devices, it) }
+                                    audioOutput?.let { InfoPill(audioIcon, it) }
                                     provider?.let { SourcePill(it) }
                                 }
                             }
@@ -808,6 +819,16 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                     val activeDevice by vm.activeDeviceName.collectAsState()
                     val provider by vm.streamProvider.collectAsState()
                     val streaming by vm.isStreaming.collectAsState()
+                    val audioOutput by vm.audioOutputName.collectAsState()
+                    val audioType by vm.audioOutputType.collectAsState()
+                    val audioCtx2 = LocalContext.current
+                    LaunchedEffect(streaming) { vm.updateAudioOutput(audioCtx2) }
+                    val audioIcon = when (audioType) {
+                        "bluetooth" -> Icons.Default.Bluetooth
+                        "wired" -> Icons.Default.Headphones
+                        "usb" -> Icons.Default.Usb
+                        else -> Icons.Default.Speaker
+                    }
                     Row(
                         Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
@@ -825,10 +846,10 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.loadDevices(); vm.showDevices.value = true },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.Devices, "Devices", tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(audioIcon, "Audio Output", tint = SpotifyWhite, modifier = Modifier.size(22.dp))
                             }
                             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                                activeDevice?.let { InfoPill(Icons.Default.Devices, it) }
+                                audioOutput?.let { InfoPill(audioIcon, it) }
                                 provider?.let { SourcePill(it) }
                             }
                         }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -150,6 +150,10 @@ class SpotifyViewModel : ViewModel() {
     private var appContext: Context? = null
     private var lastPaletteUrl: String? = null
 
+    // Audio output device (Bluetooth, speaker, wired)
+    val audioOutputName = MutableStateFlow<String?>(null)
+    val audioOutputType = MutableStateFlow("speaker") // "speaker", "bluetooth", "wired", "usb"
+
     // Audio source preference: null = auto (default chain), or "tidal", "qobuz", "youtube"
     val preferredAudioSource = MutableStateFlow<String?>(null)
     // Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"
@@ -1193,6 +1197,51 @@ class SpotifyViewModel : ViewModel() {
         appContext = context.applicationContext
         val intent = Intent(context, MusicPlaybackService::class.java)
         context.startForegroundService(intent)
+    }
+
+    fun updateAudioOutput(context: Context) {
+        val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as android.media.AudioManager
+        val devices = audioManager.getDevices(android.media.AudioManager.GET_DEVICES_OUTPUTS)
+        // Find the active output — prefer Bluetooth > USB > Wired > Speaker
+        val active = devices.firstOrNull {
+            it.type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+            it.type == android.media.AudioDeviceInfo.TYPE_BLE_HEADSET ||
+            it.type == android.media.AudioDeviceInfo.TYPE_BLE_SPEAKER
+        } ?: devices.firstOrNull {
+            it.type == android.media.AudioDeviceInfo.TYPE_USB_HEADSET ||
+            it.type == android.media.AudioDeviceInfo.TYPE_USB_DEVICE
+        } ?: devices.firstOrNull {
+            it.type == android.media.AudioDeviceInfo.TYPE_WIRED_HEADSET ||
+            it.type == android.media.AudioDeviceInfo.TYPE_WIRED_HEADPHONES
+        }
+
+        if (active != null) {
+            val name = active.productName?.toString()?.takeIf { it.isNotBlank() && it != "null" }
+                ?: when (active.type) {
+                    android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+                    android.media.AudioDeviceInfo.TYPE_BLE_HEADSET,
+                    android.media.AudioDeviceInfo.TYPE_BLE_SPEAKER -> "Bluetooth"
+                    android.media.AudioDeviceInfo.TYPE_USB_HEADSET,
+                    android.media.AudioDeviceInfo.TYPE_USB_DEVICE -> "USB Audio"
+                    android.media.AudioDeviceInfo.TYPE_WIRED_HEADSET,
+                    android.media.AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "Wired"
+                    else -> "External"
+                }
+            audioOutputName.value = name
+            audioOutputType.value = when (active.type) {
+                android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+                android.media.AudioDeviceInfo.TYPE_BLE_HEADSET,
+                android.media.AudioDeviceInfo.TYPE_BLE_SPEAKER -> "bluetooth"
+                android.media.AudioDeviceInfo.TYPE_USB_HEADSET,
+                android.media.AudioDeviceInfo.TYPE_USB_DEVICE -> "usb"
+                android.media.AudioDeviceInfo.TYPE_WIRED_HEADSET,
+                android.media.AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "wired"
+                else -> "speaker"
+            }
+        } else {
+            audioOutputName.value = "Speaker"
+            audioOutputType.value = "speaker"
+        }
     }
 
     fun wireServiceControls() {


### PR DESCRIPTION
## Summary
- Show current audio output (Bluetooth name, Speaker, Wired, USB) on player pill
- Dynamic icon: Bluetooth, Headphones, USB, or Speaker based on connection type
- Updates when streaming state changes

Closes #126