### PR TITLE
fix: recover from stale-snapshot boot failure (#254)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -407,12 +407,28 @@ class SpotifyViewModel : ViewModel() {
             } catch (e: Exception) {
                 LokiLogger.e(TAG, "Init failed", e)
                 val msg = e.message ?: "Unknown error"
-                if (msg.contains("Unauthorized") || msg.contains("401") || msg.contains("code\":400")) {
+                // The instant-home work flips isInitialized=true after the
+                // session is hydrated, before pc.ready() runs. If pc.ready()
+                // (the dealer WebSocket) then throws, we'd otherwise leave the
+                // UI in a half-booted state — visible but with no player.
+                // Roll it back so the loading screen re-engages and the user
+                // sees the auth-backoff / retry UI instead of a frozen home.
+                isInitialized.value = false
+                val isTransientAuth = msg.contains("Unauthorized") ||
+                    msg.contains("401") ||
+                    msg.contains("code\":400") ||
+                    msg.contains("bad handshake") ||
+                    msg.contains("websocket")
+                if (isTransientAuth) {
                     initRetryCount++
                     if (initRetryCount > MAX_INIT_RETRIES) {
                         LokiLogger.e(TAG, "Auth handshake rejected — $MAX_INIT_RETRIES retries exhausted, giving up")
                         initError.value = "Couldn't reach Spotify after $MAX_INIT_RETRIES attempts. Try again later."
                         authBackoffActive.value = false
+                        // Cached session snapshot may be the cause (stale deviceId
+                        // / clientToken). Drop it so the next manual retry goes
+                        // through full initSession instead of re-hydrating.
+                        appContext?.let { ch.snepilatch.app.auth.SessionSnapshotStore.clear(it) }
                         return@launch
                     }
                     val cooldownSecs = 20 * initRetryCount // 20s, 40s, 60s...


### PR DESCRIPTION
Closes #254.

Cold-start failure mode after the instant-home work in #246:
1. \`Session.hydrate()\` succeeds from cached snapshot.
2. \`isInitialized = true\` flips early so home shows.
3. \`pc.ready()\` throws \`java.io.IOException: connect: websocket: bad handshake\` — Spfy rejects the dealer WebSocket, often because the cached \`deviceId\` / \`clientToken\` aged out, or because of a transient anti-abuse 400 wave.
4. The catch only matched \`Unauthorized | 401 | code:400\` strings. "bad handshake" fell through to \`initError = msg\` with no retry. UI stayed at \`isInitialized = true\` but player was null, loadHome had also failed — looked like a frozen / un-bootable app.

Three changes:
- Roll \`isInitialized\` back to \`false\` in the init catch, so the loading screen re-engages whenever cold-start fails after the early flip.
- Add \`bad handshake\` and \`websocket\` to the transient-auth pattern; routes through the existing 3-attempt backoff (20s/40s/60s).
- On retries-exhausted, \`SessionSnapshotStore.clear()\` so the next manual retry goes through full \`initSession\` instead of re-hydrating the rejected snapshot.

Verified on device: deleted snapshot + reinstalled + cold launched → \`Player ready, device: a90140a20b3c85565dd8804e47251709\`. Clean recovery via full initSession.