### PR TITLE
feat: prompt for battery-optimization exemption and OEM autostart (#243)

### DIFF
--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -7,6 +7,23 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
+    <!-- Package visibility for probing OEM autostart / background-restrict screens
+         on Android 11+. Matched against the intent list in BatteryOptimizationHelper. -->
+    <queries>
+        <package android:name="com.miui.securitycenter" />
+        <package android:name="com.huawei.systemmanager" />
+        <package android:name="com.coloros.safecenter" />
+        <package android:name="com.oppo.safe" />
+        <package android:name="com.vivo.permissionmanager" />
+        <package android:name="com.iqoo.secure" />
+        <package android:name="com.oneplus.security" />
+        <package android:name="com.letv.android.letvsafe" />
+        <package android:name="com.asus.mobilemanager" />
+        <package android:name="com.samsung.android.lool" />
+        <package android:name="com.evenwell.powersaving.g3" />
+    </queries>
 
     <application
         android:name=".KotifyApp"

--- a/src/app/src/main/java/ch/snepilatch/app/auth/BatteryOptimizationHelper.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/auth/BatteryOptimizationHelper.kt
@@ -1,0 +1,100 @@
+package ch.snepilatch.app.auth
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.PowerManager
+import android.provider.Settings
+import ch.snepilatch.app.util.LokiLogger
+
+/**
+ * Helpers to surface the OS-level switches the user needs to flip for
+ * [TokenRefreshWorker] to actually fire reliably:
+ *
+ *  - Standard Doze whitelist (works on every device).
+ *  - OEM-specific autostart / background-app screens (Xiaomi, Huawei, Oppo,
+ *    Vivo, OnePlus, Samsung, etc.). These are non-standard and not all OEMs
+ *    expose them; we probe with `resolveActivity` and only offer the entry
+ *    if one is installed.
+ *
+ * Intent list curated from github.com/judemanutd/AutoStarter and
+ * dontkillmyapp.com. The corresponding package names are declared in
+ * `<queries>` in AndroidManifest.xml so `resolveActivity` works under
+ * Android 11+ package visibility.
+ */
+object BatteryOptimizationHelper {
+
+    private const val TAG = "BatteryOpt"
+
+    private val OEM_AUTOSTART_INTENTS: List<Pair<String, String>> = listOf(
+        // Xiaomi (MIUI)
+        "com.miui.securitycenter" to "com.miui.permcenter.autostart.AutoStartManagementActivity",
+        // Huawei / Honor
+        "com.huawei.systemmanager" to "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity",
+        "com.huawei.systemmanager" to "com.huawei.systemmanager.appcontrol.activity.StartupAppControlActivity",
+        "com.huawei.systemmanager" to "com.huawei.systemmanager.optimize.process.ProtectActivity",
+        // Oppo (ColorOS) / Realme
+        "com.coloros.safecenter" to "com.coloros.safecenter.permission.startup.StartupAppListActivity",
+        "com.coloros.safecenter" to "com.coloros.safecenter.startupapp.StartupAppListActivity",
+        "com.oppo.safe" to "com.oppo.safe.permission.startup.StartupAppListActivity",
+        // Vivo (FuntouchOS / OriginOS)
+        "com.vivo.permissionmanager" to "com.vivo.permissionmanager.activity.BgStartUpManagerActivity",
+        "com.iqoo.secure" to "com.iqoo.secure.ui.phoneoptimize.AddWhiteListActivity",
+        // OnePlus (older OxygenOS — newer ones reuse ColorOS entries above)
+        "com.oneplus.security" to "com.oneplus.security.chainlaunch.view.ChainLaunchAppListActivity",
+        // Letv (LeEco)
+        "com.letv.android.letvsafe" to "com.letv.android.letvsafe.AutobootManageActivity",
+        // Asus
+        "com.asus.mobilemanager" to "com.asus.mobilemanager.entry.FunctionActivity",
+        // Samsung — no first-class autostart screen, battery UI is the closest exported activity
+        "com.samsung.android.lool" to "com.samsung.android.sm.ui.battery.BatteryActivity",
+        // Nokia (EvenWell)
+        "com.evenwell.powersaving.g3" to "com.evenwell.powersaving.g3.exception.PowerSaverExceptionActivity",
+    )
+
+    fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+            ?: return false
+        return pm.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    /** Universal Doze whitelist prompt. No-op if already exempt. */
+    fun requestIgnoreBatteryOptimizations(context: Context) {
+        if (isIgnoringBatteryOptimizations(context)) return
+        try {
+            val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                data = Uri.parse("package:${context.packageName}")
+                if (context !is Activity) addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            LokiLogger.w(TAG, "Could not open battery-optimization prompt: ${e.message?.take(120)}")
+        }
+    }
+
+    /** True if the device exposes a known OEM autostart / background-restrict screen. */
+    fun hasOemAutostartScreen(context: Context): Boolean = findOemAutostartIntent(context) != null
+
+    /** Opens the OEM autostart screen if available. Returns false if none resolved. */
+    fun openOemAutostartSettings(context: Context): Boolean {
+        val intent = findOemAutostartIntent(context) ?: return false
+        return try {
+            if (context !is Activity) intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            true
+        } catch (e: Exception) {
+            LokiLogger.w(TAG, "Could not open OEM autostart screen: ${e.message?.take(120)}")
+            false
+        }
+    }
+
+    private fun findOemAutostartIntent(context: Context): Intent? {
+        val pm = context.packageManager
+        for ((pkg, cls) in OEM_AUTOSTART_INTENTS) {
+            val intent = Intent().setClassName(pkg, cls)
+            if (intent.resolveActivity(pm) != null) return intent
+        }
+        return null
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import ch.snepilatch.app.BuildConfig
+import ch.snepilatch.app.auth.BatteryOptimizationHelper
 import ch.snepilatch.app.ui.components.ProfileInfoItem
 import ch.snepilatch.app.ui.components.UpdateDialog
 import ch.snepilatch.app.ui.theme.*
@@ -324,7 +325,12 @@ fun AccountScreen(vm: SpotifyViewModel) {
             trailingContent = {
                 Switch(
                     checked = backgroundRefreshOn,
-                    onCheckedChange = { vm.setBackgroundTokenRefreshEnabled(it, audioContext) },
+                    onCheckedChange = { enabled ->
+                        vm.setBackgroundTokenRefreshEnabled(enabled, audioContext)
+                        if (enabled) {
+                            BatteryOptimizationHelper.requestIgnoreBatteryOptimizations(audioContext)
+                        }
+                    },
                     colors = SwitchDefaults.colors(
                         checkedThumbColor = animatedPrimary,
                         checkedTrackColor = animatedPrimary.copy(alpha = 0.5f),
@@ -335,6 +341,20 @@ fun AccountScreen(vm: SpotifyViewModel) {
             },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
         )
+
+        // Per-OEM autostart / background-restrict deep link — only shown if
+        // the device exposes one (Xiaomi, Huawei, Oppo, Vivo, OnePlus, Samsung, …).
+        if (backgroundRefreshOn && BatteryOptimizationHelper.hasOemAutostartScreen(audioContext)) {
+            ListItem(
+                headlineContent = { Text("Open device background settings", color = SpotifyWhite) },
+                supportingContent = { Text("Allow Snepilatch to run in the background on your phone", color = SpotifyLightGray) },
+                leadingContent = { Icon(Icons.Default.Settings, null, tint = SpotifyLightGray) },
+                modifier = Modifier.clickable {
+                    BatteryOptimizationHelper.openOemAutostartSettings(audioContext)
+                },
+                colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+            )
+        }
 
         // Lyrics animation direction
         val lyricsAnim by vm.lyricsAnimDirection.collectAsState()


### PR DESCRIPTION
Closes #243.

When the background-refresh toggle in #242 is flipped on, fire the standard `Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` prompt — universal across OEMs, no runtime permission grant needed. Additionally, if the device exposes a known OEM autostart / background-restrict screen, show a follow-up list item beneath the toggle that deep-links into it.

Intent list curated from [judemanutd/AutoStarter](https://github.com/judemanutd/AutoStarter):
- Xiaomi (MIUI) → `com.miui.securitycenter`
- Huawei / Honor → `com.huawei.systemmanager` (three known entry points)
- Oppo (ColorOS) / Realme → `com.coloros.safecenter`, `com.oppo.safe`
- Vivo (FuntouchOS / OriginOS) → `com.vivo.permissionmanager`, `com.iqoo.secure`
- OnePlus (older OxygenOS) → `com.oneplus.security`
- Letv → `com.letv.android.letvsafe`
- Asus → `com.asus.mobilemanager`
- Samsung → `com.samsung.android.lool` (battery activity, closest exported)
- Nokia (EvenWell) → `com.evenwell.powersaving.g3`

Probed with `resolveActivity` so the entry only appears on devices where it actually works; package names declared in `<queries>` for Android 11+ package visibility.

`./gradlew :app:assembleDebug`, `:app:testDebugUnitTest`, `detekt` all green. Verified on the maintainer's Galaxy device (S Series).