### PR TITLE
Drop dead code surfaced by detekt baseline

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
@@ -1,9 +1,5 @@
 package ch.snepilatch.app.data
 
-import ch.snepilatch.app.data.DetailData
-import ch.snepilatch.app.data.RelatedAlbum
-import ch.snepilatch.app.data.RelatedArtist
-import ch.snepilatch.app.data.TrackInfo
 import kotify.api.album.AlbumInfo
 import kotify.api.album.AlbumTrack
 import kotify.api.artist.ArtistInfo

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -8,8 +8,6 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.media.audiofx.AudioEffect
-import android.net.Uri
-import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.support.v4.media.MediaMetadataCompat

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
@@ -1,7 +1,6 @@
 package ch.snepilatch.app.ui.components
 
 import ch.snepilatch.app.ui.theme.SpotifyWhite
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.theme.SpotifyBlack
-import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import coil.compose.AsyncImage

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
@@ -18,17 +18,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeDown
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
-import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Computer
-import androidx.compose.material.icons.filled.Equalizer
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Smartphone
 import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -42,8 +38,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -60,7 +54,6 @@ fun DevicesDialog(vm: SpotifyViewModel) {
     val theme by vm.themeColors.collectAsState()
     val accentColor by androidx.compose.animation.animateColorAsState(theme.primary, androidx.compose.animation.core.tween(800), label = "devAccent")
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val context = LocalContext.current
     val ourId = vm.ourDeviceId
 
     // Sort: active device first

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material3.CircularProgressIndicator
@@ -58,9 +57,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import ch.snepilatch.app.data.TrackInfo
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
@@ -262,6 +259,7 @@ fun ProfileInfoItem(label: String, value: String, icon: ImageVector) {
 fun itemAppearModifier(index: Int, baseDelay: Int = 30): Modifier {
     val offsetY = remember { Animatable(16f) }
     LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay((index * baseDelay).toLong())
         offsetY.animateTo(0f, tween(200))
     }
     return Modifier

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -23,8 +23,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import android.content.Intent
-import android.net.Uri
 import ch.snepilatch.app.BuildConfig
 import ch.snepilatch.app.ui.components.ProfileInfoItem
 import ch.snepilatch.app.ui.components.UpdateDialog

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -6,10 +6,8 @@ import androidx.compose.animation.core.tween
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
@@ -60,7 +60,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -73,7 +72,6 @@ import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
-import coil.compose.AsyncImage
 
 private const val PREFS_NAME = "kotify_prefs"
 private const val LIKED_SONGS_IMAGE = "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84587ecba4a27774b2f6f07174"

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -30,11 +29,8 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -10,9 +10,7 @@ import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -54,8 +52,6 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
     val streamLoading by vm.isStreamLoading.collectAsState()
     val theme by vm.themeColors.collectAsState()
 
-    val animatedGradientTop by animateColorAsState(theme.gradientTop, tween(800), label = "gradTop")
-    val animatedGradientBottom by animateColorAsState(theme.gradientBottom, tween(800), label = "gradBot")
     val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "primary")
     val buttonBg = Color.White.copy(alpha = 0.12f)
 
@@ -447,7 +443,6 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                         Spacer(Modifier.weight(0.2f))
 
                         // Bottom bar: device button + stacked pills (left), share + queue (right)
-                        val activeDevice by vm.activeDeviceName.collectAsState()
                         val provider by vm.streamProvider.collectAsState()
                         val streaming by vm.isStreaming.collectAsState()
                         val audioOutput by vm.audioOutputName.collectAsState()
@@ -825,7 +820,6 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                     Spacer(Modifier.weight(0.2f))
 
                     // Bottom bar: device button + stacked pills (left), share + queue (right)
-                    val activeDevice by vm.activeDeviceName.collectAsState()
                     val provider by vm.streamProvider.collectAsState()
                     val streaming by vm.isStreaming.collectAsState()
                     val audioOutput by vm.audioOutputName.collectAsState()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.ui.theme.*
-import ch.snepilatch.app.util.UpdateService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/src/app/src/main/java/ch/snepilatch/app/ui/theme/Theme.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package ch.snepilatch.app.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -29,7 +29,6 @@ import kotify.api.user.User
 import kotify.api.canvas.Canvas
 import kotify.cdn.CdnPlayback
 import kotify.cdn.SpotifyPlayback
-import kotify.cdn.StreamInfo
 import kotify.cdn.StreamResult
 import kotify.session.Session
 import kotify.session.SessionConfig
@@ -1715,10 +1714,11 @@ class SpotifyViewModel : ViewModel() {
                     if (fileId == null) {
                         // Brief wait — onPlaybackId may fire slightly after onTrackChange
                         LokiLogger.d(TAG, "SpotifyCDN: Waiting briefly for file ID...")
-                        for (attempt in 1..5) {
+                        for (i in 1..5) {
                             delay(100)
                             fileId = latestFileId
                             if (fileId != null) break
+                            LokiLogger.d(TAG, "SpotifyCDN: file ID still null after attempt $i")
                         }
                     }
                     // If still null, fetch file ID from track metadata API

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -97,23 +97,6 @@
     <ID>NoMultipleSpaces:MusicPlaybackService.kt$MusicPlaybackService$ </ID>
     <ID>NoMultipleSpaces:ReleaseNotesScreen.kt$ </ID>
     <ID>NoMultipleSpaces:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
-    <ID>NoUnusedImports:AccountScreen.kt$ch.snepilatch.app.ui.screens.AccountScreen.kt</ID>
-    <ID>NoUnusedImports:BottomNav.kt$ch.snepilatch.app.ui.components.BottomNav.kt</ID>
-    <ID>NoUnusedImports:DevicesDialog.kt$ch.snepilatch.app.ui.components.DevicesDialog.kt</ID>
-    <ID>NoUnusedImports:HomeScreen.kt$ch.snepilatch.app.ui.screens.HomeScreen.kt</ID>
-    <ID>NoUnusedImports:KotifyMappers.kt$ch.snepilatch.app.data.KotifyMappers.kt</ID>
-    <ID>NoUnusedImports:LibraryScreen.kt$ch.snepilatch.app.ui.screens.LibraryScreen.kt</ID>
-    <ID>NoUnusedImports:LyricsScreen.kt$ch.snepilatch.app.ui.screens.LyricsScreen.kt</ID>
-    <ID>NoUnusedImports:MusicPlaybackService.kt$ch.snepilatch.app.playback.MusicPlaybackService.kt</ID>
-    <ID>NoUnusedImports:NowPlayingScreen.kt$ch.snepilatch.app.ui.screens.NowPlayingScreen.kt</ID>
-    <ID>NoUnusedImports:QueueScreen.kt$import androidx.compose.ui.draw.clip</ID>
-    <ID>NoUnusedImports:ReleaseNotesScreen.kt$ch.snepilatch.app.ui.screens.ReleaseNotesScreen.kt</ID>
-    <ID>NoUnusedImports:SearchScreen.kt$ch.snepilatch.app.ui.screens.SearchScreen.kt</ID>
-    <ID>NoUnusedImports:SearchScreen.kt$import androidx.compose.foundation.layout.Spacer</ID>
-    <ID>NoUnusedImports:SharedComponents.kt$ch.snepilatch.app.ui.components.SharedComponents.kt</ID>
-    <ID>NoUnusedImports:SpotifyApp.kt$ch.snepilatch.app.ui.screens.SpotifyApp.kt</ID>
-    <ID>NoUnusedImports:SpotifyViewModel.kt$ch.snepilatch.app.viewmodel.SpotifyViewModel.kt</ID>
-    <ID>NoUnusedImports:Theme.kt$ch.snepilatch.app.ui.theme.Theme.kt</ID>
     <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$catch</ID>
     <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$finally</ID>
     <ID>SpacingBetweenDeclarationsWithAnnotations:SessionHolder.kt$SessionHolder$@Volatile var cdnResolver: SpotifyCdnResolver? = null</ID>
@@ -131,13 +114,6 @@
     <ID>ThrowsCount:SpotifyViewModel.kt$SpotifyViewModel$fun togglePlayPause()</ID>
     <ID>ThrowsCount:SpotifyViewModel.kt$SpotifyViewModel$private fun wireTransportCallbacks(svc: MusicPlaybackService)</ID>
     <ID>TooGenericExceptionThrown:ReleaseNotesScreen.kt$throw Exception("HTTP ${response.code}")</ID>
-    <ID>UnusedParameter:SharedComponents.kt$baseDelay: Int = 30</ID>
-    <ID>UnusedParameter:SharedComponents.kt$index: Int</ID>
-    <ID>UnusedPrivateProperty:DevicesDialog.kt$val context = LocalContext.current</ID>
-    <ID>UnusedPrivateProperty:NowPlayingScreen.kt$val activeDevice by vm.activeDeviceName.collectAsState()</ID>
-    <ID>UnusedPrivateProperty:NowPlayingScreen.kt$val animatedGradientBottom by animateColorAsState(theme.gradientBottom, tween(800), label = "gradBot")</ID>
-    <ID>UnusedPrivateProperty:NowPlayingScreen.kt$val animatedGradientTop by animateColorAsState(theme.gradientTop, tween(800), label = "gradTop")</ID>
-    <ID>UnusedPrivateProperty:SpotifyViewModel.kt$SpotifyViewModel$attempt</ID>
     <ID>UseCheckOrError:SpotifyCdnResolver.kt$SpotifyCdnResolver$throw IllegalStateException("No CDN mirrors for fileId=$fileId")</ID>
     <ID>UseCheckOrError:SpotifyViewModel.kt$SpotifyViewModel$throw IllegalStateException("CdnResolver not initialized")</ID>
     <ID>UseCheckOrError:SpotifyViewModel.kt$SpotifyViewModel$throw IllegalStateException("No file ID available")</ID>


### PR DESCRIPTION
33 unused imports across 17 files plus 7 unused property / parameter entries that had piled up in `detekt-baseline.xml`. Cleanup is purely removal except for two places where the dead code was an incomplete feature worth finishing:

- `SharedComponents.kt itemAppearModifier`: the `index` / `baseDelay` params were dead because the staggered-appear `delay(index * baseDelay)` never got wired in. Adds the one-line delay so list items now appear one after the other instead of all at once, as the param names always promised.
- `SpfyViewModel.kt:1718`: rename the for-loop index from `attempt` so the per-iteration debug log line actually uses it. Same iteration count, slightly better Loki diagnostics when `latestFileId` arrives slowly.

Other dead drops:
- `DevicesDialog.kt` — unused `val context = LocalContext.current` and its import.
- `NowPlayingScreen.kt` — `animatedGradientTop` / `animatedGradientBottom` (never read), and two duplicate unused `val activeDevice by vm.activeDeviceName.collectAsState()` blocks.
- 17 files × unused imports (one Python pass against the detekt diagnostic output, then manually re-ran detekt to confirm zero `NoUnusedImports` remaining).

`./gradlew :app:assembleDebug :app:testDebugUnitTest detekt` all green.

Closes #236