### PR TITLE
feat: restart current song when back pressed past 3s (#139)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1010,6 +1010,11 @@ class SpotifyViewModel : ViewModel() {
     }
 
     fun skipPrevious() {
+        // If we're more than 3s into the track, restart it instead of going to previous.
+        if (_playback.value.positionMs > PREV_RESTART_THRESHOLD_MS) {
+            seekTo(0)
+            return
+        }
         commandJob?.cancel()
         lastCommandTs = System.currentTimeMillis()
         lastCommandName = "skipPrevious"
@@ -1501,13 +1506,7 @@ class SpotifyViewModel : ViewModel() {
                 catch (e: Exception) { LokiLogger.e(TAG, "svc next", e) }
             }
         }
-        svc.onSkipPrevious = {
-            viewModelScope.launch(Dispatchers.IO) {
-                try { player?.skipPrevious() }
-                catch (e: CancellationException) { throw e }
-                catch (e: Exception) { LokiLogger.e(TAG, "svc prev", e) }
-            }
-        }
+        svc.onSkipPrevious = { skipPrevious() }
         svc.onSeek = { posMs ->
             viewModelScope.launch(Dispatchers.IO) {
                 try { player?.seek(posMs.toInt()) }
@@ -2253,5 +2252,10 @@ class SpotifyViewModel : ViewModel() {
          *  [loadMoreDetail]; when a page returns fewer rows than this we've
          *  reached the end regardless of any server-reported total. */
         private const val DETAIL_PAGE_SIZE = 50
+
+        /** If skipPrevious is invoked after this many ms into the current track,
+         *  restart the track instead of going to the previous one. Matches the
+         *  behavior most music players use. */
+        private const val PREV_RESTART_THRESHOLD_MS = 3000L
     }
 }


### PR DESCRIPTION
Closes #139

The previous/back button now restarts the current track if playback is past 3s; otherwise it skips to the previous track. Matches the standard music-player convention.

Implementation: `SpfyViewModel.skipPrevious()` checks `positionMs` against a new `PREV_RESTART_THRESHOLD_MS = 3000L` and routes to `seekTo(0)` instead of `player.skipPrevious()` when over the threshold. The media-session callback (`onSkipPrevious`) now goes through the same path, so Bluetooth/headphone prev-button gets the same behavior.

Kept in the app layer rather than KotifyClient — Kotify is a thin protocol surface; this is UX policy.

## Test plan
- [x] Verified on device: prev button past 3s restarts, under 3s goes to previous