### PR TITLE
feat: instant home + accurate auth-failure UI (#245)

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     // needs to be applied separately.
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {

--- a/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
@@ -158,11 +158,11 @@ class MainActivity : ComponentActivity() {
                 when {
                     needsLogin -> SpotifyLoginScreen(vm)
                     !initialized -> {
-                        val cooldown by vm.rateLimitCooldown.collectAsState()
+                        val cooldown by vm.authBackoffActive.collectAsState()
                         val seconds by vm.cooldownSeconds.collectAsState()
                         LoadingScreen(
                             error = error,
-                            isRateLimited = cooldown,
+                            isAuthBackoff = cooldown,
                             cooldownSecondsRemaining = seconds,
                             onLogin = { if (!cooldown) vm.showLogin() },
                             onRetry = {

--- a/src/app/src/main/java/ch/snepilatch/app/auth/AccountCacheStore.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/auth/AccountCacheStore.kt
@@ -1,0 +1,46 @@
+package ch.snepilatch.app.auth
+
+import android.content.Context
+import ch.snepilatch.app.data.AccountInfo
+import ch.snepilatch.app.util.LokiLogger
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * Persists the last-known [AccountInfo] to disk so the home screen can show
+ * the user's name and avatar instantly on cold start while the live profile
+ * fetch runs in the background. Refreshed by [ch.snepilatch.app.viewmodel.SpotifyViewModel]
+ * after every successful profile fetch.
+ */
+object AccountCacheStore {
+
+    private const val TAG = "AccountCache"
+    private const val FILE_NAME = "account_cache.json"
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun load(context: Context): AccountInfo? {
+        val file = File(context.filesDir, FILE_NAME)
+        if (!file.exists()) return null
+        return try {
+            json.decodeFromString<AccountInfo>(file.readText())
+        } catch (e: Exception) {
+            LokiLogger.w(TAG, "Failed to decode account cache: ${e.message?.take(120)}")
+            null
+        }
+    }
+
+    fun save(context: Context, info: AccountInfo) {
+        val file = File(context.filesDir, FILE_NAME)
+        try {
+            file.writeText(json.encodeToString(AccountInfo.serializer(), info))
+        } catch (e: Exception) {
+            LokiLogger.w(TAG, "Failed to save account cache: ${e.message?.take(120)}")
+        }
+    }
+
+    fun clear(context: Context) {
+        val file = File(context.filesDir, FILE_NAME)
+        if (file.exists()) file.delete()
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/auth/SessionSnapshotStore.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/auth/SessionSnapshotStore.kt
@@ -1,0 +1,60 @@
+package ch.snepilatch.app.auth
+
+import android.content.Context
+import ch.snepilatch.app.util.LokiLogger
+import kotify.session.SessionSnapshot
+import kotlinx.serialization.json.Json
+import java.io.File
+
+/**
+ * Persists a Kotify [SessionSnapshot] to a single JSON file in
+ * `filesDir/session_snapshot.json`. Pair with [kotify.session.Session.hydrate]
+ * on cold start to skip the apresolve / token / client-token network calls.
+ *
+ * The snapshot is rewritten after every successful `Session.load()` and after
+ * every successful `BaseClient.refreshAccessToken()`, so the on-disk copy
+ * tracks the latest `accessTokenExpirationTimestampMs`.
+ */
+object SessionSnapshotStore {
+
+    private const val TAG = "SnapshotStore"
+    private const val FILE_NAME = "session_snapshot.json"
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun load(context: Context): SessionSnapshot? {
+        val file = File(context.filesDir, FILE_NAME)
+        if (!file.exists()) return null
+        return try {
+            json.decodeFromString<SessionSnapshot>(file.readText())
+        } catch (e: Exception) {
+            LokiLogger.w(TAG, "Failed to decode session snapshot: ${e.message?.take(120)}")
+            null
+        }
+    }
+
+    fun save(context: Context, snapshot: SessionSnapshot) {
+        val file = File(context.filesDir, FILE_NAME)
+        try {
+            file.writeText(json.encodeToString(SessionSnapshot.serializer(), snapshot))
+            LokiLogger.i(TAG, "Saved session snapshot (token expires at ${snapshot.baseClient.accessTokenExpirationTimestampMs})")
+        } catch (e: Exception) {
+            LokiLogger.w(TAG, "Failed to save session snapshot: ${e.message?.take(120)}")
+        }
+    }
+
+    fun clear(context: Context) {
+        val file = File(context.filesDir, FILE_NAME)
+        if (file.exists()) file.delete()
+    }
+
+    /**
+     * True if [snapshot] has an access token whose expiry is at least
+     * [graceMs] ms in the future — meaning it's safe to hydrate from this
+     * snapshot without an immediate `refreshAccessToken()` call.
+     */
+    fun isTokenValid(snapshot: SessionSnapshot, graceMs: Long = 5 * 60_000L): Boolean {
+        val expiresAt = snapshot.baseClient.accessTokenExpirationTimestampMs ?: return false
+        return expiresAt - System.currentTimeMillis() > graceMs
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
@@ -74,6 +74,7 @@ data class RelatedAlbum(
     val albumType: String?
 )
 
+@kotlinx.serialization.Serializable
 data class AccountInfo(
     val username: String = "",
     val displayName: String = "",

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -225,7 +225,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
 @Composable
 fun LoadingScreen(
     error: String?,
-    isRateLimited: Boolean = false,
+    isAuthBackoff: Boolean = false,
     cooldownSecondsRemaining: Int = 0,
     onLogin: () -> Unit = {},
     onRetry: () -> Unit = {}
@@ -233,7 +233,7 @@ fun LoadingScreen(
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             when {
-                isRateLimited -> {
+                isAuthBackoff -> {
                     // The cooldown total can vary (20s on first retry, 40s on
                     // second, etc. — see SpotifyViewModel). Track the highest
                     // value we've seen so the progress bar fills correctly
@@ -246,7 +246,7 @@ fun LoadingScreen(
 
                     Icon(Icons.Default.CloudOff, null, tint = SpotifyLightGray, modifier = Modifier.size(48.dp))
                     Spacer(Modifier.height(16.dp))
-                    Text("Rate limited", color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                    Text("Reconnecting to Spotify", color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(Modifier.height(8.dp))
                     Text("Retrying in ${cooldownSecondsRemaining}s", color = SpotifyLightGray, fontSize = 14.sp)
                     Spacer(Modifier.height(24.dp))

--- a/src/app/src/main/java/ch/snepilatch/app/util/CookieManager.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/util/CookieManager.kt
@@ -31,4 +31,9 @@ fun loadCookies(context: Context): Map<String, String>? {
 fun clearCookies(context: Context) {
     context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         .edit().remove(COOKIES_KEY).apply()
+    // The session snapshot and account cache are bound to whichever sp_dc
+    // cookie produced them; wipe so the next launch goes through the webview
+    // cleanly with no stale identity bleeding into the new account.
+    ch.snepilatch.app.auth.SessionSnapshotStore.clear(context)
+    ch.snepilatch.app.auth.AccountCacheStore.clear(context)
 }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -66,7 +66,14 @@ class SpotifyViewModel : ViewModel() {
     private var username: String = ""
     val isInitialized = MutableStateFlow(false)
     val initError = MutableStateFlow<String?>(null)
-    val rateLimitCooldown = MutableStateFlow(false)
+
+    /**
+     * True while we're sitting through a backoff after Spotify rejected the
+     * auth handshake (typically a 400 "Unauthorized request" from `/api/token`,
+     * which is bot-detection / anti-abuse rather than a real rate limit).
+     * The LoadingScreen reads this to show a countdown.
+     */
+    val authBackoffActive = MutableStateFlow(false)
     val cooldownSeconds = MutableStateFlow(0)
     private var initRetryCount = 0
 
@@ -225,41 +232,81 @@ class SpotifyViewModel : ViewModel() {
                     initialCookies = cookies,
                     deviceProfile = kotify.config.DeviceProfile.CHROME_WINDOWS
                 ))
-                sess.load()
+
+                // Warm-start path: if we have a persisted snapshot with a
+                // still-valid access token, hydrate from disk and skip
+                // initSession's apresolve/token/client-token network round-trips.
+                // On 401 from any subsequent call, HttpClient.onAuthRefreshNeeded
+                // transparently refreshes; on hard auth failure we fall through
+                // to the cold-init catch block below.
+                val ctx = appContext
+                val cachedSnapshot = ctx?.let { ch.snepilatch.app.auth.SessionSnapshotStore.load(it) }
+                val hydrated = cachedSnapshot != null &&
+                    ch.snepilatch.app.auth.SessionSnapshotStore.isTokenValid(cachedSnapshot)
+                if (hydrated && cachedSnapshot != null) {
+                    sess.hydrate(cachedSnapshot)
+                    LokiLogger.i(TAG, "Session hydrated from snapshot (cold-start fast path)")
+                } else {
+                    sess.load()
+                    LokiLogger.i(TAG, "Session loaded via full initSession")
+                    if (ctx != null) {
+                        ch.snepilatch.app.auth.SessionSnapshotStore.save(ctx, sess.snapshot())
+                    }
+                }
                 session = sess
                 val sp = SpotifyPlayback(sess)
                 spotifyPlayback = sp
                 cdnResolver = SpotifyCdnResolver(sess, sp)
-                LokiLogger.i(TAG, "Session loaded")
+
+                // Show cached account immediately so the home screen renders the
+                // user's name/avatar from frame 1. The live profile fetch below
+                // overwrites this once it returns.
+                ctx?.let {
+                    ch.snepilatch.app.auth.AccountCacheStore.load(it)?.let { cached ->
+                        _account.value = cached
+                        username = cached.username
+                    }
+                }
+
+                // Unblock the UI gate now — the home screen can render with
+                // cached account (or empty defaults) while loadHome / loadLibrary
+                // / profile fetches finish in the background.
+                isInitialized.value = true
+                initRetryCount = 0
 
                 // Start loading home and library immediately after session is ready
                 // These run in parallel with user profile and player setup
                 loadHome()
                 loadLibrary()
 
-                val userApi = User(sess)
-                val me = userApi.getCurrentUser()
-                username = me.username
-                val isPremium = userApi.hasPremium()
-                // Get public profile (display name + avatar) from user-profile-view API
-                val pubProfile = userApi.getProfile(username)
-                val displayName = pubProfile.displayName.ifEmpty { username }
-                val userId = username
-                val imageUrl = pubProfile.imageUrl
-                LokiLogger.i(TAG, "Profile: display=$displayName, user=$username, image=${imageUrl?.take(40)}")
-                _account.value = AccountInfo(
-                    username = username,
-                    displayName = displayName,
-                    isPremium = isPremium,
-                    profileImageUrl = imageUrl,
-                    userId = username,
-                    followers = pubProfile.followers,
-                    playlistCount = pubProfile.publicPlaylists
-                )
-                LokiLogger.i(TAG, "User: $username ($displayName), premium: $isPremium")
-
-                isInitialized.value = true
-                initRetryCount = 0
+                // Live profile refresh — fire-and-forget. Overwrites the cached
+                // AccountInfo when it returns, and persists the fresh copy to disk.
+                viewModelScope.launch(Dispatchers.IO) {
+                    try {
+                        val userApi = User(sess)
+                        val me = userApi.getCurrentUser()
+                        username = me.username
+                        val isPremium = userApi.hasPremium()
+                        val pubProfile = userApi.getProfile(username)
+                        val displayName = pubProfile.displayName.ifEmpty { username }
+                        val imageUrl = pubProfile.imageUrl
+                        LokiLogger.i(TAG, "Profile: display=$displayName, user=$username, image=${imageUrl?.take(40)}")
+                        val fresh = AccountInfo(
+                            username = username,
+                            displayName = displayName,
+                            isPremium = isPremium,
+                            profileImageUrl = imageUrl,
+                            userId = username,
+                            followers = pubProfile.followers,
+                            playlistCount = pubProfile.publicPlaylists,
+                        )
+                        _account.value = fresh
+                        ctx?.let { ch.snepilatch.app.auth.AccountCacheStore.save(it, fresh) }
+                        LokiLogger.i(TAG, "User: $username ($displayName), premium: $isPremium")
+                    } catch (e: Exception) {
+                        LokiLogger.w(TAG, "Profile refresh failed (cached value still shown): ${e.message?.take(120)}")
+                    }
+                }
 
                 // Disconnect any existing player before creating a new one
                 // This prevents duplicate device registrations
@@ -295,6 +342,7 @@ class SpotifyViewModel : ViewModel() {
                     if (backgroundTokenRefreshEnabled.value) {
                         appContext?.let { ch.snepilatch.app.auth.TokenRefreshWorker.enable(it) }
                     }
+                    var consecutiveRefreshFailures = 0
                     while (true) {
                         val expiresAt = sess.baseClient.accessTokenExpirationTimestampMs
                         val sleepMs = if (expiresAt != null) {
@@ -307,8 +355,23 @@ class SpotifyViewModel : ViewModel() {
                         try {
                             sess.baseClient.refreshAccessToken()
                             LokiLogger.i(TAG, "Access token refreshed (next in ~${sleepMs / 60_000}m)")
+                            consecutiveRefreshFailures = 0
+                            appContext?.let {
+                                ch.snepilatch.app.auth.SessionSnapshotStore.save(it, sess.snapshot())
+                            }
                         } catch (e: Exception) {
-                            LokiLogger.w(TAG, "Token refresh failed: ${e.message}")
+                            consecutiveRefreshFailures++
+                            LokiLogger.w(TAG, "Token refresh failed (#$consecutiveRefreshFailures): ${e.message?.take(120)}")
+                            if (consecutiveRefreshFailures >= MAX_CONSECUTIVE_REFRESH_FAILURES) {
+                                // Persistent auth failure — Spotify is rejecting our /api/token
+                                // even with backoff. Drop the UI back to the loading/error screen
+                                // so the user can re-login or wait it out, instead of silently
+                                // failing every interaction.
+                                LokiLogger.e(TAG, "Session auth lost after $consecutiveRefreshFailures consecutive refresh failures")
+                                initError.value = "Lost Spotify session — sign in again to continue"
+                                isInitialized.value = false
+                                return@launch
+                            }
                             delay(REFRESH_RETRY_DELAY_MS)
                         }
                     }
@@ -334,21 +397,21 @@ class SpotifyViewModel : ViewModel() {
                 val msg = e.message ?: "Unknown error"
                 if (msg.contains("Unauthorized") || msg.contains("401") || msg.contains("code\":400")) {
                     initRetryCount++
-                    if (initRetryCount > 5) {
-                        LokiLogger.e(TAG, "Rate limited — 5 retries exhausted, giving up")
-                        initError.value = "Connection failed after 5 attempts. Please try again later."
-                        rateLimitCooldown.value = false
+                    if (initRetryCount > MAX_INIT_RETRIES) {
+                        LokiLogger.e(TAG, "Auth handshake rejected — $MAX_INIT_RETRIES retries exhausted, giving up")
+                        initError.value = "Couldn't reach Spotify after $MAX_INIT_RETRIES attempts. Try again later."
+                        authBackoffActive.value = false
                         return@launch
                     }
                     val cooldownSecs = 20 * initRetryCount // 20s, 40s, 60s...
-                    LokiLogger.w(TAG, "Rate limited, attempt $initRetryCount/5, cooling down ${cooldownSecs}s...")
-                    initError.value = "Rate limited — attempt $initRetryCount/5"
-                    rateLimitCooldown.value = true
+                    LokiLogger.w(TAG, "Auth handshake rejected, attempt $initRetryCount/$MAX_INIT_RETRIES, retrying in ${cooldownSecs}s")
+                    initError.value = "Spotify is throttling sign-in — attempt $initRetryCount/$MAX_INIT_RETRIES"
+                    authBackoffActive.value = true
                     for (i in cooldownSecs downTo 1) {
                         cooldownSeconds.value = i
                         delay(1000)
                     }
-                    rateLimitCooldown.value = false
+                    authBackoffActive.value = false
                     cooldownSeconds.value = 0
                     initError.value = null
                     // Retry after cooldown
@@ -2246,5 +2309,17 @@ class SpotifyViewModel : ViewModel() {
         private const val MIN_REFRESH_DELAY_MS = 5 * 1000L
         private const val FALLBACK_REFRESH_INTERVAL_MS = 50 * 60 * 1000L
         private const val REFRESH_RETRY_DELAY_MS = 60 * 1000L
+
+        /** How many init attempts we make before showing the user a hard fail.
+         *  Matches the 3-attempt cap in KotifyClient's HttpClient 401 retry path
+         *  so the two layers are consistent. */
+        private const val MAX_INIT_RETRIES = 3
+
+        /** How many back-to-back foreground refresh failures we tolerate before
+         *  dropping the UI back to the loading screen and forcing user action.
+         *  Three with a 60s gap ≈ 3 minutes of failed retries — enough that
+         *  transient Spotify 4xx blips don't kick the user out, but persistent
+         *  rejection does. */
+        private const val MAX_CONSECUTIVE_REFRESH_FAILURES = 3
     }
 }

--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -34,4 +34,5 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 


### PR DESCRIPTION
Closes #245. Depends on KotifyClient #125 (already merged).

Three connected changes:

1. **Instant home screen.** `isInitialized` flips to true immediately after `session.hydrate()` / `session.load()` instead of waiting on the three sequential `User` API calls (`getCurrentUser`, `hasPremium`, `getProfile`). Those moved into a `viewModelScope.launch(IO)` coroutine that overwrites `_account.value` when it returns and persists the fresh copy to disk. `AccountCacheStore` hydrates the last-known account synchronously before `isInitialized` flips, so the name and avatar are correct from frame 1.

2. **Misleading "Rate limited" label fixed.** Catch block was tagging Spfy's 400 "Unauthorized request" (bot-detection / anti-abuse on `/api/token`) as "Rate limited", which is wrong. Renamed `rateLimitCooldown` → `authBackoffActive`. LoadingScreen now reads "Reconnecting to Spfy". Init retry cap drops from 5 → 3 to match KotifyClient's HttpClient 3-attempt cap.

3. **Mid-session auth loss surfaces to UI.** The foreground refresh loop now counts consecutive failures via `MAX_CONSECUTIVE_REFRESH_FAILURES = 3`. After three in a row (~3 min of retries), it flips `isInitialized = false` and sets `initError = "Lost Spfy session — sign in again to continue"`. The existing loading-screen gate in MainActivity re-engages with Retry / Login buttons. Replaces the previous silent-retry behavior where buttons looked functional but every call 401'd.

Side effect of (3): `Session.snapshot()` is now persisted after each successful `refreshAccessToken()` as well, not just after the initial load — so the on-disk copy always tracks the latest `accessTokenExpirationTimestampMs`.

`./gradlew :app:assembleDebug :app:testDebugUnitTest detekt` all green. Verified end-to-end on Galaxy S25 Ultra: first cold start shows `Session initialized successfully`, next launch shows `Hydrated session for kotify-android from snapshot` followed by the home screen with cached name/avatar, then `Profile: display=...` once the live refresh lands.