### PR TITLE
refactor: remove staggered item-appear animation (#259)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -1,7 +1,6 @@
 package ch.snepilatch.app.ui.components
 
 import ch.snepilatch.app.ui.theme.SpotifyWhite
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -15,7 +14,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -38,7 +36,6 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,7 +45,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -57,7 +53,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import kotlinx.coroutines.delay
 import ch.snepilatch.app.data.TrackInfo
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
@@ -251,17 +246,4 @@ fun ProfileInfoItem(label: String, value: String, icon: ImageVector) {
         leadingContent = { Icon(icon, null, tint = SpotifyLightGray) },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent)
     )
-}
-
-// --- Item appear animation ---
-
-@Composable
-fun itemAppearModifier(index: Int, baseDelay: Int = 30): Modifier {
-    val offsetY = remember { Animatable(16f) }
-    LaunchedEffect(Unit) {
-        kotlinx.coroutines.delay((index * baseDelay).toLong())
-        offsetY.animateTo(0f, tween(200))
-    }
-    return Modifier
-        .offset { IntOffset(0, offsetY.value.toInt()) }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import ch.snepilatch.app.ui.components.itemAppearModifier
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.clickable
@@ -291,12 +290,10 @@ fun DetailScreen(vm: SpotifyViewModel) {
             if (hasMore && index >= detail.tracks.size - 5) {
                 LaunchedEffect(detail.tracks.size) { vm.loadMoreDetail() }
             }
-            Box(itemAppearModifier(index)) {
-                when {
-                    isArtist -> ArtistTrackRow(index + 1, track, vm, detail.uri, detail.topTrackPlaycounts.getOrNull(index))
-                    detail.type == "album" -> AlbumTrackRow(track, vm, detail.uri)
-                    else -> TrackRow(track, vm, contextUri = detail.uri)
-                }
+            when {
+                isArtist -> ArtistTrackRow(index + 1, track, vm, detail.uri, detail.topTrackPlaycounts.getOrNull(index))
+                detail.type == "album" -> AlbumTrackRow(track, vm, detail.uri)
+                else -> TrackRow(track, vm, contextUri = detail.uri)
             }
         }
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
@@ -66,7 +66,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.data.LibraryItem
 import ch.snepilatch.app.ui.components.SpotifyImage
-import ch.snepilatch.app.ui.components.itemAppearModifier
 import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
@@ -243,9 +242,7 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 itemsIndexed(sortedLibrary) { index, item ->
-                    Box(itemAppearModifier(index)) {
-                        LibraryGridCard(item, vm)
-                    }
+                    LibraryGridCard(item, vm)
                     if (libraryHasMore && index >= library.size - 10) {
                         LaunchedEffect(library.size) { vm.loadMoreLibrary() }
                     }
@@ -257,9 +254,7 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                 verticalArrangement = Arrangement.spacedBy(0.dp)
             ) {
                 itemsIndexed(sortedLibrary) { index, item ->
-                    Box(itemAppearModifier(index)) {
-                        LibraryListItem(item, vm)
-                    }
+                    LibraryListItem(item, vm)
                     if (libraryHasMore && index >= library.size - 10) {
                         LaunchedEffect(library.size) { vm.loadMoreLibrary() }
                     }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.ui.components.SpotifyImage
-import ch.snepilatch.app.ui.components.itemAppearModifier
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
@@ -75,19 +74,17 @@ fun QueueScreen(vm: SpotifyViewModel) {
 
         LazyColumn(Modifier.fillMaxSize(), contentPadding = androidx.compose.foundation.layout.PaddingValues(bottom = LocalBottomOverlayHeight.current.value + 16.dp)) {
             itemsIndexed(queue) { index, track ->
-                Box(itemAppearModifier(index)) {
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .clickable { vm.skipToQueueIndex(index) }
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        SpotifyImage(track.albumArt, Modifier.size(48.dp).clip(RoundedCornerShape(4.dp)))
-                        Column(Modifier.padding(start = 12.dp).weight(1f)) {
-                            Text(track.name, color = SpotifyWhite, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                            Text(track.artist, color = SpotifyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        }
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { vm.skipToQueueIndex(index) }
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    SpotifyImage(track.albumArt, Modifier.size(48.dp).clip(RoundedCornerShape(4.dp)))
+                    Column(Modifier.padding(start = 12.dp).weight(1f)) {
+                        Text(track.name, color = SpotifyWhite, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Text(track.artist, color = SpotifyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                 }
             }


### PR DESCRIPTION
Closes #259.

\`itemAppearModifier\` staggered each row by \`index × 30ms\` and animated 200ms. After two iterations (slide → fade with a 240ms stagger cap), fast-scroll still produced visible lag — items instantiated by LazyList earlier still had pending delays when they entered the viewport. Drop the helper and the four wrappers at call sites; items render immediately.

\`./gradlew :app:assembleDebug detekt\` green.