### PR TITLE
Kill all app entities on close

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
@@ -44,6 +44,19 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        if (isFinishing) {
+            // App is actually closing (not config change) — kill everything
+            MusicPlaybackService.instance?.let { svc ->
+                svc.player.stop()
+                svc.stopSelf()
+            }
+            MusicPlaybackService.sharedPlayer = null
+            MusicPlaybackService.sharedSession = null
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         handleDeepLinkIntent(intent)

--- a/src/app/src/main/java/ch/snepilatch/app/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MusicPlaybackService.kt
@@ -39,6 +39,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         private const val NOTIFICATION_ID = 1
         var instance: MusicPlaybackService? = null
             private set
+        // Shared PlayerConnect — survives Activity/ViewModel recreation
+        var sharedPlayer: kotify.api.playerconnect.PlayerConnect? = null
+        var sharedSession: kotify.session.Session? = null
     }
 
     private var mediaSession: MediaSessionCompat? = null
@@ -587,10 +590,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
-        if (!player.isPlaying) {
-            stopForeground(STOP_FOREGROUND_REMOVE)
-            stopSelf()
-        }
+        // App swiped from recents — kill everything
+        player.stop()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+        stopSelf()
     }
 
     private fun broadcastAudioEffectAction(action: String) {
@@ -623,6 +626,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             release()
         }
         player.release()
+        // Clean up shared references
+        sharedPlayer = null
+        sharedSession = null
         instance = null
         super.onDestroy()
     }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -178,6 +178,12 @@ class SpotifyViewModel : ViewModel() {
 
 
     fun initialize(cookies: Map<String, String>) {
+        // Clean up any leftover from previous session
+        MusicPlaybackService.sharedPlayer?.let {
+            try { kotlinx.coroutines.runBlocking { it.disconnect() } } catch (_: Exception) {}
+        }
+        MusicPlaybackService.sharedPlayer = null
+        MusicPlaybackService.sharedSession = null
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val sess = Session(SessionConfig(
@@ -234,6 +240,9 @@ class SpotifyViewModel : ViewModel() {
                 // Fresh device ID every launch — avoids stale server-side registrations
                 pc.ready()
                 player = pc
+                // Store on service so it survives Activity/ViewModel recreation
+                MusicPlaybackService.sharedPlayer = pc
+                MusicPlaybackService.sharedSession = sess
                 LokiLogger.i(TAG, "Player ready, device: ${pc.ourDeviceId()}")
                 loadDevices()
 
@@ -1902,7 +1911,8 @@ class SpotifyViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val devicesInfo = player?.getDevices() ?: return@launch
-                _devices.value = devicesInfo.devices.values.toList()
+                // Filter out hobs_ duplicates — they're internal Spotify IDs for the same device
+                _devices.value = devicesInfo.devices.filter { !it.key.startsWith("hobs_") }.values.toList()
                 val activeId = devicesInfo.activeDeviceId
                 LokiLogger.i(TAG, "Devices: ${devicesInfo.devices.keys}, activeId=$activeId")
                 activeDeviceName.value = if (activeId != null) {
@@ -2018,14 +2028,15 @@ class SpotifyViewModel : ViewModel() {
     override fun onCleared() {
         super.onCleared()
         positionJob?.cancel()
-        // Use runBlocking to ensure disconnect completes before the process dies.
-        // viewModelScope is already cancelled at this point.
+        // Kill everything — disconnect player and clean up
         val p = player
+        player = null
+        MusicPlaybackService.sharedPlayer = null
+        MusicPlaybackService.sharedSession = null
         if (p != null) {
             Thread {
                 kotlinx.coroutines.runBlocking {
-                    try { p.disconnect() }
-                    catch (_: Exception) {}
+                    try { p.disconnect() } catch (_: Exception) {}
                 }
             }.start()
         }


### PR DESCRIPTION
## Summary
- onTaskRemoved: stop ExoPlayer, stop service, kill notification
- onDestroy (isFinishing): same cleanup
- onCleared: disconnect PlayerConnect, clear shared refs
- initialize: disconnect any leftover old player before creating new one
- No more ghost devices or duplicate registrations

Closes #132