### PR TITLE
Detail header 3-dot menu with all supported actions

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -219,18 +219,19 @@ fun DetailScreen(vm: SpotifyViewModel) {
                     }
                 }
 
-                // 3-dot menu
-                IconButton(onClick = {
-                    val id = detail.uri.substringAfterLast(":")
-                    val type = detail.type
-                    val shareUrl = "https://open.spotify.com/$type/$id"
-                    val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
-                        this.type = "text/plain"
-                        putExtra(android.content.Intent.EXTRA_TEXT, shareUrl)
-                    }
-                    context.startActivity(android.content.Intent.createChooser(intent, "Share"))
-                }) {
+                // 3-dot menu — opens a bottom sheet with every action
+                // KotifyClient supports for the current detail type.
+                var showHeaderMenu by remember { mutableStateOf(false) }
+                IconButton(onClick = { showHeaderMenu = true }) {
                     Icon(Icons.Default.MoreVert, "More", tint = SpotifyLightGray, modifier = Modifier.size(24.dp))
+                }
+                if (showHeaderMenu) {
+                    DetailHeaderMenu(
+                        detail = detail,
+                        vm = vm,
+                        context = context,
+                        onDismiss = { showHeaderMenu = false }
+                    )
                 }
 
                 Spacer(Modifier.weight(1f))
@@ -706,5 +707,102 @@ private fun AlbumTrackRow(
                 Spacer(Modifier.navigationBarsPadding().height(12.dp))
             }
         }
+    }
+}
+
+/**
+ * Bottom-sheet menu opened from the 3-dot button on the detail header
+ * (album, playlist, artist, Liked Songs). Each row is a single action that
+ * KotifyClient actually supports — no Premium-gated entries, no UI-only
+ * "show Spotify Code" filler. Action set adapts to the detail type.
+ *
+ * Skips "Remove from Library" because the like/save toggle already lives
+ * elsewhere in the header.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DetailHeaderMenu(
+    detail: ch.snepilatch.app.data.DetailData,
+    vm: ch.snepilatch.app.viewmodel.SpotifyViewModel,
+    context: android.content.Context,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val trackUris = detail.tracks.map { it.uri }
+    val type = detail.type
+    val isAlbum = type == "album"
+    val isCollection = type == "collection"
+    val isArtist = type == "artist"
+    val hasTracks = trackUris.isNotEmpty()
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = SpotifyElevated,
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            ch.snepilatch.app.ui.components.SpotifyImage(
+                url = detail.imageUrl,
+                modifier = Modifier.size(48.dp),
+                shape = RoundedCornerShape(8.dp)
+            )
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text(detail.name, color = SpotifyWhite, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                val subtitle = detail.artistName ?: detail.ownerName ?: type.replaceFirstChar { it.uppercase() }
+                Text(subtitle, color = SpotifyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        HorizontalDivider(color = SpotifyLightGray.copy(alpha = 0.15f))
+
+        val items = buildList<Triple<androidx.compose.ui.graphics.vector.ImageVector, String, () -> Unit>> {
+            if (!isCollection) {
+                val id = detail.uri.substringAfterLast(":")
+                add(Triple(Icons.Default.Share, "Share") {
+                    onDismiss()
+                    val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                        this.type = "text/plain"
+                        putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/$type/$id")
+                    }
+                    context.startActivity(android.content.Intent.createChooser(intent, "Share"))
+                })
+            }
+            if (hasTracks && !isArtist) {
+                add(Triple(Icons.AutoMirrored.Filled.QueueMusic, "Add to Queue") {
+                    onDismiss()
+                    vm.addAllToQueue(trackUris)
+                })
+                add(Triple(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Playlist") {
+                    onDismiss()
+                    vm.showPlaylistPickerForTracks(trackUris)
+                })
+            }
+            if (isAlbum && detail.artistUri != null) {
+                add(Triple(Icons.Default.Person, "Visit Artist") {
+                    onDismiss()
+                    val artistId = detail.artistUri.substringAfterLast(":")
+                    vm.openArtist(artistId)
+                })
+            }
+        }
+
+        items.forEach { (icon, label, onClick) ->
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { onClick() }
+                    .padding(horizontal = 20.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(icon, null, tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                Spacer(Modifier.width(16.dp))
+                Text(label, color = SpotifyWhite, fontSize = 15.sp)
+            }
+        }
+        Spacer(Modifier.navigationBarsPadding().height(12.dp))
     }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -185,8 +185,9 @@ fun SpotifyApp(vm: SpotifyViewModel) {
                                 Modifier
                                     .fillMaxWidth()
                                     .clickable {
-                                        val trackUri = vm.pendingPlaylistTrackUri.value ?: return@clickable
-                                        vm.addTrackToPlaylist(playlist.uri.substringAfterLast(":"), trackUri)
+                                        val trackUris = vm.pendingPlaylistTrackUris.value
+                                        if (trackUris.isEmpty()) return@clickable
+                                        vm.addTracksToPlaylist(playlist.uri.substringAfterLast(":"), trackUris)
                                         vm.showPlaylistPicker.value = false
                                     }
                                     .padding(vertical = 10.dp),

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
 
+@Suppress("TooManyFunctions") // central view-model; split-by-feature is tracked separately
 class SpotifyViewModel : ViewModel() {
 
     private val TAG = "SpotifyVM"
@@ -1110,19 +1111,38 @@ class SpotifyViewModel : ViewModel() {
     }
 
     fun addTrackToPlaylist(playlistId: String, trackUri: String) {
-        launchWithSession("addTrackToPlaylist") { sess ->
-            kotify.api.playlist.Playlist(sess).addToPlaylist(playlistId, listOf(trackUri))
-            LokiLogger.i(TAG, "Added $trackUri to playlist $playlistId")
-            _snackbarMessage.tryEmit("Added to playlist")
+        addTracksToPlaylist(playlistId, listOf(trackUri))
+    }
+
+    /**
+     * Add many tracks to a playlist in a single API call. Used by the detail
+     * header's "Add to Playlist" action when the user adds an entire album,
+     * playlist, or the Liked Songs collection to another playlist.
+     */
+    fun addTracksToPlaylist(playlistId: String, trackUris: List<String>) {
+        if (trackUris.isEmpty()) return
+        launchWithSession("addTracksToPlaylist") { sess ->
+            kotify.api.playlist.Playlist(sess).addToPlaylist(playlistId, trackUris)
+            LokiLogger.i(TAG, "Added ${trackUris.size} tracks to playlist $playlistId")
+            _snackbarMessage.tryEmit(
+                if (trackUris.size == 1) "Added to playlist" else "Added ${trackUris.size} tracks to playlist"
+            )
         }
     }
 
