### PR TITLE
TrackRow tap plays the song; navigation moves to the 3-dot menu

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -156,24 +156,17 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
             .padding(horizontal = 16.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Album art — tap to open album
         SpotifyImage(
             url = track.albumArt,
-            modifier = Modifier
-                .size(48.dp)
-                .clickable { vm.openAlbumForTrack(track.uri) },
+            modifier = Modifier.size(48.dp),
             shape = RoundedCornerShape(4.dp)
         )
         Spacer(Modifier.width(12.dp))
         Column(Modifier.weight(1f)) {
-            // Song name — tap to open album
             Text(track.name, color = if (isPlaying) accent else SpotifyWhite, fontSize = 15.sp, fontWeight = FontWeight.Medium,
-                maxLines = 1, overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.clickable { vm.openAlbumForTrack(track.uri) })
-            // Artist — tap to open artist
+                maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(track.artist, color = SpotifyLightGray, fontSize = 13.sp,
-                maxLines = 1, overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.clickable { vm.openArtistForTrack(track.uri) })
+                maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
         if (track.durationMs > 0) {
             Text(formatTime(track.durationMs), color = SpotifyLightGray, fontSize = 12.sp)


### PR DESCRIPTION
The shared `TrackRow` (`SharedComponents.kt:144`) put `clickable` on the cover (`:164`), title (`:172`) and artist sub-line (`:176`), each consuming the gesture before it reached the outer row's `playTrack` tap (`:155`). Tapping a track in a playlist or Liked Songs opened the album rather than playing. Drops all three child `clickable`s so the outer row wins everywhere.

Visit Album, Visit Artist, Add to Queue, Add to Playlist, Like and Share are all already wired into the bottom-sheet at `SharedComponents.kt:223-224`, reachable from the 3-dot button on the row — no functionality lost.

Closes #224