### PR TITLE
Fix playback bugs, device transfer stop, token refresh

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MusicPlaybackService.kt
@@ -263,11 +263,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         mainHandler.post {
             player.playWhenReady = false
             player.setMediaItem(buildMediaItem(url))
-            player.prepare()
-            updateMediaSessionMetadata()
-            updateNotification()
 
             if (startPlaying) {
+                // Register listener BEFORE prepare() so we catch STATE_READY
                 player.addListener(object : Player.Listener {
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         if (playbackState == Player.STATE_READY) {
@@ -280,6 +278,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                     }
                 })
             }
+
+            player.prepare()
+            updateMediaSessionMetadata()
+            updateNotification()
         }
 
         // Load art in background, update notification when ready
@@ -389,18 +391,20 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         mainHandler.post {
             player.playWhenReady = false
             player.setMediaItem(buildDrmMediaItem(url, licenseUrl, licenseHeaders))
-            player.prepare()
-            updateMediaSessionMetadata()
-            updateNotification()
+            // Register listener BEFORE prepare() so we catch STATE_READY
             player.addListener(object : Player.Listener {
                 override fun onPlaybackStateChanged(playbackState: Int) {
                     if (playbackState == Player.STATE_READY) {
                         player.removeListener(this)
                         player.play()
+                        LokiLogger.i(TAG, "DRM stream ready, playback started")
                         onReady?.invoke()
                     }
                 }
             })
+            player.prepare()
+            updateMediaSessionMetadata()
+            updateNotification()
         }
 
         // Load art in background

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -246,6 +246,19 @@ class SpotifyViewModel : ViewModel() {
                 LokiLogger.i(TAG, "Player ready, device: ${pc.ourDeviceId()}")
                 loadDevices()
 
+                // Refresh access token periodically to prevent stale credentials
+                viewModelScope.launch(Dispatchers.IO) {
+                    while (true) {
+                        delay(50 * 60 * 1000L) // Every 50 minutes
+                        try {
+                            sess.baseClient.refreshAccessToken()
+                            LokiLogger.i(TAG, "Access token refreshed")
+                        } catch (e: Exception) {
+                            LokiLogger.w(TAG, "Token refresh failed: ${e.message}")
+                        }
+                    }
+                }
+
                 pc.onPlaybackId { fileId ->
                     LokiLogger.i(TAG, "Got file ID from state machine: $fileId")
                     latestFileId = fileId
@@ -576,6 +589,18 @@ class SpotifyViewModel : ViewModel() {
             svc.isLiked = currentTrackLiked.value
             svc.isShuffling = state.is_shuffling
             svc.repeatMode = state.repeat_mode
+        }
+
+        // Detect playback transfer away — stop local ExoPlayer
+        if (isStreaming.value && state.has_active_device && !state.is_active_device) {
+            LokiLogger.i(TAG, "Playback transferred to another device — stopping local stream")
+            isStreaming.value = false
+            streamProvider.value = null
+            currentStreamUri = null
+            positionJob?.cancel()
+            withContext(Dispatchers.Main) {
+                MusicPlaybackService.instance?.stop()
+            }
         }
 
         // Update active device indicator from state
@@ -1334,14 +1359,17 @@ class SpotifyViewModel : ViewModel() {
         svc.onPlaybackEnded = {
             viewModelScope.launch(Dispatchers.IO) {
                 try {
-                    // TrackPlaybackHandler.autoAdvanceToNextTrack() already advanced
-                    // the state machine and sent state updates to Spotify.
-                    // DON'T call skipNext() — it would double-advance.
-                    LokiLogger.i(TAG, "ExoPlayer ended — TrackPlaybackHandler auto-advanced")
+                    LokiLogger.i(TAG, "ExoPlayer ended — waiting 1s for auto-advance...")
+                    // Give TrackPlaybackHandler time to auto-advance via state machine
+                    delay(1000)
+                    // Safety net: if no new track loaded after 1s, force skip
+                    if (!(_playback.value.isPlaying && !_playback.value.isPaused)) {
+                        LokiLogger.w(TAG, "Auto-advance didn't fire, forcing skipNext")
+                        player?.skipNext()
+                    }
                 } catch (e: CancellationException) { throw e }
                 catch (e: Exception) {
                     LokiLogger.e(TAG, "playbackEnded advance failed, stopping", e)
-                    // Skip failed (auth error, etc.) — update UI to reflect stopped state
                     isStreaming.value = false
                     streamProvider.value = null
                     currentStreamUri = null


### PR DESCRIPTION
## Summary
- Register ExoPlayer STATE_READY listener before prepare() (#143)
- Safety net skipNext in onPlaybackEnded if auto-advance doesn't fire (#136)
- Stop ExoPlayer when playback transfers to another device (#141)
- Periodic token refresh every 50 minutes (#142, #144)

Closes #136, #141, #143