### PR TITLE
Invalidate persisted device ID on app update

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -223,18 +223,26 @@ class SpotifyViewModel : ViewModel() {
                 val phoneName = android.os.Build.MODEL
                 val pc = PlayerConnect(sess, deviceName = phoneName)
 
-                // Persist device ID to avoid ghost devices on Spotify's device list
+                // Persist device ID — but invalidate if app version changed
+                // (capabilities may have changed between builds)
                 val svcContext = MusicPlaybackService.instance as? android.content.Context
                 val devicePrefs = svcContext?.getSharedPreferences("kotify_prefs", android.content.Context.MODE_PRIVATE)
+                val currentVersion = try { svcContext?.packageManager?.getPackageInfo(svcContext.packageName, 0)?.versionCode } catch (_: Exception) { null }
+                val savedVersion = devicePrefs?.getInt("device_id_version", -1)
                 val savedDeviceId = devicePrefs?.getString("persisted_device_id", null)
-                if (savedDeviceId != null) {
+                if (savedDeviceId != null && savedVersion == currentVersion) {
                     pc.setPersistedDeviceId(savedDeviceId)
                     LokiLogger.i(TAG, "Reusing persisted device ID: $savedDeviceId")
+                } else if (savedDeviceId != null) {
+                    LokiLogger.i(TAG, "App version changed ($savedVersion -> $currentVersion), generating fresh device ID")
                 }
                 pc.ready()
                 val currentDeviceId = pc.ourDeviceId()
-                if (currentDeviceId != null && currentDeviceId != savedDeviceId) {
-                    devicePrefs?.edit()?.putString("persisted_device_id", currentDeviceId)?.apply()
+                if (currentDeviceId != null) {
+                    devicePrefs?.edit()
+                        ?.putString("persisted_device_id", currentDeviceId)
+                        ?.putInt("device_id_version", currentVersion ?: -1)
+                        ?.apply()
                 }
                 player = pc
                 LokiLogger.i(TAG, "Player ready, device: $currentDeviceId")


### PR DESCRIPTION
## Summary
- Track versionCode alongside persisted device ID
- Generate fresh device ID when app is updated (versionCode changes)
- Prevents stale server-side device registration from breaking playback

Closes #128