### PR TITLE
Lift session ownership into process-scoped SessionHolder

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.playback.MusicPlaybackService
+import ch.snepilatch.app.playback.SessionHolder
 import ch.snepilatch.app.ui.components.UpdateDialog
 import ch.snepilatch.app.ui.screens.LoadingScreen
 import ch.snepilatch.app.ui.screens.SpotifyApp
@@ -53,8 +54,7 @@ class MainActivity : ComponentActivity() {
                 svc.player.stop()
                 svc.stopSelf()
             }
-            MusicPlaybackService.sharedPlayer = null
-            MusicPlaybackService.sharedSession = null
+            SessionHolder.clear()
         }
     }
 

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -41,9 +41,6 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         private const val NOTIFICATION_ID = 1
         var instance: MusicPlaybackService? = null
             private set
-        // Shared PlayerConnect — survives Activity/ViewModel recreation
-        var sharedPlayer: kotify.api.playerconnect.PlayerConnect? = null
-        var sharedSession: kotify.session.Session? = null
     }
 
     private var mediaSession: MediaSessionCompat? = null
@@ -637,9 +634,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             release()
         }
         player.release()
-        // Clean up shared references
-        sharedPlayer = null
-        sharedSession = null
+        // Do NOT clear SessionHolder here — the VM and MainActivity already
+        // handle explicit user-close teardown. If the service is dying for
+        // other reasons (e.g. low memory) we want the session to stay live
+        // so the next launch can resume.
         instance = null
         super.onDestroy()
     }

