### PR TITLE
Opt-in AlarmManager token refresh that survives Doze

### DIFF
--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -102,6 +102,13 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
         </receiver>
+
+        <!-- Opt-in Doze-tolerant token refresh. Fired by AlarmManager from
+             TokenRefreshScheduler; not exported because only our own
+             setAndAllowWhileIdle targets it. -->
+        <receiver
+            android:name=".auth.TokenRefreshAlarmReceiver"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/src/app/src/main/java/ch/snepilatch/app/auth/TokenRefreshAlarmReceiver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/auth/TokenRefreshAlarmReceiver.kt
@@ -1,0 +1,59 @@
+package ch.snepilatch.app.auth
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.util.LokiLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Wakes the process during Doze to refresh the Spotify access token.
+ *
+ * Triggered by [TokenRefreshScheduler] via `setAndAllowWhileIdle`. We use
+ * `goAsync()` so the receiver stays alive while the HTTP refresh runs;
+ * the platform grants ~10 seconds of wake time which is plenty for a
+ * single token-refresh request. After the refresh attempt (success or
+ * failure) we reschedule against the new expiry timestamp so the chain
+ * keeps going as long as the user has the toggle on.
+ */
+class TokenRefreshAlarmReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent?) {
+        val appContext = context.applicationContext
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val session = SessionHolder.session
+                if (session == null) {
+                    LokiLogger.w(TAG, "Alarm fired but session is null; not rescheduling")
+                    return@launch
+                }
+                try {
+                    session.baseClient.refreshAccessToken()
+                    LokiLogger.i(TAG, "Background token refresh succeeded")
+                } catch (e: Exception) {
+                    LokiLogger.w(TAG, "Background token refresh failed: ${e.message?.take(120)}")
+                    // Reschedule anyway — transient network failure shouldn't
+                    // break the chain. If sp_dc is dead the next attempt will
+                    // also fail; user will be prompted to re-login by the
+                    // normal flow.
+                }
+                val nextExpiresAt = session.baseClient.accessTokenExpirationTimestampMs
+                if (nextExpiresAt != null) {
+                    TokenRefreshScheduler.enable(appContext, nextExpiresAt)
+                } else {
+                    LokiLogger.w(TAG, "No expiry timestamp after refresh; not rescheduling")
+                }
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "TokenRefreshAlarm"
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/auth/TokenRefreshScheduler.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/auth/TokenRefreshScheduler.kt
@@ -1,0 +1,66 @@
+package ch.snepilatch.app.auth
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import ch.snepilatch.app.util.LokiLogger
+
+/**
+ * Schedules a Doze-tolerant alarm that wakes the device to refresh the
+ * Spotify access token. Inexact `setAndAllowWhileIdle` is fine because we
+ * always schedule LEAD_MS=15min ahead of the actual expiry — even the
+ * worst-case Doze fudging stays inside that window.
+ *
+ * No `SCHEDULE_EXACT_ALARM` permission required; this is deliberate so
+ * users don't have to grant a privileged alarm permission for a comfort
+ * feature.
+ */
+object TokenRefreshScheduler {
+
+    private const val TAG = "TokenRefreshScheduler"
+    private const val REQUEST_CODE = 0xC0FFEE
+
+    /** Schedule LEAD_MS before the actual expiry — keeps us inside the
+     *  Doze inexact-alarm fudging window. */
+    private const val LEAD_MS = 15L * 60L * 1000L
+
+    /** Minimum delay even if expiry is near; never schedule something
+     *  that would fire in the past. */
+    private const val MIN_DELAY_MS = 30L * 1000L
+
+    fun enable(context: Context, expiresAtMs: Long) {
+        val triggerAt = (expiresAtMs - LEAD_MS).coerceAtLeast(System.currentTimeMillis() + MIN_DELAY_MS)
+        val pi = pendingIntent(context, create = true) ?: run {
+            LokiLogger.w(TAG, "Could not build PendingIntent for token refresh alarm")
+            return
+        }
+        val am = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: run {
+            LokiLogger.w(TAG, "AlarmManager unavailable, cannot schedule background refresh")
+            return
+        }
+        try {
+            am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, pi)
+            val mins = (triggerAt - System.currentTimeMillis()) / 60_000
+            LokiLogger.i(TAG, "Background token refresh scheduled in ~${mins}m (expires at $expiresAtMs)")
+        } catch (e: SecurityException) {
+            // Some OEM ROMs restrict alarm scheduling — fall back to logging.
+            LokiLogger.w(TAG, "setAndAllowWhileIdle rejected by platform: ${e.message?.take(120)}")
+        }
+    }
+
+    fun disable(context: Context) {
+        val am = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager ?: return
+        val pi = pendingIntent(context, create = false) ?: return
+        am.cancel(pi)
+        pi.cancel()
+        LokiLogger.i(TAG, "Background token refresh cancelled")
+    }
+
+    private fun pendingIntent(context: Context, create: Boolean): PendingIntent? {
+        val intent = Intent(context, TokenRefreshAlarmReceiver::class.java)
+        val flags = PendingIntent.FLAG_IMMUTABLE or
+            (if (create) PendingIntent.FLAG_UPDATE_CURRENT else PendingIntent.FLAG_NO_CREATE)
+        return PendingIntent.getBroadcast(context.applicationContext, REQUEST_CODE, intent, flags)
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -310,6 +310,32 @@ fun AccountScreen(vm: SpotifyViewModel) {
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
         )
 
+        // Background token refresh (opt-in, Doze-tolerant)
+        val backgroundRefreshOn by vm.backgroundTokenRefreshEnabled.collectAsState()
+        val backgroundRefreshLabel = if (backgroundRefreshOn) {
+            "Wakes device hourly to keep playback ready"
+        } else {
+            "Off — token may expire while phone sleeps"
+        }
+        ListItem(
+            headlineContent = { Text("Background Token Refresh", color = SpotifyWhite) },
+            supportingContent = { Text(backgroundRefreshLabel, color = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Default.Refresh, null, tint = SpotifyLightGray) },
+            trailingContent = {
+                Switch(
+                    checked = backgroundRefreshOn,
+                    onCheckedChange = { vm.setBackgroundTokenRefreshEnabled(it, audioContext) },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = animatedPrimary,
+                        checkedTrackColor = animatedPrimary.copy(alpha = 0.5f),
+                        uncheckedThumbColor = SpotifyLightGray,
+                        uncheckedTrackColor = SpotifyLightGray.copy(alpha = 0.3f)
+                    )
+                )
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+        )
+
         // Lyrics animation direction
         val lyricsAnim by vm.lyricsAnimDirection.collectAsState()
         var showLyricsPicker by remember { mutableStateOf(false) }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -192,6 +192,13 @@ class SpotifyViewModel : ViewModel() {
     val notificationRightButton = MutableStateFlow("like")
     // Content region for CDN resolution
     val contentRegion = MutableStateFlow("US")
+
+    // Doze-tolerant background token refresh. Off by default — uses a wake-lock
+    // each hour. When enabled, AlarmManager wakes the device to refresh before
+    // the access token expires, so playback survives long screen-off periods.
+    val backgroundTokenRefreshEnabled = MutableStateFlow(false)
+
+
     // Canvas background
     val canvasEnabled = MutableStateFlow(false)
     val canvasUrl = MutableStateFlow<String?>(null)
@@ -280,6 +287,18 @@ class SpotifyViewModel : ViewModel() {
                 // Falls back to a 50-minute interval if the timestamp isn't
                 // available (e.g. older Kotify or unexpected response shape).
                 viewModelScope.launch(Dispatchers.IO) {
+                    // Initial arm: if the user already had the background-refresh
+                    // toggle on at last launch, set the alarm against the initial
+                    // expiry right now. The receiver will reschedule itself
+                    // thereafter, and the loop below also re-arms on every
+                    // foreground refresh.
+                    if (backgroundTokenRefreshEnabled.value) {
+                        val initialExpiresAt = sess.baseClient.accessTokenExpirationTimestampMs
+                        val ctx = appContext
+                        if (initialExpiresAt != null && ctx != null) {
+                            ch.snepilatch.app.auth.TokenRefreshScheduler.enable(ctx, initialExpiresAt)
+                        }
+                    }
                     while (true) {
                         val expiresAt = sess.baseClient.accessTokenExpirationTimestampMs
                         val sleepMs = if (expiresAt != null) {
@@ -292,6 +311,16 @@ class SpotifyViewModel : ViewModel() {
                         try {
                             sess.baseClient.refreshAccessToken()
                             LokiLogger.i(TAG, "Access token refreshed (next in ~${sleepMs / 60_000}m)")
+                            // If the user opted into background refresh, re-arm
+                            // the alarm against the new expiry so it survives
+                            // Doze the next time the screen goes off.
+                            if (backgroundTokenRefreshEnabled.value) {
+                                val newExpiresAt = sess.baseClient.accessTokenExpirationTimestampMs
+                                val ctx = appContext
+                                if (newExpiresAt != null && ctx != null) {
+                                    ch.snepilatch.app.auth.TokenRefreshScheduler.enable(ctx, newExpiresAt)
+                                }
+                            }
                         } catch (e: Exception) {
                             LokiLogger.w(TAG, "Token refresh failed: ${e.message}")
                             delay(REFRESH_RETRY_DELAY_MS)
@@ -1351,6 +1380,7 @@ class SpotifyViewModel : ViewModel() {
     }
 
     fun loadPreferences(context: Context) {
+        appContext = context.applicationContext
         val prefs = context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
         val savedSource = prefs.getString("audio_source", null)
         // Migrate: old "spotify" value → null (Spotify CDN is now the default)
@@ -1370,6 +1400,7 @@ class SpotifyViewModel : ViewModel() {
             context.resources.updateConfiguration(config, context.resources.displayMetrics)
         }
         canvasEnabled.value = prefs.getBoolean("canvas_enabled", false)
+        backgroundTokenRefreshEnabled.value = prefs.getBoolean("background_token_refresh", false)
         contentRegion.value = prefs.getString("content_region", "US") ?: "US"
         notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"
         notificationRightButton.value = prefs.getString("notification_right_button", "like") ?: "like"
@@ -1400,6 +1431,28 @@ class SpotifyViewModel : ViewModel() {
         context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
             .edit().putBoolean("canvas_enabled", enabled).apply()
         if (!enabled) canvasUrl.value = null
+    }
+
+    /**
+     * Toggle the AlarmManager-based token refresh. When enabled, schedules an
+     * alarm to fire LEAD_MS before the current access token expires, even
+     * during Android Doze. When disabled, cancels any pending alarm. Persists
+     * the choice across launches.
+     */
+    fun setBackgroundTokenRefreshEnabled(enabled: Boolean, context: Context) {
+        backgroundTokenRefreshEnabled.value = enabled
+        context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
+            .edit().putBoolean("background_token_refresh", enabled).apply()
+        if (enabled) {
+            val expiresAt = session?.baseClient?.accessTokenExpirationTimestampMs
+            if (expiresAt != null) {
+                ch.snepilatch.app.auth.TokenRefreshScheduler.enable(context, expiresAt)
+            } else {
+                LokiLogger.w(TAG, "Background refresh toggled on but no expiry available yet; will schedule on next refresh")
+            }
+        } else {
+            ch.snepilatch.app.auth.TokenRefreshScheduler.disable(context)
+        }
     }
 
     private fun fetchCanvasForTrack(trackUri: String) {

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -12,6 +12,7 @@
     <ID>CyclomaticComplexMethod:LibraryScreen.kt$@Composable fun LibraryScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen(vm: SpotifyViewModel)</ID>
+    <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$fun initialize(cookies: Map&lt;String, String&gt;)</ID>
     <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
     <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun updatePlaybackFromState(state: PlayerStateData)</ID>
     <ID>Filename:AudioOutputDetector.kt$ch.snepilatch.app.util.AudioOutputDetector.kt</ID>


### PR DESCRIPTION
The existing coroutine-based refresh loop sleeps via \`delay()\` which Android Doze pauses; tokens expire while the device sleeps and the user sees a stall on first request after waking. KotifyClient #117 catches 401 reactively but doesn't prevent the stall.

This adds an **opt-in** AlarmManager-based refresh:

- \`TokenRefreshScheduler\` arms \`AlarmManager.setAndAllowWhileIdle\` 15 min before expiry — generous enough that the inexact-alarm Doze fudging window can't miss it, so we don't need \`SCHEDULE_EXACT_ALARM\` permission.
- \`TokenRefreshAlarmReceiver\` uses \`goAsync()\` to keep the receiver alive while \`refreshAccessToken()\` runs, then reschedules itself against the new expiry.
- \`SpfyViewModel.backgroundTokenRefreshEnabled\` (persisted to \`kotify_prefs\`) gates the feature. Default off because it draws a wake-lock hourly.
- Existing foreground refresh loop now also re-arms the alarm after each refresh so the chain always tracks latest expiry.
- New "Background Token Refresh" toggle in `AccountScreen`.

Receiver declared `android:exported=\"false\"` in the manifest (only our own `setAndAllowWhileIdle` targets it).

Detekt baseline gets `initialize` added for `CyclomaticComplexMethod` (it crossed 25→27 with the new branch).

Closes #238