### PR TITLE
Fix duplicate player on reopen and live audio output

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -452,9 +452,18 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                         val streaming by vm.isStreaming.collectAsState()
                         val audioOutput by vm.audioOutputName.collectAsState()
                         val audioType by vm.audioOutputType.collectAsState()
-                        // Refresh audio output info
+                        // Live audio output tracking
                         val audioCtx = LocalContext.current
-                        LaunchedEffect(streaming) { vm.updateAudioOutput(audioCtx) }
+                        DisposableEffect(Unit) {
+                            val am = audioCtx.getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager
+                            vm.updateAudioOutput(audioCtx)
+                            val cb = object : android.media.AudioDeviceCallback() {
+                                override fun onAudioDevicesAdded(added: Array<out android.media.AudioDeviceInfo>?) { vm.updateAudioOutput(audioCtx) }
+                                override fun onAudioDevicesRemoved(removed: Array<out android.media.AudioDeviceInfo>?) { vm.updateAudioOutput(audioCtx) }
+                            }
+                            am.registerAudioDeviceCallback(cb, null)
+                            onDispose { am.unregisterAudioDeviceCallback(cb) }
+                        }
                         val audioIcon = when (audioType) {
                             "bluetooth" -> Icons.Default.Bluetooth
                             "wired" -> Icons.Default.Headphones
@@ -822,7 +831,16 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                     val audioOutput by vm.audioOutputName.collectAsState()
                     val audioType by vm.audioOutputType.collectAsState()
                     val audioCtx2 = LocalContext.current
-                    LaunchedEffect(streaming) { vm.updateAudioOutput(audioCtx2) }
+                    DisposableEffect(Unit) {
+                        val am = audioCtx2.getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager
+                        vm.updateAudioOutput(audioCtx2)
+                        val cb = object : android.media.AudioDeviceCallback() {
+                            override fun onAudioDevicesAdded(added: Array<out android.media.AudioDeviceInfo>?) { vm.updateAudioOutput(audioCtx2) }
+                            override fun onAudioDevicesRemoved(removed: Array<out android.media.AudioDeviceInfo>?) { vm.updateAudioOutput(audioCtx2) }
+                        }
+                        am.registerAudioDeviceCallback(cb, null)
+                        onDispose { am.unregisterAudioDeviceCallback(cb) }
+                    }
                     val audioIcon = when (audioType) {
                         "bluetooth" -> Icons.Default.Bluetooth
                         "wired" -> Icons.Default.Headphones

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -220,32 +220,21 @@ class SpotifyViewModel : ViewModel() {
                 isInitialized.value = true
                 initRetryCount = 0
 
+                // Disconnect any existing player before creating a new one
+                // This prevents duplicate device registrations
+                player?.let { oldPlayer ->
+                    LokiLogger.i(TAG, "Disconnecting old player before creating new one")
+                    try { oldPlayer.disconnect() } catch (_: Exception) {}
+                    player = null
+                }
+
                 val phoneName = android.os.Build.MODEL
                 val pc = PlayerConnect(sess, deviceName = phoneName)
 
-                // Persist device ID — but invalidate if app version changed
-                // (capabilities may have changed between builds)
-                val svcContext = MusicPlaybackService.instance as? android.content.Context
-                val devicePrefs = svcContext?.getSharedPreferences("kotify_prefs", android.content.Context.MODE_PRIVATE)
-                val currentVersion = try { svcContext?.packageManager?.getPackageInfo(svcContext.packageName, 0)?.versionCode } catch (_: Exception) { null }
-                val savedVersion = devicePrefs?.getInt("device_id_version", -1)
-                val savedDeviceId = devicePrefs?.getString("persisted_device_id", null)
-                if (savedDeviceId != null && savedVersion == currentVersion) {
-                    pc.setPersistedDeviceId(savedDeviceId)
-                    LokiLogger.i(TAG, "Reusing persisted device ID: $savedDeviceId")
-                } else if (savedDeviceId != null) {
-                    LokiLogger.i(TAG, "App version changed ($savedVersion -> $currentVersion), generating fresh device ID")
-                }
+                // Fresh device ID every launch — avoids stale server-side registrations
                 pc.ready()
-                val currentDeviceId = pc.ourDeviceId()
-                if (currentDeviceId != null) {
-                    devicePrefs?.edit()
-                        ?.putString("persisted_device_id", currentDeviceId)
-                        ?.putInt("device_id_version", currentVersion ?: -1)
-                        ?.apply()
-                }
                 player = pc
-                LokiLogger.i(TAG, "Player ready, device: $currentDeviceId")
+                LokiLogger.i(TAG, "Player ready, device: ${pc.ourDeviceId()}")
                 loadDevices()
 
                 pc.onPlaybackId { fileId ->


### PR DESCRIPTION
## Summary
- Disconnect old PlayerConnect before creating new one (prevents duplicate devices)
- Fresh device ID every launch — no stale server registrations
- Audio output pill live-updates via AudioDeviceCallback (Bluetooth connect/disconnect)

Closes #130