### PR TITLE
Declare snepilatch as a music app in the manifest

### DIFF
--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <application
         android:name=".KotifyApp"
         android:allowBackup="true"
+        android:appCategory="audio"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:networkSecurityConfig="@xml/network_security_config"
@@ -29,6 +30,7 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.APP_MUSIC" />
             </intent-filter>
 
             <intent-filter android:autoVerify="true">


### PR DESCRIPTION
Adds android:appCategory='audio' and the APP_MUSIC launcher category so the system 'default music app' picker lists snepilatch alongside Auxio, Spfy, etc.