### PR TITLE
Bump version to 2.3 (versionCode 15)

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "2.2"
+        versionCode = 15
+        versionName = "2.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Releases everything that landed since 2.2: AGP 9.0 migration, headphone cold-launch, idle notification metadata, music app declarations, cold-start guards, Spfy-style search with suggestions/chips/categorized results, ARCHITECTURE/CLAUDE/REFACTOR_ROADMAP docs, detekt linting, test rig + 23 unit tests, search VM extraction.