### PR TITLE
fix: playlist infinite scroll keeps paginating past first page (#251)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
@@ -153,12 +153,18 @@ fun PlaylistInfo.toDetailData(playlistId: String) = DetailData(
     description = description.takeIf { it.isNotBlank() },
     uri = "spotify:playlist:$playlistId",
     type = "playlist",
-    totalCount = totalTracks,
+    // KotifyClient's PlaylistMapper returns 0 when content.totalCount isn't
+    // where it expects in the GraphQL response. If we received a full page
+    // but the server didn't tell us the total, treat it as unknown (-1) so
+    // pagination keeps going until a short page proves we're at the end.
+    totalCount = if (totalTracks <= 0 && tracks.size >= PLAYLIST_PAGE_SIZE) -1 else totalTracks,
     loadedOffset = tracks.size,
     ownerName = owner.name,
     followers = followers,
     tracks = tracks.map { it.toTrackInfo() },
 )
+
+private const val PLAYLIST_PAGE_SIZE = 50
 
 fun LikedSongsPage.toDetailData(offset: Int) = DetailData(
     name = "Liked Songs",

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -2134,12 +2134,22 @@ class SpotifyViewModel : ViewModel() {
                     )
                 } else if (uri.startsWith("spotify:playlist:")) {
                     val id = uri.removePrefix("spotify:playlist:")
-                    val info = Playlist(sess).getPlaylist(id, limit = 50, offset = offset)
+                    val info = Playlist(sess).getPlaylist(id, limit = DETAIL_PAGE_SIZE, offset = offset)
                     val more = info.tracks.map { it.toTrackInfo() }
+                    val newSize = current.tracks.size + more.size
+                    // Server-reported totalTracks is unreliable (PlaylistMapper
+                    // returns 0 when content.totalCount is missing). Use the
+                    // page-shorter-than-limit signal as the authoritative
+                    // "we're at the end" indicator instead.
+                    val newTotalCount = when {
+                        more.size < DETAIL_PAGE_SIZE -> newSize
+                        info.totalTracks > 0 -> info.totalTracks
+                        else -> -1
+                    }
                     _detail.value = current.copy(
                         tracks = current.tracks + more,
-                        totalCount = info.totalTracks,
-                        loadedOffset = offset + more.size
+                        totalCount = newTotalCount,
+                        loadedOffset = newSize
                     )
                 } else if (uri.startsWith("spotify:album:")) {
                     val id = uri.removePrefix("spotify:album:")
@@ -2334,6 +2344,12 @@ class SpotifyViewModel : ViewModel() {
          *  lands within ~1.5s; 5s gives generous headroom so we don't double-skip
          *  when the natural advance arrives just past a tighter timeout. */
         private const val AUTO_ADVANCE_GRACE_MS = 5000L
+
+        /** Page size for playlist/album detail pagination. Matches the limit
+         *  passed to [kotify.api.playlist.Playlist.getPlaylist] in
+         *  [loadMoreDetail]; when a page returns fewer rows than this we've
+         *  reached the end regardless of any server-reported total. */
+        private const val DETAIL_PAGE_SIZE = 50
 
         /** How many init attempts we make before showing the user a hard fail.
          *  Matches the 3-attempt cap in KotifyClient's HttpClient 401 retry path


### PR DESCRIPTION
Closes #251. Pairs with KotifyClient #129 (just merged).

On any playlist with more than 50 tracks, the bottom-of-list pagination trigger never fired — only the initial \`fetchPlaylist\` call ran. Root cause: KotifyClient's \`PlaylistMapper\` returned \`totalTracks = 0\` when Spfy encoded \`content.totalCount\` as a string. \`DetailData.totalCount = 0\` then made \`hasMore = tracks.size < totalCount\` evaluate \`50 < 0 = false\`, so the \`LaunchedEffect(detail.tracks.size)\` inside the last-5 items was never composed and \`loadMoreDetail\` never ran.

KotifyClient #129 fixes the root cause. This PR adds defense-in-depth on the consumer side so future mapper regressions don't break user-visible pagination:

- \`toDetailData\` treats \`totalTracks <= 0\` with a full first page as "unknown total" (-1) instead of 0.
- \`loadMoreDetail\` uses "page shorter than \`DETAIL_PAGE_SIZE\`" as the authoritative end-of-list signal, rather than trusting the server-reported total.

\`./gradlew :app:assembleDebug :app:testDebugUnitTest detekt\` green.