-    // Track URI pending playlist picker
-    val pendingPlaylistTrackUri = MutableStateFlow<String?>(null)
+    // Tracks pending playlist picker. Always treated as a list so the same
+    // picker dialog covers single-track adds (from TrackRow) and bulk adds
+    // (from the album/playlist detail header).
+    val pendingPlaylistTrackUris = MutableStateFlow<List<String>>(emptyList())
     val showPlaylistPicker = MutableStateFlow(false)
 
     fun showPlaylistPickerForTrack(trackUri: String) {
-        pendingPlaylistTrackUri.value = trackUri
+        showPlaylistPickerForTracks(listOf(trackUri))
+    }
+
+    fun showPlaylistPickerForTracks(trackUris: List<String>) {
+        if (trackUris.isEmpty()) return
+        pendingPlaylistTrackUris.value = trackUris
         showPlaylistPicker.value = true
     }
 
@@ -1145,12 +1165,23 @@ class SpotifyViewModel : ViewModel() {
     }
 
     fun addToQueue(trackUri: String) {
+        addAllToQueue(listOf(trackUri))
+    }
+
+    /**
+     * Queue multiple tracks in a single Connect call. Used by the detail
+     * header's "Add to Queue" action.
+     */
+    fun addAllToQueue(trackUris: List<String>) {
+        if (trackUris.isEmpty()) return
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                player?.addToQueue(listOf(trackUri))
-                _snackbarMessage.tryEmit("Added to queue")
+                player?.addToQueue(trackUris)
+                _snackbarMessage.tryEmit(
+                    if (trackUris.size == 1) "Added to queue" else "Added ${trackUris.size} tracks to queue"
+                )
             }
-            catch (e: Exception) { LokiLogger.e(TAG, "addToQueue", e) }
+            catch (e: Exception) { LokiLogger.e(TAG, "addAllToQueue", e) }
         }
     }
 


### PR DESCRIPTION
On album/playlist/artist/Liked Songs detail pages the 3-dot button used to fire an immediate share intent. The Spfy Android client shows a multi-row bottom sheet there, and we now mirror that — but only for actions KotifyClient actually supports.

**New menu**:
- Share (universal; skipped for Liked Songs since the URI doesn't share well)
- Add to Queue — albums/playlists/collection, queues every track in a single Connect call
- Add to Playlist — albums/playlists/collection, opens the existing picker extended to accept a list
- Visit Artist — albums only (uses `DetailData.artistUri`)

**Skipped per request**: Remove from Library (the like/save button already does this).

**Skipped because KotifyClient doesn't expose them**: Album/Artist Radio, Show Spfy Code, Download (Premium-only), Legal disclosure.

**Plumbing**:
- `addAllToQueue(uris)` batches multiple tracks into one Connect call; the existing `addToQueue(single)` now delegates.
- `addTracksToPlaylist(playlistId, uris)` for batch playlist adds.
- `pendingPlaylistTrackUris: List<String>` replaces the old single-URI `pendingPlaylistTrackUri`. The global picker in `SpfyApp` reads the list and uses `addTracksToPlaylist` on selection.

Closes #240