### PR TITLE
feat: wire Session.onAuthLost for immediate auth-loss surfacing (#247)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -253,6 +253,18 @@ class SpotifyViewModel : ViewModel() {
                         ch.snepilatch.app.auth.SessionSnapshotStore.save(ctx, sess.snapshot())
                     }
                 }
+
+                // Fast-path detection of persistent auth failure: when any API
+                // call's 401-refresh retry path gives up MAX_AUTH_REFRESH_FAILURES
+                // times in a row, the foreground refresh loop's 3-strikes guard
+                // would eventually catch it ~3 min later. This callback drops the
+                // UI back to the loading gate immediately instead.
+                sess.onAuthLost = {
+                    LokiLogger.e(TAG, "Session auth lost (HttpClient onAuthLost fired)")
+                    initError.value = "Lost Spotify session — sign in again to continue"
+                    isInitialized.value = false
+                }
+
                 session = sess
                 val sp = SpotifyPlayback(sess)
                 spotifyPlayback = sp


### PR DESCRIPTION
Closes #247. Depends on KotifyClient #127 (already merged).

Wires `Session.onAuthLost` in `SpfyViewModel.initialize()` — when any API call's 401-refresh budget exhausts (HttpClient gives up after `MAX_AUTH_ATTEMPTS = 3`), the callback flips `isInitialized = false` and sets the lost-session error. MainActivity's existing gate immediately re-shows the loading screen with Retry / Login.

Drops detection time for persistent auth loss from ~3 minutes (foreground refresh loop catching it on its next scheduled tick — added in #246) to ~60s (HttpClient retry cap giving up). Both paths still exist and are complementary.

`./gradlew :app:assembleDebug :app:testDebugUnitTest detekt` green.