### PR TITLE
Paginate album detail and library list past 50 items

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
@@ -200,7 +200,7 @@ fun AlbumInfo.toDetailData(albumId: String): DetailData {
                 albumType = r.type,
             )
         },
-        totalCount = mappedTracks.size,
+        totalCount = totalTracks,
         loadedOffset = mappedTracks.size,
     )
 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -82,7 +83,9 @@ private const val LIKED_SONGS_IMAGE = "https://image-cdn-ak.spotifycdn.com/image
 @Composable
 fun LibraryScreen(vm: SpotifyViewModel) {
     val library by vm.library.collectAsState()
+    val libraryTotal by vm.libraryTotal.collectAsState()
     val account by vm.account.collectAsState()
+    val libraryHasMore = libraryTotal < 0 || library.size < libraryTotal
     var showCreateDialog by remember { mutableStateOf(false) }
     val context = androidx.compose.ui.platform.LocalContext.current
     val prefs = remember { context.getSharedPreferences(PREFS_NAME, android.content.Context.MODE_PRIVATE) }
@@ -245,6 +248,9 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                     Box(itemAppearModifier(index)) {
                         LibraryGridCard(item, vm)
                     }
+                    if (libraryHasMore && index >= library.size - 10) {
+                        LaunchedEffect(library.size) { vm.loadMoreLibrary() }
+                    }
                 }
             }
         } else {
@@ -255,6 +261,9 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                 itemsIndexed(sortedLibrary) { index, item ->
                     Box(itemAppearModifier(index)) {
                         LibraryListItem(item, vm)
+                    }
+                    if (libraryHasMore && index >= library.size - 10) {
+                        LaunchedEffect(library.size) { vm.loadMoreLibrary() }
                     }
                 }
             }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -133,6 +133,10 @@ class SpotifyViewModel : ViewModel() {
     // Library
     private val _library = MutableStateFlow<List<LibraryItem>>(emptyList())
     val library: StateFlow<List<LibraryItem>> = _library
+    private val _libraryTotal = MutableStateFlow(-1)
+    val libraryTotal: StateFlow<Int> = _libraryTotal
+    private val _isLoadingMoreLibrary = MutableStateFlow(false)
+    val isLoadingMoreLibrary: StateFlow<Boolean> = _isLoadingMoreLibrary
 
     // Queue
     private val _queue = MutableStateFlow<List<TrackInfo>>(emptyList())
@@ -1921,7 +1925,27 @@ class SpotifyViewModel : ViewModel() {
 
     fun loadLibrary() {
         launchWithSession("loadLibrary") { sess ->
-            _library.value = Playlist(sess).getLibrary(limit = 50).toUiLibraryList()
+            val page = Playlist(sess).getLibrary(limit = 50, offset = 0)
+            _library.value = page.toUiLibraryList()
+            _libraryTotal.value = page.total
+        }
+    }
+
+    fun loadMoreLibrary() {
+        if (_isLoadingMoreLibrary.value) return
+        val loaded = _library.value.size
+        val total = _libraryTotal.value
+        if (total in 0..loaded) return
+        _isLoadingMoreLibrary.value = true
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val sess = session ?: return@launch
+                val page = Playlist(sess).getLibrary(limit = 50, offset = loaded)
+                val more = page.toUiLibraryList()
+                _library.value = _library.value + more
+                _libraryTotal.value = page.total
+            } catch (e: Exception) { LokiLogger.e(TAG, "loadMoreLibrary", e) }
+            finally { _isLoadingMoreLibrary.value = false }
         }
     }
 
@@ -1966,6 +1990,15 @@ class SpotifyViewModel : ViewModel() {
                     val id = uri.removePrefix("spotify:playlist:")
                     val info = Playlist(sess).getPlaylist(id, limit = 50, offset = offset)
                     val more = info.tracks.map { it.toTrackInfo() }
+                    _detail.value = current.copy(
+                        tracks = current.tracks + more,
+                        totalCount = info.totalTracks,
+                        loadedOffset = offset + more.size
+                    )
+                } else if (uri.startsWith("spotify:album:")) {
+                    val id = uri.removePrefix("spotify:album:")
+                    val info = Album(sess).getAlbum(id, limit = 50, offset = offset)
+                    val more = info.tracks.map { it.toTrackInfo(info.coverArtUrl) }
                     _detail.value = current.copy(
                         tracks = current.tracks + more,
                         totalCount = info.totalTracks,

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -9,6 +9,7 @@
     <ID>ComplexCondition:SpotifyViewModel.kt$SpotifyViewModel$isStreaming.value &amp;&amp; !isSeekGuarded &amp;&amp; !isStreamLoading.value &amp;&amp; !isTrackMismatch &amp;&amp; !isStaleSnapshot</ID>
     <ID>CyclomaticComplexMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: SpotifyViewModel)</ID>
+    <ID>CyclomaticComplexMethod:LibraryScreen.kt$@Composable fun LibraryScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>


### PR DESCRIPTION
`loadMoreDetail` (`[REDACTED].kt:1951`) now branches on `[REDACTED]:album:` and calls `Album.getAlbum(id, limit=50, offset=offset)`, mirroring the playlist branch. `AlbumInfo.toDetailData` (`KotifyMappers.kt:203`) reports the real `totalTracks` instead of `mappedTracks.size`, so `hasMore` at `DetailScreen.kt:60` can evaluate truthfully for compilations and soundtracks.

Library list now tracks `libraryTotal` and `isLoadingMoreLibrary` on the view-model, exposes `loadMoreLibrary`, and `LibraryScreen` triggers it from the LazyVerticalGrid / LazyColumn 10 items before the end. Requires the offset parameter added to `Playlist.getLibrary` in KotifyClient #102 (already merged and bundled).

Detekt baseline updated for `LibraryScreen` cyclomatic complexity, matching the pattern already in place for `AccountScreen`, `DetailScreen`, `LyricsScreen`, `NowPlayingScreen`.

Closes #100