--- a/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
@@ -1,0 +1,53 @@
+package ch.snepilatch.app.playback
+
+import ch.snepilatch.app.playback.engine.SpotifyCdnResolver
+import kotify.api.playerconnect.PlayerConnect
+import kotify.cdn.SpotifyPlayback
+import kotify.session.Session
+
+/**
+ * Process-scoped holder for the Kotify session and its derived objects.
+ *
+ * Ownership used to live on [ch.snepilatch.app.viewmodel.SpotifyViewModel] (which
+ * ties lifetime to the Activity) and was duplicated onto
+ * [MusicPlaybackService] static fields for the service to reach. Neither
+ * location works when we need to start playback from a cold process — e.g.
+ * when the user presses the play button on their headphones with the app
+ * fully closed. Lifting these references to a process-level object means
+ * the service and future entry points (MediaButtonReceiver, Tiles, Widgets)
+ * can reach them without requiring an Activity.
+ *
+ * The ViewModel is still the only writer — it drives initialization and
+ * teardown. Everything else is a reader.
+ */
+object SessionHolder {
+    @Volatile var session: Session? = null
+    @Volatile var player: PlayerConnect? = null
+    @Volatile var spotifyPlayback: SpotifyPlayback? = null
+    @Volatile var cdnResolver: SpotifyCdnResolver? = null
+
+    /** True if the holder has a ready-to-use session + player + resolver. */
+    val isReady: Boolean
+        get() = session != null && player != null && cdnResolver != null
+
+    /** Called by the ViewModel once a new Kotify session is fully initialized. */
+    fun set(
+        session: Session,
+        player: PlayerConnect,
+        spotifyPlayback: SpotifyPlayback,
+        cdnResolver: SpotifyCdnResolver
+    ) {
+        this.session = session
+        this.player = player
+        this.spotifyPlayback = spotifyPlayback
+        this.cdnResolver = cdnResolver
+    }
+
+    /** Called on teardown — clears all references without disconnecting. */
+    fun clear() {
+        session = null
+        player = null
+        spotifyPlayback = null
+        cdnResolver = null
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -9,6 +9,7 @@ import ch.snepilatch.app.util.detectActiveAudioOutput
 import ch.snepilatch.app.util.extractThemeColorsFromArt
 import ch.snepilatch.app.playback.MusicPlaybackService
 import ch.snepilatch.app.playback.PositionInterpolator
+import ch.snepilatch.app.playback.SessionHolder
 import ch.snepilatch.app.playback.engine.SpotifyCdnResolver
 import ch.snepilatch.app.playback.engine.SpotifyStream
 import ch.snepilatch.app.data.*
@@ -52,9 +53,15 @@ class SpotifyViewModel : ViewModel() {
     private var screenStack = mutableListOf<Screen>()
     val needsLogin = MutableStateFlow(false)
 
-    // Session state
-    private var session: Session? = null
-    private var player: PlayerConnect? = null
+    // Session state — ownership lives in SessionHolder (process-scoped).
+    // These accessors make it obvious that the VM is a reader, not an owner,
+    // and keep the rest of the file unchanged.
+    private var session: Session?
+        get() = SessionHolder.session
+        set(value) { SessionHolder.session = value }
+    private var player: PlayerConnect?
+        get() = SessionHolder.player
+        set(value) { SessionHolder.player = value }
     private var username: String = ""
     val isInitialized = MutableStateFlow(false)
     val initError = MutableStateFlow<String?>(null)
@@ -64,8 +71,12 @@ class SpotifyViewModel : ViewModel() {
 
     // Streaming
     private val cdn = CdnPlayback()
-    private var spotifyPlayback: SpotifyPlayback? = null
-    private var cdnResolver: SpotifyCdnResolver? = null
+    private var spotifyPlayback: SpotifyPlayback?
+        get() = SessionHolder.spotifyPlayback
+        set(value) { SessionHolder.spotifyPlayback = value }
+    private var cdnResolver: SpotifyCdnResolver?
+        get() = SessionHolder.cdnResolver
+        set(value) { SessionHolder.cdnResolver = value }
     private var latestFileId: String? = null  // from TrackPlaybackHandler via onPlaybackId
     private var currentStreamUri: String? = null
     private var nextStreamUrl: String? = null
@@ -195,11 +206,10 @@ class SpotifyViewModel : ViewModel() {
 
     fun initialize(cookies: Map<String, String>) {
         // Clean up any leftover from previous session
-        MusicPlaybackService.sharedPlayer?.let {
+        SessionHolder.player?.let {
             try { kotlinx.coroutines.runBlocking { it.disconnect() } } catch (_: Exception) {}
         }
-        MusicPlaybackService.sharedPlayer = null
-        MusicPlaybackService.sharedSession = null
+        SessionHolder.clear()
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 val sess = Session(SessionConfig(
@@ -256,10 +266,10 @@ class SpotifyViewModel : ViewModel() {
 
                 // Fresh device ID every launch — avoids stale server-side registrations
                 pc.ready()
+                // Assigning through the property setter publishes the player to
+                // SessionHolder — session/spotifyPlayback/cdnResolver are already
+                // live there from the initialization block above.
                 player = pc
-                // Store on service so it survives Activity/ViewModel recreation
-                MusicPlaybackService.sharedPlayer = pc
-                MusicPlaybackService.sharedSession = sess
                 LokiLogger.i(TAG, "Player ready, device: ${pc.ourDeviceId()}")
                 loadDevices()
 
@@ -2077,11 +2087,9 @@ class SpotifyViewModel : ViewModel() {
     override fun onCleared() {
         super.onCleared()
         stopPositionTicker()
-        // Kill everything — disconnect player and clean up
-        val p = player
-        player = null
-        MusicPlaybackService.sharedPlayer = null
-        MusicPlaybackService.sharedSession = null
+        // Kill everything — disconnect player and clear the process-level holder.
+        val p = SessionHolder.player
+        SessionHolder.clear()
         if (p != null) {
             Thread {
                 kotlinx.coroutines.runBlocking {


### PR DESCRIPTION
Closes #169

Moves Session / PlayerConnect / SpfyPlayback / SpfyCdnResolver ownership from SpfyViewModel (Activity-scoped) into a process-level `SessionHolder` object. Removes the redundant `MusicPlaybackService.sharedPlayer` / `sharedSession` fields. Unblocks headphone cold launch.