### PR TITLE
Fix idle progress shown as song-finished on app open

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -524,9 +524,14 @@ class SpotifyViewModel : ViewModel() {
                 MusicPlaybackService.instance?.getCurrentPosition()
             } ?: state.position_as_of_timestamp
             else -> {
-                // Not streaming: interpolate from timestamp
-                val elapsed = (System.currentTimeMillis() - state.timestamp).coerceAtLeast(0)
-                if (state.is_playing && !state.is_paused) {
+                // Not streaming: interpolate the snapshot position only if a device is
+                // actually playing right now. Spotify keeps is_playing=true even when no
+                // device is active (idle state), so on init the snapshot can be hours
+                // stale — interpolating against that would clamp the position to the end
+                // of the track. isActuallyPlaying already accounts for has_active_device
+                // and the position-vs-duration boundary, so it's the correct gate here.
+                if (state.isActuallyPlaying) {
+                    val elapsed = (System.currentTimeMillis() - state.timestamp).coerceAtLeast(0)
                     (state.position_as_of_timestamp + elapsed).coerceAtMost(state.duration)
                 } else {
                     state.position_as_of_timestamp


### PR DESCRIPTION
On app open the now-playing seekbar showed the last-played song clamped to its end (e.g. 3:16 / 3:16) instead of the actual last-known position. Spfy keeps `is_playing=true` even when no device is active, so `updatePlaybackFromState` interpolated `position_as_of_timestamp` by the elapsed time since the snapshot — often hours on cold init — and the result clamped to `duration`.

**Live probe via KotifyClient:**
```
position_as_of_timestamp = 175673 ms
timestamp                = 1775564369477  (~53 min ago)
duration                 = 196417 ms
is_playing               = true
has_active_device        = false
isActuallyPlaying        = false
```
Old code: 175673 + 3174971 → clamped to 196417 (song shown as finished). New code uses 175673 raw.

Gate the interpolation on `state.isActuallyPlaying` instead of `is_playing && !is_paused`. `isActuallyPlaying` already includes `has_active_device` and the position-vs-duration check, so when the snapshot is stale snepilatch shows the actual last-known position.

Pre-existing bug — not caused by PR #151. Branched from main and applies cleanly without the migration.

Closes #152