### PR TITLE
feat(i18n): wire UI strings to string resources (#124)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
@@ -26,8 +26,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
@@ -61,11 +63,12 @@ fun BottomNav(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
         ) {
             data class NavItem(val s: Screen, val icon: ImageVector, val label: String)
             val items = listOf(
-                NavItem(Screen.HOME, Icons.Default.Home, "Home"),
-                NavItem(Screen.SEARCH, Icons.Default.Search, "Search"),
-                NavItem(Screen.LIBRARY, Icons.AutoMirrored.Filled.QueueMusic, "Library"),
-                NavItem(Screen.ACCOUNT, Icons.Default.Person, "Account")
+                NavItem(Screen.HOME, Icons.Default.Home, stringResource(R.string.nav_home)),
+                NavItem(Screen.SEARCH, Icons.Default.Search, stringResource(R.string.nav_search)),
+                NavItem(Screen.LIBRARY, Icons.AutoMirrored.Filled.QueueMusic, stringResource(R.string.nav_library)),
+                NavItem(Screen.ACCOUNT, Icons.Default.Person, stringResource(R.string.nav_account))
             )
+            val accountDesc = stringResource(R.string.account_image)
             items.forEach { nav ->
                 val selected = screen == nav.s
                 NavigationBarItem(
@@ -85,7 +88,7 @@ fun BottomNav(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
                             ) {
                                 AsyncImage(
                                     model = account.profileImageUrl,
-                                    contentDescription = "Account",
+                                    contentDescription = accountDesc,
                                     modifier = Modifier.size(24.dp).clip(CircleShape),
                                     contentScale = ContentScale.Crop
                                 )

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
@@ -38,9 +38,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
@@ -82,7 +84,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
         ) {
             // Title
             Text(
-                "Connect",
+                stringResource(R.string.connect),
                 color = SpotifyWhite,
                 fontSize = 22.sp,
                 fontWeight = FontWeight.Bold,
@@ -97,7 +99,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                 ) {
                     CircularProgressIndicator(color = SpotifyWhite, modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
                     Spacer(Modifier.width(12.dp))
-                    Text("Searching for devices...", color = SpotifyLightGray, fontSize = 14.sp)
+                    Text(stringResource(R.string.searching_devices), color = SpotifyLightGray, fontSize = 14.sp)
                 }
             }
 
@@ -127,7 +129,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                     Column(Modifier.weight(1f)) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(
-                                if (isOurDevice) "This Smartphone" else activeDevice.name,
+                                if (isOurDevice) stringResource(R.string.this_smartphone) else activeDevice.name,
                                 color = accentColor,
                                 fontSize = 16.sp,
                                 fontWeight = FontWeight.Bold
@@ -188,7 +190,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                     )
                     Spacer(Modifier.width(16.dp))
                     Text(
-                        if (isOurDevice) "This Smartphone" else device.name,
+                        if (isOurDevice) stringResource(R.string.this_smartphone) else device.name,
                         color = SpotifyWhite,
                         fontSize = 16.sp,
                         modifier = Modifier.weight(1f)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
@@ -33,10 +33,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
@@ -101,12 +103,12 @@ fun MiniPlayer(vm: SpotifyViewModel) {
                 } else {
                     Icon(
                         if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
-                        "Play/Pause", tint = SpotifyWhite, modifier = Modifier.size(28.dp)
+                        stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(28.dp)
                     )
                 }
             }
             IconButton(onClick = { vm.skipNext() }, modifier = Modifier.size(40.dp)) {
-                Icon(Icons.Default.SkipNext, "Next", tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
             }
         }
         if (playback.durationMs > 0) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -1,5 +1,6 @@
 package ch.snepilatch.app.ui.components
 
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyWhite
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
@@ -49,6 +50,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -165,7 +167,7 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
             Spacer(Modifier.width(4.dp))
         }
         IconButton(onClick = { showMenu = true }, modifier = Modifier.size(36.dp)) {
-            Icon(Icons.Default.MoreVert, "More", tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+            Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
     }
 
@@ -201,20 +203,36 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
             Spacer(Modifier.height(8.dp))
             HorizontalDivider(color = SpotifyLightGray.copy(alpha = 0.15f))
 
+            val shareLabel = stringResource(R.string.share)
+            val addToQueueLabel = stringResource(R.string.add_to_queue)
+            val addToPlaylistLabel = stringResource(R.string.add_to_playlist)
+            val likeLabel = stringResource(R.string.like)
+            val visitAlbumLabel = stringResource(R.string.visit_album)
+            val visitArtistLabel = stringResource(R.string.visit_artist)
             val items = listOf(
-                Triple(Icons.AutoMirrored.Filled.QueueMusic, "Add to Queue") { vm.addToQueue(track.uri); showMenu = false },
-                Triple(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Playlist") { showMenu = false; vm.showPlaylistPickerForTrack(track.uri) },
-                Triple(Icons.Default.Favorite, "Like") { vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false },
-                Triple(Icons.Default.Album, "Visit Album") { showMenu = false; vm.openAlbumForTrack(track.uri) },
-                Triple(Icons.Default.Person, "Visit Artist") { showMenu = false; vm.openArtistForTrack(track.uri) },
-                Triple(Icons.Default.Share, "Share") {
+                Triple(Icons.AutoMirrored.Filled.QueueMusic, addToQueueLabel) {
+                    vm.addToQueue(track.uri); showMenu = false
+                },
+                Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addToPlaylistLabel) {
+                    showMenu = false; vm.showPlaylistPickerForTrack(track.uri)
+                },
+                Triple(Icons.Default.Favorite, likeLabel) {
+                    vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
+                },
+                Triple(Icons.Default.Album, visitAlbumLabel) {
+                    showMenu = false; vm.openAlbumForTrack(track.uri)
+                },
+                Triple(Icons.Default.Person, visitArtistLabel) {
+                    showMenu = false; vm.openArtistForTrack(track.uri)
+                },
+                Triple(Icons.Default.Share, shareLabel) {
                     showMenu = false
                     val id = track.uri.removePrefix("spotify:track:")
                     val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                         type = "text/plain"
                         putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/track/$id")
                     }
-                    context.startActivity(android.content.Intent.createChooser(intent, "Share"))
+                    context.startActivity(android.content.Intent.createChooser(intent, shareLabel))
                 }
             )
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
@@ -9,8 +9,10 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.util.UpdateInfo
 import ch.snepilatch.app.util.UpdateService
 import kotlinx.coroutines.launch
@@ -35,7 +37,7 @@ fun UpdateDialog(
                 tint = MaterialTheme.colorScheme.primary
             )
         },
-        title = { Text("Update Available") },
+        title = { Text(stringResource(R.string.update_available)) },
         text = {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -55,7 +57,7 @@ fun UpdateDialog(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Column {
-                            Text("Current", style = MaterialTheme.typography.labelSmall)
+                            Text(stringResource(R.string.current_version), style = MaterialTheme.typography.labelSmall)
                             Text(
                                 updateInfo.currentVersion,
                                 style = MaterialTheme.typography.bodyLarge,
@@ -64,7 +66,7 @@ fun UpdateDialog(
                         }
                         Text("→", style = MaterialTheme.typography.titleLarge)
                         Column(horizontalAlignment = Alignment.End) {
-                            Text("New", style = MaterialTheme.typography.labelSmall)
+                            Text(stringResource(R.string.new_version), style = MaterialTheme.typography.labelSmall)
                             Text(
                                 updateInfo.latestVersion,
                                 style = MaterialTheme.typography.bodyLarge,
@@ -114,7 +116,7 @@ fun UpdateDialog(
 
                 // Release notes
                 if (!isDownloading && updateInfo.releaseNotes.isNotBlank()) {
-                    Text("What's new:", style = MaterialTheme.typography.titleSmall)
+                    Text(stringResource(R.string.whats_new), style = MaterialTheme.typography.titleSmall)
                     Card(
                         colors = CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
@@ -142,11 +144,11 @@ fun UpdateDialog(
                             UpdateService.installApk(context, file)
                         } else {
                             isDownloading = false
-                            error = "Download failed. Please try again."
+                            error = context.getString(R.string.update_download_failed)
                         }
                     }
                 }) {
-                    Text("Update Now")
+                    Text(stringResource(R.string.update_now))
                 }
             }
         },
@@ -156,11 +158,11 @@ fun UpdateDialog(
                     UpdateService.dismissVersion(context, updateInfo.latestVersion)
                     onDismiss()
                 }) {
-                    Text("Later")
+                    Text(stringResource(R.string.later))
                 }
             } else {
                 TextButton(onClick = onDismiss) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -19,11 +19,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import ch.snepilatch.app.BuildConfig
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.ProfileInfoItem
 import ch.snepilatch.app.ui.components.UpdateDialog
 import ch.snepilatch.app.ui.theme.*
@@ -65,7 +67,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                 if (account.profileImageUrl != null) {
                     AsyncImage(
                         model = account.profileImageUrl,
-                        contentDescription = "Profile",
+                        contentDescription = stringResource(R.string.profile_image),
                         modifier = Modifier.size(120.dp).clip(CircleShape),
                         contentScale = ContentScale.Crop
                     )
@@ -77,7 +79,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
             Spacer(Modifier.height(16.dp))
 
             Text(
-                account.displayName.ifEmpty { account.username.ifEmpty { "Loading..." } },
+                account.displayName.ifEmpty { account.username.ifEmpty { stringResource(R.string.loading_dots) } },
                 color = SpotifyWhite,
                 fontSize = 24.sp,
                 fontWeight = FontWeight.Bold
@@ -85,7 +87,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
 
             Spacer(Modifier.height(6.dp))
             Text(
-                "${account.followers} Followers · ${account.playlistCount} Playlists",
+                stringResource(R.string.followers_playlists, account.followers, account.playlistCount),
                 color = SpotifyLightGray,
                 fontSize = 13.sp
             )
@@ -103,7 +105,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                     ) {
                         Icon(Icons.Default.Star, null, tint = animatedPrimary, modifier = Modifier.size(16.dp))
                         Spacer(Modifier.width(6.dp))
-                        Text("Premium", color = animatedPrimary, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+                        Text(stringResource(R.string.premium), color = animatedPrimary, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
                     }
                 }
             }
@@ -113,23 +115,38 @@ fun AccountScreen(vm: SpotifyViewModel) {
 
         // Account details
         Text(
-            "Account",
+            stringResource(R.string.account),
             color = SpotifyWhite,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
         )
 
-        ProfileInfoItem("Username", account.displayName.ifEmpty { account.username.ifEmpty { "..." } }, Icons.Default.Person)
-        ProfileInfoItem("User ID", account.username.ifEmpty { "..." }, Icons.Default.Badge)
-        ProfileInfoItem("Plan", if (account.isPremium) "Premium" else "Free", Icons.Default.CreditCard)
+        val dots = stringResource(R.string.placeholder_dots)
+        val premiumLabel = stringResource(R.string.premium)
+        val freeLabel = stringResource(R.string.plan_free)
+        ProfileInfoItem(
+            stringResource(R.string.username),
+            account.displayName.ifEmpty { account.username.ifEmpty { dots } },
+            Icons.Default.Person
+        )
+        ProfileInfoItem(
+            stringResource(R.string.user_id),
+            account.username.ifEmpty { dots },
+            Icons.Default.Badge
+        )
+        ProfileInfoItem(
+            stringResource(R.string.plan),
+            if (account.isPremium) premiumLabel else freeLabel,
+            Icons.Default.CreditCard
+        )
 
         Spacer(Modifier.height(24.dp))
 
         HorizontalDivider(color = SpotifyGray, modifier = Modifier.padding(horizontal = 16.dp))
 
         Text(
-            "Settings",
+            stringResource(R.string.settings),
             color = SpotifyWhite,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
@@ -141,16 +158,17 @@ fun AccountScreen(vm: SpotifyViewModel) {
         // Language picker
         val appLanguage by vm.appLanguage.collectAsState()
         var showLanguagePicker by remember { mutableStateOf(false) }
+        val systemDefaultLabel = stringResource(R.string.language_system_default)
         val languages = listOf(
-            "system" to "System Default",
+            "system" to systemDefaultLabel,
             "en" to "English",
             "de" to "Deutsch",
             "ru" to "Русский",
             "gsw" to "Schwiizerdütsch"
         )
-        val currentLanguageLabel = languages.find { it.first == appLanguage }?.second ?: "System Default"
+        val currentLanguageLabel = languages.find { it.first == appLanguage }?.second ?: systemDefaultLabel
         ListItem(
-            headlineContent = { Text("Language", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.language), color = SpotifyWhite) },
             supportingContent = { Text(currentLanguageLabel, color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Default.Language, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
@@ -160,7 +178,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         if (showLanguagePicker) {
             AlertDialog(
                 onDismissRequest = { showLanguagePicker = false },
-                title = { Text("Language", color = SpotifyWhite) },
+                title = { Text(stringResource(R.string.language), color = SpotifyWhite) },
                 text = {
                     Column {
                         languages.forEach { (code, label) ->
@@ -182,7 +200,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                     }
                 },
                 containerColor = SpotifyGray, confirmButton = {},
-                dismissButton = { TextButton(onClick = { showLanguagePicker = false }) { Text("Cancel", color = SpotifyLightGray) } }
+                dismissButton = { TextButton(onClick = { showLanguagePicker = false }) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) } }
             )
         }
 
@@ -191,11 +209,14 @@ fun AccountScreen(vm: SpotifyViewModel) {
         val isLossless = audioSource == "tidal" || audioSource == "qobuz"
 
         // Lossless toggle
+        val tidalLabel = stringResource(R.string.tidal)
+        val qobuzLabel = stringResource(R.string.qobuz)
+        val losslessOnText = stringResource(R.string.lossless_on, if (audioSource == "tidal") tidalLabel else qobuzLabel)
+        val losslessOffText = stringResource(R.string.lossless_off_spotify)
         ListItem(
-            headlineContent = { Text("Lossless Audio", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.lossless_audio), color = SpotifyWhite) },
             supportingContent = { Text(
-                if (isLossless) "FLAC via ${if (audioSource == "tidal") "Tidal" else "Qobuz"}"
-                else "Standard quality (Spotify)",
+                if (isLossless) losslessOnText else losslessOffText,
                 color = SpotifyLightGray
             ) },
             leadingContent = { Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray) },
@@ -223,10 +244,10 @@ fun AccountScreen(vm: SpotifyViewModel) {
         if (isLossless) {
             var showProviderPicker by remember { mutableStateOf(false) }
             ListItem(
-                headlineContent = { Text("Lossless Provider", color = SpotifyWhite) },
+                headlineContent = { Text(stringResource(R.string.lossless_provider), color = SpotifyWhite) },
                 supportingContent = { Text(
-                    if (audioSource == "tidal") "Tidal — FLAC up to 1411kbps"
-                    else "Qobuz — FLAC up to 9216kbps",
+                    if (audioSource == "tidal") stringResource(R.string.tidal_desc)
+                    else stringResource(R.string.qobuz_desc),
                     color = SpotifyLightGray
                 ) },
                 leadingContent = { Spacer(Modifier.width(24.dp)) },
@@ -237,12 +258,12 @@ fun AccountScreen(vm: SpotifyViewModel) {
             if (showProviderPicker) {
                 AlertDialog(
                     onDismissRequest = { showProviderPicker = false },
-                    title = { Text("Lossless Provider", color = SpotifyWhite) },
+                    title = { Text(stringResource(R.string.lossless_provider), color = SpotifyWhite) },
                     text = {
                         Column {
                             listOf(
-                                "tidal" to "Tidal" to "FLAC up to 1411kbps",
-                                "qobuz" to "Qobuz" to "FLAC up to 9216kbps"
+                                "tidal" to stringResource(R.string.tidal) to stringResource(R.string.tidal_short_desc),
+                                "qobuz" to stringResource(R.string.qobuz) to stringResource(R.string.qobuz_short_desc)
                             ).forEach { (pair, desc) ->
                                 val (value, label) = pair
                                 Row(
@@ -279,7 +300,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                     confirmButton = {},
                     dismissButton = {
                         TextButton(onClick = { showProviderPicker = false }) {
-                            Text("Cancel", color = SpotifyLightGray)
+                            Text(stringResource(R.string.cancel), color = SpotifyLightGray)
                         }
                     }
                 )
@@ -289,9 +310,9 @@ fun AccountScreen(vm: SpotifyViewModel) {
         // Canvas background
         val canvasOn by vm.canvasEnabled.collectAsState()
         ListItem(
-            headlineContent = { Text("Canvas Background", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.canvas_background), color = SpotifyWhite) },
             supportingContent = { Text(
-                if (canvasOn) "Looping video behind album art" else "Off",
+                if (canvasOn) stringResource(R.string.canvas_on) else stringResource(R.string.canvas_off),
                 color = SpotifyLightGray
             ) },
             leadingContent = { Icon(Icons.Default.PlayCircle, null, tint = SpotifyLightGray) },
@@ -313,9 +334,9 @@ fun AccountScreen(vm: SpotifyViewModel) {
         // Lyrics animation direction
         val lyricsAnim by vm.lyricsAnimDirection.collectAsState()
         var showLyricsPicker by remember { mutableStateOf(false) }
-        val lyricsLabel = if (lyricsAnim == "horizontal") "Left to Right" else "Top to Bottom"
+        val lyricsLabel = if (lyricsAnim == "horizontal") stringResource(R.string.lyrics_horizontal) else stringResource(R.string.lyrics_vertical)
         ListItem(
-            headlineContent = { Text("Lyrics Animation", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.lyrics_animation), color = SpotifyWhite) },
             supportingContent = { Text(lyricsLabel, color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
@@ -325,15 +346,15 @@ fun AccountScreen(vm: SpotifyViewModel) {
         if (showLyricsPicker) {
             AlertDialog(
                 onDismissRequest = { showLyricsPicker = false },
-                title = { Text("Lyrics Animation", color = SpotifyWhite) },
+                title = { Text(stringResource(R.string.lyrics_animation), color = SpotifyWhite) },
                 text = {
                     Column {
-                        Text("Choose how line-synced lyrics animate.",
+                        Text(stringResource(R.string.lyrics_anim_desc),
                             color = SpotifyLightGray, fontSize = 13.sp)
                         Spacer(Modifier.height(12.dp))
                         listOf(
-                            "vertical" to "Top to Bottom",
-                            "horizontal" to "Left to Right"
+                            "vertical" to stringResource(R.string.lyrics_vertical),
+                            "horizontal" to stringResource(R.string.lyrics_horizontal)
                         ).forEach { (value, label) ->
                             Row(
                                 Modifier
@@ -366,7 +387,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                 confirmButton = {},
                 dismissButton = {
                     TextButton(onClick = { showLyricsPicker = false }) {
-                        Text("Cancel", color = SpotifyLightGray)
+                        Text(stringResource(R.string.cancel), color = SpotifyLightGray)
                     }
                 }
             )
@@ -376,7 +397,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         val currentRegion by vm.contentRegion.collectAsState()
         var showRegionPicker by remember { mutableStateOf(false) }
         ListItem(
-            headlineContent = { Text("Content Region", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.content_region), color = SpotifyWhite) },
             supportingContent = { Text(currentRegion, color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Default.Language, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
@@ -386,21 +407,21 @@ fun AccountScreen(vm: SpotifyViewModel) {
         if (showRegionPicker) {
             AlertDialog(
                 onDismissRequest = { showRegionPicker = false },
-                title = { Text("Content Region", color = SpotifyWhite) },
+                title = { Text(stringResource(R.string.content_region), color = SpotifyWhite) },
                 text = {
                     Column {
                         listOf(
-                            "US" to "United States",
-                            "GB" to "United Kingdom",
-                            "DE" to "Germany",
-                            "CH" to "Switzerland",
-                            "FR" to "France",
-                            "JP" to "Japan",
-                            "KR" to "South Korea",
-                            "AU" to "Australia",
-                            "BR" to "Brazil",
-                            "CA" to "Canada",
-                            "SE" to "Sweden"
+                            "US" to stringResource(R.string.region_us),
+                            "GB" to stringResource(R.string.region_gb),
+                            "DE" to stringResource(R.string.region_de),
+                            "CH" to stringResource(R.string.region_ch),
+                            "FR" to stringResource(R.string.region_fr),
+                            "JP" to stringResource(R.string.region_jp),
+                            "KR" to stringResource(R.string.region_kr),
+                            "AU" to stringResource(R.string.region_au),
+                            "BR" to stringResource(R.string.region_br),
+                            "CA" to stringResource(R.string.region_ca),
+                            "SE" to stringResource(R.string.region_se)
                         ).forEach { (code, label) ->
                             Row(
                                 Modifier
@@ -436,22 +457,25 @@ fun AccountScreen(vm: SpotifyViewModel) {
                 confirmButton = {},
                 dismissButton = {
                     TextButton(onClick = { showRegionPicker = false }) {
-                        Text("Cancel", color = SpotifyLightGray)
+                        Text(stringResource(R.string.cancel), color = SpotifyLightGray)
                     }
                 }
             )
         }
 
         // Notification button options
+        val notifLikeLabel = stringResource(R.string.notif_like)
+        val notifShuffleLabel = stringResource(R.string.notif_shuffle)
+        val notifRepeatLabel = stringResource(R.string.notif_repeat)
         val buttonOptions = listOf(
-            "like" to "Like / Unlike" to "Toggle liked state",
-            "shuffle" to "Shuffle" to "Toggle shuffle mode",
-            "repeat" to "Repeat" to "Cycle repeat (off → all → one)"
+            "like" to notifLikeLabel to stringResource(R.string.notif_like_short_desc),
+            "shuffle" to notifShuffleLabel to stringResource(R.string.notif_shuffle_desc),
+            "repeat" to notifRepeatLabel to stringResource(R.string.notif_repeat_desc)
         )
         fun buttonLabel(type: String) = when (type) {
-            "like" -> "Like / Unlike"
-            "shuffle" -> "Shuffle"
-            "repeat" -> "Repeat"
+            "like" -> notifLikeLabel
+            "shuffle" -> notifShuffleLabel
+            "repeat" -> notifRepeatLabel
             else -> type
         }
 
@@ -459,7 +483,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         val leftButton by vm.notificationLeftButton.collectAsState()
         var showLeftPicker by remember { mutableStateOf(false) }
         ListItem(
-            headlineContent = { Text("Notification Left Button", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.notification_left_button), color = SpotifyWhite) },
             supportingContent = { Text(buttonLabel(leftButton), color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Default.Notifications, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
@@ -469,7 +493,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         if (showLeftPicker) {
             AlertDialog(
                 onDismissRequest = { showLeftPicker = false },
-                title = { Text("Left Button", color = SpotifyWhite) },
+                title = { Text(stringResource(R.string.notification_button_left), color = SpotifyWhite) },
                 text = {
                     Column {
                         buttonOptions.forEach { (pair, desc) ->
@@ -492,7 +516,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                     }
                 },
                 containerColor = SpotifyGray, confirmButton = {},
-                dismissButton = { TextButton(onClick = { showLeftPicker = false }) { Text("Cancel", color = SpotifyLightGray) } }
+                dismissButton = { TextButton(onClick = { showLeftPicker = false }) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) } }
             )
         }
 
@@ -500,7 +524,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         val rightButton by vm.notificationRightButton.collectAsState()
         var showRightPicker by remember { mutableStateOf(false) }
         ListItem(
-            headlineContent = { Text("Notification Right Button", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.notification_right_button), color = SpotifyWhite) },
             supportingContent = { Text(buttonLabel(rightButton), color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Default.Notifications, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
@@ -510,7 +534,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         if (showRightPicker) {
             AlertDialog(
                 onDismissRequest = { showRightPicker = false },
-                title = { Text("Right Button", color = SpotifyWhite) },
+                title = { Text(stringResource(R.string.notification_button_right), color = SpotifyWhite) },
                 text = {
                     Column {
                         buttonOptions.forEach { (pair, desc) ->
@@ -533,12 +557,12 @@ fun AccountScreen(vm: SpotifyViewModel) {
                     }
                 },
                 containerColor = SpotifyGray, confirmButton = {},
-                dismissButton = { TextButton(onClick = { showRightPicker = false }) { Text("Cancel", color = SpotifyLightGray) } }
+                dismissButton = { TextButton(onClick = { showRightPicker = false }) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) } }
             )
         }
 
         ListItem(
-            headlineContent = { Text("Connect to a device", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.connect_to_device), color = SpotifyWhite) },
             leadingContent = { Icon(Icons.Default.Devices, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
@@ -551,7 +575,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
 
         // About section
         Text(
-            "About",
+            stringResource(R.string.about),
             color = SpotifyWhite,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
@@ -559,7 +583,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         )
 
         ListItem(
-            headlineContent = { Text("App Version", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.app_version), color = SpotifyWhite) },
             supportingContent = { Text(BuildConfig.VERSION_NAME, color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Default.Info, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
@@ -573,12 +597,12 @@ fun AccountScreen(vm: SpotifyViewModel) {
         var upToDate by remember { mutableStateOf(false) }
 
         ListItem(
-            headlineContent = { Text("Check for Updates", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.check_for_updates), color = SpotifyWhite) },
             supportingContent = { Text(
                 when {
-                    isChecking -> "Checking..."
-                    upToDate -> "You're on the latest version"
-                    else -> "Tap to check for new versions"
+                    isChecking -> stringResource(R.string.checking)
+                    upToDate -> stringResource(R.string.up_to_date)
+                    else -> stringResource(R.string.tap_to_check)
                 },
                 color = if (upToDate) animatedPrimary else SpotifyLightGray
             ) },
@@ -623,8 +647,8 @@ fun AccountScreen(vm: SpotifyViewModel) {
         var showReleaseNotes by remember { mutableStateOf(false) }
 
         ListItem(
-            headlineContent = { Text("Release Notes", color = SpotifyWhite) },
-            supportingContent = { Text("View changelog", color = SpotifyLightGray) },
+            headlineContent = { Text(stringResource(R.string.release_notes), color = SpotifyWhite) },
+            supportingContent = { Text(stringResource(R.string.view_changelog), color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Default.Description, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
@@ -640,7 +664,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         HorizontalDivider(color = SpotifyGray, modifier = Modifier.padding(horizontal = 16.dp))
 
         Text(
-            "Special Thanks",
+            stringResource(R.string.special_thanks),
             color = SpotifyWhite,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
@@ -677,7 +701,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
 
         val context = androidx.compose.ui.platform.LocalContext.current
         ListItem(
-            headlineContent = { Text("Log out", color = Color(0xFFE57373)) },
+            headlineContent = { Text(stringResource(R.string.log_out), color = Color(0xFFE57373)) },
             leadingContent = { Icon(Icons.AutoMirrored.Filled.ExitToApp, null, tint = Color(0xFFE57373)) },
             trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -30,10 +30,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.components.TrackRow
 import ch.snepilatch.app.ui.theme.*
@@ -86,7 +88,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                         .clickable { vm.goBack() },
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                 }
                 Column(Modifier.align(Alignment.BottomStart).padding(16.dp)) {
                     Text(
@@ -114,12 +116,12 @@ fun DetailScreen(vm: SpotifyViewModel) {
                         val f = if (detail.followers!! >= 1_000_000) String.format("%.1fM", detail.followers!! / 1_000_000.0)
                             else if (detail.followers!! >= 1_000) String.format("%,d", detail.followers)
                             else detail.followers.toString()
-                        meta.add("$f likes")
+                        meta.add(stringResource(R.string.detail_likes, f))
                     }
                     if (detail.tracks.isNotEmpty()) {
                         val totalMin = detail.tracks.sumOf { it.durationMs } / 60000
-                        meta.add("${detail.totalCount.takeIf { it > 0 } ?: detail.tracks.size} songs")
-                        meta.add("${totalMin} min")
+                        meta.add(stringResource(R.string.detail_songs, detail.totalCount.takeIf { it > 0 } ?: detail.tracks.size))
+                        meta.add(stringResource(R.string.detail_minutes, totalMin.toInt()))
                     }
                     if (meta.isNotEmpty()) {
                         Text(meta.joinToString(" · "), color = SpotifyLightGray, fontSize = 13.sp)
@@ -162,7 +164,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                     else -> detail.monthlyListeners.toString()
                 }
                 Text(
-                    "$formatted monthly listeners",
+                    stringResource(R.string.detail_monthly_listeners, formatted),
                     color = SpotifyLightGray,
                     fontSize = 13.sp,
                     modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 0.dp, bottom = 0.dp)
@@ -201,7 +203,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                             modifier = Modifier.height(32.dp)
                         ) {
                             Text(
-                                if (saved) "Following" else "Follow",
+                                if (saved) stringResource(R.string.following) else stringResource(R.string.follow),
                                 fontSize = 12.sp,
                                 fontWeight = FontWeight.SemiBold
                             )
@@ -210,7 +212,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                         IconButton(onClick = { vm.toggleDetailSaved(detail.type, detailId) }) {
                             Icon(
                                 if (saved) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                "Save",
+                                stringResource(R.string.save),
                                 tint = if (saved) accentColor else SpotifyWhite,
                                 modifier = Modifier.size(28.dp)
                             )
@@ -222,7 +224,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                 // KotifyClient supports for the current detail type.
                 var showHeaderMenu by remember { mutableStateOf(false) }
                 IconButton(onClick = { showHeaderMenu = true }) {
-                    Icon(Icons.Default.MoreVert, "More", tint = SpotifyLightGray, modifier = Modifier.size(24.dp))
+                    Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(24.dp))
                 }
                 if (showHeaderMenu) {
                     DetailHeaderMenu(
@@ -238,7 +240,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                 // Shuffle
                 IconButton(onClick = { vm.toggleShuffle() }) {
                     Icon(
-                        Icons.Default.Shuffle, "Shuffle",
+                        Icons.Default.Shuffle, stringResource(R.string.shuffle),
                         tint = if (shuffling) accentColor else SpotifyWhite,
                         modifier = Modifier.size(24.dp)
                     )
@@ -264,7 +266,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                 ) {
                     Icon(
                         if (isPlayingThis) Icons.Default.Pause else Icons.Default.PlayArrow,
-                        "Play",
+                        stringResource(R.string.play),
                         tint = Color.Black,
                         modifier = Modifier.size(28.dp)
                     )
@@ -276,7 +278,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
         if (isArtist) {
             item {
                 Text(
-                    "Popular",
+                    stringResource(R.string.popular),
                     color = SpotifyWhite,
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold,
@@ -310,7 +312,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
             item {
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    "Popular Releases",
+                    stringResource(R.string.popular_releases),
                     color = SpotifyWhite,
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold,
@@ -355,7 +357,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
             item {
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    "Fans also like",
+                    stringResource(R.string.fans_also_like),
                     color = SpotifyWhite,
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold,
@@ -399,7 +401,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
             item {
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    "About",
+                    stringResource(R.string.about),
                     color = SpotifyWhite,
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold,
@@ -421,7 +423,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
             item {
                 Spacer(Modifier.height(16.dp))
                 Text(
-                    "More by ${detail.artistName ?: "Artist"}",
+                    stringResource(R.string.more_by, detail.artistName ?: stringResource(R.string.unknown)),
                     color = SpotifyWhite,
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold,
@@ -532,7 +534,7 @@ private fun ArtistTrackRow(
         // 3-dot menu
         var showMenu by remember { mutableStateOf(false) }
         IconButton(onClick = { showMenu = true }, modifier = Modifier.size(36.dp)) {
-            Icon(Icons.Default.MoreVert, "More", tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+            Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
         if (showMenu) {
             val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -566,19 +568,32 @@ private fun ArtistTrackRow(
                 HorizontalDivider(color = SpotifyLightGray.copy(alpha = 0.15f))
 
                 val menuContext = androidx.compose.ui.platform.LocalContext.current
+                val shareLabel = stringResource(R.string.share)
+                val addQueueLabel = stringResource(R.string.add_to_queue)
+                val addPlaylistLabel = stringResource(R.string.add_to_playlist)
+                val likeLabel = stringResource(R.string.like)
+                val visitAlbumLabel = stringResource(R.string.visit_album)
                 val items = listOf(
-                    Triple(Icons.AutoMirrored.Filled.QueueMusic, "Add to Queue") { vm.addToQueue(track.uri); showMenu = false },
-                    Triple(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Playlist") { showMenu = false; vm.showPlaylistPickerForTrack(track.uri) },
-                    Triple(Icons.Default.Favorite, "Like") { vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false },
-                    Triple(Icons.Default.Album, "Visit Album") { showMenu = false; vm.openAlbumForTrack(track.uri) },
-                    Triple(Icons.Default.Share, "Share") {
+                    Triple(Icons.AutoMirrored.Filled.QueueMusic, addQueueLabel) {
+                        vm.addToQueue(track.uri); showMenu = false
+                    },
+                    Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addPlaylistLabel) {
+                        showMenu = false; vm.showPlaylistPickerForTrack(track.uri)
+                    },
+                    Triple(Icons.Default.Favorite, likeLabel) {
+                        vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
+                    },
+                    Triple(Icons.Default.Album, visitAlbumLabel) {
+                        showMenu = false; vm.openAlbumForTrack(track.uri)
+                    },
+                    Triple(Icons.Default.Share, shareLabel) {
                         showMenu = false
                         val id = track.uri.removePrefix("spotify:track:")
                         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                             type = "text/plain"
                             putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/track/$id")
                         }
-                        menuContext.startActivity(android.content.Intent.createChooser(intent, "Share"))
+                        menuContext.startActivity(android.content.Intent.createChooser(intent, shareLabel))
                     }
                 )
 
@@ -641,7 +656,7 @@ private fun AlbumTrackRow(
         }
         var showMenu by remember { mutableStateOf(false) }
         IconButton(onClick = { showMenu = true }, modifier = Modifier.size(36.dp)) {
-            Icon(Icons.Default.MoreVert, "More", tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+            Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
         if (showMenu) {
             val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -673,19 +688,32 @@ private fun AlbumTrackRow(
                 Spacer(Modifier.height(8.dp))
                 HorizontalDivider(color = SpotifyLightGray.copy(alpha = 0.15f))
                 val menuContext = androidx.compose.ui.platform.LocalContext.current
+                val shareLabel = stringResource(R.string.share)
+                val addQueueLabel = stringResource(R.string.add_to_queue)
+                val addPlaylistLabel = stringResource(R.string.add_to_playlist)
+                val likeLabel = stringResource(R.string.like)
+                val visitArtistLabel = stringResource(R.string.visit_artist)
                 val items = listOf(
-                    Triple(Icons.AutoMirrored.Filled.QueueMusic, "Add to Queue") { vm.addToQueue(track.uri); showMenu = false },
-                    Triple(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Playlist") { showMenu = false; vm.showPlaylistPickerForTrack(track.uri) },
-                    Triple(Icons.Default.Favorite, "Like") { vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false },
-                    Triple(Icons.Default.Person, "Visit Artist") { showMenu = false; vm.openArtistForTrack(track.uri) },
-                    Triple(Icons.Default.Share, "Share") {
+                    Triple(Icons.AutoMirrored.Filled.QueueMusic, addQueueLabel) {
+                        vm.addToQueue(track.uri); showMenu = false
+                    },
+                    Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addPlaylistLabel) {
+                        showMenu = false; vm.showPlaylistPickerForTrack(track.uri)
+                    },
+                    Triple(Icons.Default.Favorite, likeLabel) {
+                        vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
+                    },
+                    Triple(Icons.Default.Person, visitArtistLabel) {
+                        showMenu = false; vm.openArtistForTrack(track.uri)
+                    },
+                    Triple(Icons.Default.Share, shareLabel) {
                         showMenu = false
                         val id = track.uri.removePrefix("spotify:track:")
                         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                             type = "text/plain"
                             putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/track/$id")
                         }
-                        menuContext.startActivity(android.content.Intent.createChooser(intent, "Share"))
+                        menuContext.startActivity(android.content.Intent.createChooser(intent, shareLabel))
                     }
                 )
                 items.forEach { (icon, label, onClick) ->
@@ -727,11 +755,12 @@ private fun DetailHeaderMenu(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val trackUris = detail.tracks.map { it.uri }
     val type = detail.type
-    val isAlbum = type == "album"
-    val isCollection = type == "collection"
-    val isArtist = type == "artist"
+    val isAlbum = type == "album"; val isCollection = type == "collection"; val isArtist = type == "artist"
     val hasTracks = trackUris.isNotEmpty()
-
+    val shareLabel = stringResource(R.string.share)
+    val addToQueueLabel = stringResource(R.string.add_to_queue)
+    val addToPlaylistLabel = stringResource(R.string.add_to_playlist)
+    val visitArtistLabel = stringResource(R.string.visit_artist)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
@@ -755,38 +784,36 @@ private fun DetailHeaderMenu(
         }
         Spacer(Modifier.height(8.dp))
         HorizontalDivider(color = SpotifyLightGray.copy(alpha = 0.15f))
-
         val items = buildList<Triple<androidx.compose.ui.graphics.vector.ImageVector, String, () -> Unit>> {
             if (!isCollection) {
                 val id = detail.uri.substringAfterLast(":")
-                add(Triple(Icons.Default.Share, "Share") {
+                add(Triple(Icons.Default.Share, shareLabel) {
                     onDismiss()
                     val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                         this.type = "text/plain"
                         putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/$type/$id")
                     }
-                    context.startActivity(android.content.Intent.createChooser(intent, "Share"))
+                    context.startActivity(android.content.Intent.createChooser(intent, shareLabel))
                 })
             }
             if (hasTracks && !isArtist) {
-                add(Triple(Icons.AutoMirrored.Filled.QueueMusic, "Add to Queue") {
+                add(Triple(Icons.AutoMirrored.Filled.QueueMusic, addToQueueLabel) {
                     onDismiss()
                     vm.addAllToQueue(trackUris)
                 })
-                add(Triple(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Playlist") {
+                add(Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addToPlaylistLabel) {
                     onDismiss()
                     vm.showPlaylistPickerForTracks(trackUris)
                 })
             }
             if (isAlbum && detail.artistUri != null) {
-                add(Triple(Icons.Default.Person, "Visit Artist") {
+                add(Triple(Icons.Default.Person, visitArtistLabel) {
                     onDismiss()
                     val artistId = detail.artistUri.substringAfterLast(":")
                     vm.openArtist(artistId)
                 })
             }
         }
-
         items.forEach { (icon, label, onClick) ->
             Row(
                 Modifier

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -1,5 +1,6 @@
 package ch.snepilatch.app.ui.screens
 
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyWhite
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
@@ -37,6 +38,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -71,7 +73,7 @@ fun HomeScreen(vm: SpotifyViewModel) {
     ) {
         item {
             Text(
-                homeData?.greeting ?: "Good evening",
+                homeData?.greeting ?: stringResource(R.string.greeting_fallback),
                 color = SpotifyWhite,
                 fontSize = 26.sp,
                 fontWeight = FontWeight.Bold,

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
@@ -60,10 +60,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.data.LibraryItem
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.SpotifyBlack
@@ -118,13 +120,13 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                 .padding(horizontal = 12.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text("Your Library", color = SpotifyWhite, fontSize = 24.sp, fontWeight = FontWeight.Bold,
+            Text(stringResource(R.string.library_title), color = SpotifyWhite, fontSize = 24.sp, fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(1f))
             IconButton(onClick = { searchActive = !searchActive; if (!searchActive) searchQuery = "" }) {
-                Icon(Icons.Default.Search, "Search", tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                Icon(Icons.Default.Search, stringResource(R.string.search), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
             }
             IconButton(onClick = { showCreateDialog = true }) {
-                Icon(Icons.Default.Add, "Create", tint = SpotifyWhite, modifier = Modifier.size(26.dp))
+                Icon(Icons.Default.Add, stringResource(R.string.library_create), tint = SpotifyWhite, modifier = Modifier.size(26.dp))
             }
         }
 
@@ -137,12 +139,17 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                     .fillMaxWidth()
                     .padding(horizontal = 12.dp, vertical = 4.dp)
                     .clip(RoundedCornerShape(8.dp)),
-                placeholder = { Text("Search in Your Library", color = SpotifyLightGray.copy(alpha = 0.7f)) },
+                placeholder = {
+                    Text(
+                        stringResource(R.string.library_search_placeholder),
+                        color = SpotifyLightGray.copy(alpha = 0.7f)
+                    )
+                },
                 leadingIcon = { Icon(Icons.Default.Search, null, tint = SpotifyLightGray) },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) {
                         IconButton(onClick = { searchQuery = "" }) {
-                            Icon(Icons.Default.Close, "Clear", tint = SpotifyLightGray)
+                            Icon(Icons.Default.Close, stringResource(R.string.clear), tint = SpotifyLightGray)
                         }
                     }
                 },
@@ -160,19 +167,23 @@ fun LibraryScreen(vm: SpotifyViewModel) {
         }
 
         // Filter chips row
+        val filters = listOf(
+            "Playlists" to stringResource(R.string.library_filter_playlists),
+            "Artists" to stringResource(R.string.library_filter_artists),
+            "Albums" to stringResource(R.string.library_filter_albums)
+        )
         LazyRow(
             contentPadding = PaddingValues(horizontal = 12.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.padding(vertical = 8.dp)
         ) {
-            val filters = listOf("Playlists", "Artists", "Albums")
             items(filters.size) { i ->
                 FilterChip(
-                    selected = selectedFilter == filters[i],
+                    selected = selectedFilter == filters[i].first,
                     onClick = {
-                        selectedFilter = if (selectedFilter == filters[i]) null else filters[i]
+                        selectedFilter = if (selectedFilter == filters[i].first) null else filters[i].first
                     },
-                    label = { Text(filters[i], fontSize = 13.sp) },
+                    label = { Text(filters[i].second, fontSize = 13.sp) },
                     colors = FilterChipDefaults.filterChipColors(
                         selectedContainerColor = SpotifyWhite,
                         selectedLabelColor = SpotifyBlack,
@@ -197,12 +208,12 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                     Modifier.clickable { showSortMenu = true }.padding(vertical = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(Icons.Default.SwapVert, "Sort", tint = SpotifyLightGray, modifier = Modifier.size(16.dp))
+                    Icon(Icons.Default.SwapVert, stringResource(R.string.library_sort), tint = SpotifyLightGray, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))
                     val sortLabel = when (sortMode) {
-                        "alpha" -> "Alphabetical"
-                        "type" -> "By Type"
-                        else -> "Recent"
+                        "alpha" -> stringResource(R.string.library_sort_alpha)
+                        "type" -> stringResource(R.string.library_sort_by_type)
+                        else -> stringResource(R.string.library_sort_recent)
                     }
                     Text(sortLabel, color = SpotifyLightGray, fontSize = 13.sp)
                 }
@@ -211,7 +222,11 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                     onDismissRequest = { showSortMenu = false },
                     containerColor = SpotifyGray
                 ) {
-                    listOf("recent" to "Recent", "alpha" to "Alphabetical", "type" to "By Type").forEach { (value, label) ->
+                    listOf(
+                        "recent" to stringResource(R.string.library_sort_recent),
+                        "alpha" to stringResource(R.string.library_sort_alpha),
+                        "type" to stringResource(R.string.library_sort_by_type)
+                    ).forEach { (value, label) ->
                         DropdownMenuItem(
                             text = { Text(label, color = if (sortMode == value) SpotifyWhite else SpotifyLightGray) },
                             onClick = { sortMode = value; prefs.edit().putString("library_sort", value).apply(); showSortMenu = false }
@@ -225,7 +240,7 @@ fun LibraryScreen(vm: SpotifyViewModel) {
             ) {
                 Icon(
                     if (gridView) Icons.AutoMirrored.Filled.List else Icons.Default.GridView,
-                    "Toggle view",
+                    stringResource(R.string.library_toggle_view),
                     tint = SpotifyLightGray,
                     modifier = Modifier.size(20.dp)
                 )
@@ -391,12 +406,12 @@ fun CreatePlaylistDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
         containerColor = SpotifyElevated,
-        title = { Text("Create Playlist", color = SpotifyWhite, fontWeight = FontWeight.Bold) },
+        title = { Text(stringResource(R.string.library_create_playlist), color = SpotifyWhite, fontWeight = FontWeight.Bold) },
         text = {
             TextField(
                 value = name,
                 onValueChange = { name = it },
-                placeholder = { Text("Playlist name", color = SpotifyLightGray) },
+                placeholder = { Text(stringResource(R.string.library_playlist_name_hint), color = SpotifyLightGray) },
                 colors = TextFieldDefaults.colors(
                     focusedTextColor = SpotifyWhite,
                     unfocusedTextColor = SpotifyWhite,
@@ -412,11 +427,11 @@ fun CreatePlaylistDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
         },
         confirmButton = {
             TextButton(onClick = { if (name.isNotBlank()) onCreate(name) }) {
-                Text("Create", color = SpotifyWhite, fontWeight = FontWeight.Bold)
+                Text(stringResource(R.string.library_create_button), color = SpotifyWhite, fontWeight = FontWeight.Bold)
             }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Cancel", color = SpotifyLightGray) }
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) }
         }
     )
 }
@@ -425,20 +440,20 @@ fun CreatePlaylistDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
 private fun LibraryRemoveDialog(item: LibraryItem, vm: SpotifyViewModel, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("Remove from Library", color = SpotifyWhite) },
-        text = { Text("Remove \"${item.name}\" from your library?", color = SpotifyLightGray) },
+        title = { Text(stringResource(R.string.library_remove_title), color = SpotifyWhite) },
+        text = { Text(stringResource(R.string.library_remove_message, item.name), color = SpotifyLightGray) },
         containerColor = SpotifyGray,
         confirmButton = {
             TextButton(onClick = {
                 vm.removeFromLibrary(item)
                 onDismiss()
             }) {
-                Text("Remove", color = Color.Red)
+                Text(stringResource(R.string.library_remove_button), color = Color.Red)
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancel", color = SpotifyLightGray)
+                Text(stringResource(R.string.cancel), color = SpotifyLightGray)
             }
         }
     )

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
@@ -1,5 +1,6 @@
 package ch.snepilatch.app.ui.screens
 
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyWhite
 import android.webkit.CookieManager
 import android.webkit.WebView
@@ -20,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -38,10 +40,10 @@ fun SpotifyLoginScreen(vm: SpotifyViewModel) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = { vm.needsLogin.value = false }) {
-                Icon(Icons.Default.Close, "Close", tint = SpotifyWhite)
+                Icon(Icons.Default.Close, stringResource(R.string.close), tint = SpotifyWhite)
             }
             Spacer(Modifier.width(8.dp))
-            Text("Login to Spotify", color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.Bold)
+            Text(stringResource(R.string.login_title), color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.Bold)
         }
 
         AndroidView(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
@@ -29,12 +29,14 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
@@ -157,7 +159,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                             ) {
                                 Icon(
                                     when (playback.repeatMode) { "track" -> Icons.Default.RepeatOne; else -> Icons.Default.Repeat },
-                                    "Repeat",
+                                    stringResource(R.string.repeat),
                                     tint = if (playback.repeatMode != "off") animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -166,7 +168,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 Modifier.size(36.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.skipPrevious() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.SkipPrevious, "Previous", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                Icon(Icons.Default.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                             }
                             Box(
                                 Modifier
@@ -181,7 +183,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 } else {
                                     Icon(
                                         if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
-                                        "Play/Pause", tint = SpotifyWhite, modifier = Modifier.size(26.dp)
+                                        stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(26.dp)
                                     )
                                 }
                             }
@@ -189,7 +191,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 Modifier.size(36.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.skipNext() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.SkipNext, "Next", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                             }
                             Box(
                                 Modifier.size(36.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable {
@@ -200,7 +202,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                             ) {
                                 Icon(
                                     if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                    "Like",
+                                    stringResource(R.string.like),
                                     tint = if (isLiked) animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(18.dp)
                                 )
@@ -227,7 +229,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                         Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray.copy(alpha = 0.5f), modifier = Modifier.size(48.dp))
                                         Spacer(Modifier.height(12.dp))
-                                        Text("No lyrics available", color = SpotifyLightGray, fontSize = 16.sp)
+                                        Text(stringResource(R.string.lyrics_not_available), color = SpotifyLightGray, fontSize = 16.sp)
                                     }
                                 }
                             }
@@ -268,7 +270,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 .clickable { vm.goBack() },
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(Icons.Default.KeyboardArrowDown, "Close", tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                            Icon(Icons.Default.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
                         }
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text(track?.name ?: "", color = SpotifyWhite, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, maxLines = 1)
@@ -288,7 +290,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                     Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray.copy(alpha = 0.5f), modifier = Modifier.size(48.dp))
                                     Spacer(Modifier.height(12.dp))
-                                    Text("No lyrics available", color = SpotifyLightGray, fontSize = 16.sp)
+                                    Text(stringResource(R.string.lyrics_not_available), color = SpotifyLightGray, fontSize = 16.sp)
                                 }
                             }
                         }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -26,10 +26,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import coil.compose.AsyncImage
 import android.graphics.SurfaceTexture
 import android.net.Uri
@@ -58,6 +60,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
     var showMore by remember { mutableStateOf(false) }
     var showPlaylistPicker by remember { mutableStateOf(false) }
     val shareContext = LocalContext.current
+    val shareTrackLabel = stringResource(R.string.share_track_chooser)
     val canvasVideoUrl by vm.canvasUrl.collectAsState()
     val canvasOn by vm.canvasEnabled.collectAsState()
     val hasCanvas = canvasOn && canvasVideoUrl != null
@@ -254,12 +257,12 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.goBack() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.KeyboardArrowDown, "Close", tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                                Icon(Icons.Default.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
                             }
                             val ctx by vm.playingContext.collectAsState()
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 Text(
-                                    ctx?.let { "Playing from ${it.type}" } ?: "Now playing",
+                                    ctx?.let { stringResource(R.string.now_playing_playing_from, it.type) } ?: stringResource(R.string.now_playing),
                                     color = SpotifyLightGray,
                                     fontSize = 10.sp
                                 )
@@ -295,7 +298,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                         ) {
                             Column(Modifier.weight(1f).padding(end = 8.dp)) {
                                 Text(
-                                    track?.name ?: "Not Playing",
+                                    track?.name ?: stringResource(R.string.now_playing_not_playing),
                                     color = SpotifyWhite,
                                     fontSize = 18.sp,
                                     fontWeight = FontWeight.Bold,
@@ -335,7 +338,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             ) {
                                 Icon(
                                     if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                    "Like",
+                                    stringResource(R.string.like),
                                     tint = if (isLiked) animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(24.dp)
                                 )
@@ -387,7 +390,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 Modifier.size(44.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.toggleShuffle() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.Shuffle, "Shuffle",
+                                Icon(Icons.Default.Shuffle, stringResource(R.string.shuffle),
                                     tint = if (playback.isShuffling) animatedPrimary else SpotifyWhite,
                                     modifier = Modifier.size(20.dp))
                             }
@@ -395,7 +398,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 Modifier.size(48.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.skipPrevious() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.SkipPrevious, "Previous", tint = SpotifyWhite, modifier = Modifier.size(28.dp))
+                                Icon(Icons.Default.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
                             }
                             Box(
                                 Modifier
@@ -410,7 +413,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 } else {
                                     Icon(
                                         if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
-                                        "Play/Pause", tint = SpotifyWhite, modifier = Modifier.size(32.dp)
+                                        stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(32.dp)
                                     )
                                 }
                             }
@@ -424,7 +427,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 if (nextLoading) {
                                     CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 2.dp, modifier = Modifier.size(20.dp))
                                 } else {
-                                    Icon(Icons.Default.SkipNext, "Next", tint = SpotifyWhite, modifier = Modifier.size(28.dp))
+                                    Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
                                 }
                             }
                             Box(
@@ -433,7 +436,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             ) {
                                 Icon(
                                     when (playback.repeatMode) { "track" -> Icons.Default.RepeatOne; else -> Icons.Default.Repeat },
-                                    "Repeat",
+                                    stringResource(R.string.repeat),
                                     tint = if (playback.repeatMode != "off") animatedPrimary else SpotifyWhite,
                                     modifier = Modifier.size(20.dp)
                                 )
@@ -482,7 +485,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                         .clickable { vm.loadDevices(); vm.showDevices.value = true },
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    Icon(audioIcon, "Audio Output", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                    Icon(audioIcon, stringResource(R.string.audio_output), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                                 }
                                 Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                                     audioOutput?.let { InfoPill(audioIcon, it) }
@@ -504,12 +507,12 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                                     type = "text/plain"
                                                     putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/track/$id")
                                                 }
-                                                shareContext.startActivity(android.content.Intent.createChooser(intent, "Share track"))
+                                                shareContext.startActivity(android.content.Intent.createChooser(intent, shareTrackLabel))
                                             }
                                         },
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    Icon(Icons.Default.Share, "Share", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                    Icon(Icons.Default.Share, stringResource(R.string.share), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                                 }
                                 Box(
                                     Modifier
@@ -519,7 +522,12 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                         .clickable { vm.openQueue() },
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    Icon(Icons.AutoMirrored.Filled.QueueMusic, "Queue", tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.QueueMusic,
+                                        stringResource(R.string.queue),
+                                        tint = SpotifyWhite,
+                                        modifier = Modifier.size(20.dp)
+                                    )
                                 }
                             }
                         }
@@ -563,7 +571,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.goBack() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.KeyboardArrowDown, "Close", tint = SpotifyWhite, modifier = Modifier.size(28.dp))
+                                Icon(Icons.Default.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
                             }
                             val ctx by vm.playingContext.collectAsState()
                             Column(
@@ -571,7 +579,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 modifier = Modifier.clickable(enabled = ctx?.uri != null) { vm.navigateToContext() }
                             ) {
                                 Text(
-                                    ctx?.let { "Playing from ${it.type}" } ?: "Now playing",
+                                    ctx?.let { stringResource(R.string.now_playing_playing_from, it.type) } ?: stringResource(R.string.now_playing),
                                     color = secondaryText,
                                     fontSize = 11.sp
                                 )
@@ -604,7 +612,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.Tune, "Equalizer", tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(Icons.Default.Tune, stringResource(R.string.equalizer), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
                             }
                     }
 
@@ -634,7 +642,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                     ) {
                         Column(Modifier.weight(1f).padding(end = 12.dp)) {
                             MarqueeText(
-                                text = track?.name ?: "Not Playing",
+                                text = track?.name ?: stringResource(R.string.now_playing_not_playing),
                                 color = SpotifyWhite,
                                 fontSize = 22.sp,
                                 fontWeight = FontWeight.Bold
@@ -674,7 +682,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             ) {
                                 Icon(
                                     if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                    "Like",
+                                    stringResource(R.string.like),
                                     tint = if (isLiked) animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(28.dp)
                                 )
@@ -741,7 +749,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 .clickable { vm.toggleShuffle() },
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(Icons.Default.Shuffle, "Shuffle",
+                            Icon(Icons.Default.Shuffle, stringResource(R.string.shuffle),
                                 tint = if (playback.isShuffling) animatedPrimary else SpotifyWhite,
                                 modifier = Modifier.size(22.dp))
                         }
@@ -754,7 +762,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 .clickable { vm.skipPrevious() },
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(Icons.Default.SkipPrevious, "Previous", tint = SpotifyWhite, modifier = Modifier.size(32.dp))
+                            Icon(Icons.Default.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(32.dp))
                         }
                         // Play/Pause — large prominent button
                         Box(
@@ -777,7 +785,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             } else {
                                 Icon(
                                     if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
-                                    "Play/Pause", tint = SpotifyWhite, modifier = Modifier.size(38.dp)
+                                    stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(38.dp)
                                 )
                             }
                         }
@@ -796,7 +804,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             if (nextLoading) {
                                 CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 2.dp, modifier = Modifier.size(22.dp))
                             } else {
-                                Icon(Icons.Default.SkipNext, "Next", tint = SpotifyWhite, modifier = Modifier.size(32.dp))
+                                Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(32.dp))
                             }
                         }
                         // Repeat
@@ -810,7 +818,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                         ) {
                             Icon(
                                 when (playback.repeatMode) { "track" -> Icons.Default.RepeatOne; else -> Icons.Default.Repeat },
-                                "Repeat",
+                                stringResource(R.string.repeat),
                                 tint = if (playback.repeatMode != "off") animatedPrimary else SpotifyWhite,
                                 modifier = Modifier.size(22.dp)
                             )
@@ -858,7 +866,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.loadDevices(); vm.showDevices.value = true },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(audioIcon, "Audio Output", tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(audioIcon, stringResource(R.string.audio_output), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
                             }
                             Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
                                 audioOutput?.let { InfoPill(audioIcon, it) }
@@ -880,12 +888,12 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                                 type = "text/plain"
                                                 putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/track/$id")
                                             }
-                                            shareContext.startActivity(android.content.Intent.createChooser(intent, "Share track"))
+                                            shareContext.startActivity(android.content.Intent.createChooser(intent, shareTrackLabel))
                                         }
                                     },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.Share, "Share", tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(Icons.Default.Share, stringResource(R.string.share), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
                             }
                             Box(
                                 Modifier
@@ -895,7 +903,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.openQueue() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.AutoMirrored.Filled.QueueMusic, "Queue", tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(Icons.AutoMirrored.Filled.QueueMusic, stringResource(R.string.queue), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
                             }
                         }
                     }
@@ -912,7 +920,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
         val playlists = libraryItems.filter { it.type == "playlist" }
         AlertDialog(
             onDismissRequest = { showPlaylistPicker = false },
-            title = { Text("Add to Playlist", color = SpotifyWhite) },
+            title = { Text(stringResource(R.string.add_to_playlist), color = SpotifyWhite) },
             containerColor = SpotifyGray,
             text = {
                 LazyColumn(Modifier.fillMaxWidth()) {
@@ -949,7 +957,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
             confirmButton = {},
             dismissButton = {
                 TextButton(onClick = { showPlaylistPicker = false }) {
-                    Text("Cancel", color = SpotifyLightGray)
+                    Text(stringResource(R.string.cancel), color = SpotifyLightGray)
                 }
             }
         )
@@ -1011,7 +1019,7 @@ private fun NowPlayingMenu(
             .clickable { onShowMore(true) },
         contentAlignment = Alignment.Center
     ) {
-        Icon(Icons.Default.MoreVert, "More", tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+        Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
     }
 
     if (showMore) {
@@ -1051,21 +1059,41 @@ private fun NowPlayingMenu(
                 HorizontalDivider(color = SpotifyLightGray.copy(alpha = 0.15f))
             }
 
+            val shareTrackLabel = stringResource(R.string.share_track_chooser)
+            val lyricsLabel = stringResource(R.string.lyrics)
+            val addQueueLabel = stringResource(R.string.add_to_queue)
+            val addPlaylistLabel = stringResource(R.string.add_to_playlist)
+            val viewQueueLabel = stringResource(R.string.view_queue)
+            val visitAlbumLabel = stringResource(R.string.visit_album)
+            val devicesLabel = stringResource(R.string.devices)
+            val shareLabel = stringResource(R.string.share)
             val items = listOf(
-                Triple(Icons.Default.MusicNote, "Lyrics") { onShowMore(false); vm.openLyrics() },
-                Triple(Icons.AutoMirrored.Filled.QueueMusic, "Add to Queue") { track?.uri?.let { vm.addToQueue(it) }; onShowMore(false) },
-                Triple(Icons.AutoMirrored.Filled.PlaylistAdd, "Add to Playlist") { onShowMore(false); onShowPlaylistPicker() },
-                Triple(Icons.AutoMirrored.Filled.QueueMusic, "View Queue") { vm.openQueue(); onShowMore(false) },
-                Triple(Icons.Default.Album, "Visit Album") { onShowMore(false); vm.openAlbumFromCurrentTrack() },
-                Triple(Icons.Default.Devices, "Devices") { onShowMore(false); vm.loadDevices(); vm.showDevices.value = true },
-                Triple(Icons.Default.Share, "Share") {
+                Triple(Icons.Default.MusicNote, lyricsLabel) {
+                    onShowMore(false); vm.openLyrics()
+                },
+                Triple(Icons.AutoMirrored.Filled.QueueMusic, addQueueLabel) {
+                    track?.uri?.let { vm.addToQueue(it) }; onShowMore(false)
+                },
+                Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addPlaylistLabel) {
+                    onShowMore(false); onShowPlaylistPicker()
+                },
+                Triple(Icons.AutoMirrored.Filled.QueueMusic, viewQueueLabel) {
+                    vm.openQueue(); onShowMore(false)
+                },
+                Triple(Icons.Default.Album, visitAlbumLabel) {
+                    onShowMore(false); vm.openAlbumFromCurrentTrack()
+                },
+                Triple(Icons.Default.Devices, devicesLabel) {
+                    onShowMore(false); vm.loadDevices(); vm.showDevices.value = true
+                },
+                Triple(Icons.Default.Share, shareLabel) {
                     onShowMore(false)
                     track?.uri?.removePrefix("spotify:track:")?.let { id ->
                         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                             type = "text/plain"
                             putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/track/$id")
                         }
-                        shareContext.startActivity(android.content.Intent.createChooser(intent, "Share track"))
+                        shareContext.startActivity(android.content.Intent.createChooser(intent, shareTrackLabel))
                     }
                 }
             )

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
@@ -13,10 +13,12 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
@@ -32,15 +34,15 @@ fun QueueScreen(vm: SpotifyViewModel) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = { vm.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back", tint = SpotifyWhite)
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back), tint = SpotifyWhite)
             }
-            Text("Queue", color = SpotifyWhite, fontSize = 22.sp, fontWeight = FontWeight.Bold)
+            Text(stringResource(R.string.queue), color = SpotifyWhite, fontSize = 22.sp, fontWeight = FontWeight.Bold)
         }
 
         // Now playing
         playback.track?.let { track ->
             Text(
-                "Now playing",
+                stringResource(R.string.now_playing),
                 color = SpotifyLightGray,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Bold,
@@ -64,7 +66,7 @@ fun QueueScreen(vm: SpotifyViewModel) {
         // Next up
         if (queue.isNotEmpty()) {
             Text(
-                "Next up",
+                stringResource(R.string.queue_next_up),
                 color = SpotifyLightGray,
                 fontSize = 14.sp,
                 fontWeight = FontWeight.Bold,
@@ -92,7 +94,7 @@ fun QueueScreen(vm: SpotifyViewModel) {
 
         if (queue.isEmpty() && playback.track == null) {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                Text("Queue is empty", color = SpotifyLightGray, fontSize = 16.sp)
+                Text(stringResource(R.string.queue_empty), color = SpotifyLightGray, fontSize = 16.sp)
             }
         }
     }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
@@ -12,9 +12,12 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -34,19 +37,21 @@ data class ReleaseNote(
 @Composable
 fun ReleaseNotesScreen(onBack: () -> Unit) {
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     var releases by remember { mutableStateOf<List<ReleaseNote>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
     var error by remember { mutableStateOf<String?>(null) }
+    val genericError = stringResource(R.string.release_load_generic_error)
 
     fun load() {
         isLoading = true
         error = null
         scope.launch {
             try {
-                val notes = withContext(Dispatchers.IO) { fetchReleaseNotes() }
+                val notes = withContext(Dispatchers.IO) { fetchReleaseNotes(context) }
                 releases = notes
             } catch (e: Exception) {
-                error = e.message ?: "Failed to load"
+                error = e.message ?: genericError
             }
             isLoading = false
         }
@@ -58,7 +63,7 @@ fun ReleaseNotesScreen(onBack: () -> Unit) {
         containerColor = SpotifyBlack,
         topBar = {
             TopAppBar(
-                title = { Text("Release Notes", color = SpotifyWhite) },
+                title = { Text(stringResource(R.string.release_notes), color = SpotifyWhite) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = SpotifyWhite)
@@ -79,14 +84,14 @@ fun ReleaseNotesScreen(onBack: () -> Unit) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Icon(Icons.Default.ErrorOutline, null, tint = SpotifyLightGray, modifier = Modifier.size(64.dp))
                         Spacer(Modifier.height(16.dp))
-                        Text("Failed to load release notes", color = SpotifyWhite, fontSize = 18.sp)
+                        Text(stringResource(R.string.release_load_failed), color = SpotifyWhite, fontSize = 18.sp)
                         Spacer(Modifier.height(8.dp))
                         Text(error!!, color = SpotifyLightGray, fontSize = 13.sp)
                         Spacer(Modifier.height(24.dp))
                         Button(onClick = { load() }) {
                             Icon(Icons.Default.Refresh, null)
                             Spacer(Modifier.width(8.dp))
-                            Text("Retry")
+                            Text(stringResource(R.string.retry))
                         }
                     }
                 }
@@ -139,7 +144,7 @@ private fun ReleaseNoteCard(note: ReleaseNote, isLatest: Boolean) {
                         shape = RoundedCornerShape(12.dp)
                     ) {
                         Text(
-                            "LATEST",
+                            stringResource(R.string.release_latest_badge),
                             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
                             fontSize = 11.sp,
                             fontWeight = FontWeight.Bold,
@@ -221,13 +226,14 @@ private fun String.cleanMarkdown(): String {
 @Composable
 fun ReleaseNotesDialog(onDismiss: () -> Unit) {
     val scope = rememberCoroutineScope()
+    val context = LocalContext.current
     var releases by remember { mutableStateOf<List<ReleaseNote>>(emptyList()) }
     var isLoading by remember { mutableStateOf(true) }
     var error by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(Unit) {
         try {
-            releases = withContext(Dispatchers.IO) { fetchReleaseNotes() }
+            releases = withContext(Dispatchers.IO) { fetchReleaseNotes(context) }
         } catch (e: Exception) {
             error = e.message
         }
@@ -237,14 +243,14 @@ fun ReleaseNotesDialog(onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
         containerColor = SpotifyDarkGray,
-        title = { Text("Release Notes", color = SpotifyWhite) },
+        title = { Text(stringResource(R.string.release_notes), color = SpotifyWhite) },
         text = {
             Box(Modifier.heightIn(max = 500.dp)) {
                 when {
                     isLoading -> Box(Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
                         CircularProgressIndicator(color = SpotifyLightGray)
                     }
-                    error != null -> Text("Failed to load: $error", color = SpotifyLightGray)
+                    error != null -> Text(stringResource(R.string.release_load_failed_short, error ?: ""), color = SpotifyLightGray)
                     else -> LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                         itemsIndexed(releases) { index, note ->
                             ReleaseNoteCard(note, isLatest = index == 0)
@@ -255,13 +261,13 @@ fun ReleaseNotesDialog(onDismiss: () -> Unit) {
         },
         confirmButton = {
             TextButton(onClick = onDismiss) {
-                Text("Close", color = SpotifyLightGray)
+                Text(stringResource(R.string.close), color = SpotifyLightGray)
             }
         }
     )
 }
 
-private suspend fun fetchReleaseNotes(): List<ReleaseNote> {
+private suspend fun fetchReleaseNotes(context: android.content.Context): List<ReleaseNote> {
     val client = OkHttpClient()
     val request = Request.Builder()
         .url("https://api.github.com/repos/PianoNic/Snepilatch/releases")
@@ -278,7 +284,7 @@ private suspend fun fetchReleaseNotes(): List<ReleaseNote> {
         val date = if (published.length >= 10) published.substring(0, 10) else published
         notes.add(ReleaseNote(
             version = tag,
-            title = obj.optString("name", "Release $tag"),
+            title = obj.optString("name", context.getString(R.string.release_fallback_title, tag)),
             body = obj.optString("body", ""),
             date = date
         ))

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
@@ -1,5 +1,6 @@
 package ch.snepilatch.app.ui.screens
 
+import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -48,13 +49,16 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
@@ -105,7 +109,7 @@ fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel()) 
 
     Column(Modifier.fillMaxSize().padding(top = 12.dp)) {
         Text(
-            "Search",
+            stringResource(R.string.search_title),
             color = SpotifyWhite,
             fontSize = 26.sp,
             fontWeight = FontWeight.Bold,
@@ -120,12 +124,12 @@ fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel()) 
                 .padding(horizontal = 16.dp)
                 .clip(RoundedCornerShape(8.dp))
                 .focusRequester(focusRequester),
-            placeholder = { Text("Search", color = SpotifyLightGray.copy(alpha = 0.7f)) },
+            placeholder = { Text(stringResource(R.string.search_field_placeholder), color = SpotifyLightGray.copy(alpha = 0.7f)) },
             leadingIcon = { Icon(Icons.Default.Search, null, tint = SpotifyBlack) },
             trailingIcon = {
                 if (query.isNotEmpty()) {
                     IconButton(onClick = { searchVm.updateQuery("") }) {
-                        Icon(Icons.Default.Close, "Clear", tint = SpotifyBlack)
+                        Icon(Icons.Default.Close, stringResource(R.string.search_clear), tint = SpotifyBlack)
                     }
                 }
             },
@@ -188,7 +192,7 @@ fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel()) 
 private fun BrowseCategoriesGrid(onCategoryTap: (String) -> Unit) {
     Column {
         Text(
-            "Browse All",
+            stringResource(R.string.search_browse_all),
             color = SpotifyWhite,
             fontSize = 16.sp,
             fontWeight = FontWeight.Bold,
@@ -273,19 +277,19 @@ private data class UnifiedResult(
     val onClick: () -> Unit
 )
 
-private fun SearchTrack.toUnified(vm: SpotifyViewModel) = UnifiedResult(
+private fun SearchTrack.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
-    subtitle = "Song · ${artists.joinToString(", ") { it.name }}",
+    subtitle = ctx.getString(R.string.search_subtitle_song, artists.joinToString(", ") { it.name }),
     imageUrl = album.coverArtUrl,
     circular = false,
     onClick = { vm.playTrack(uri) }
 )
 
-private fun SearchArtist.toUnified(vm: SpotifyViewModel) = UnifiedResult(
+private fun SearchArtist.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
-    subtitle = "Artist",
+    subtitle = ctx.getString(R.string.search_subtitle_artist),
     imageUrl = avatarUrl,
     circular = true,
     onClick = { vm.openArtist(idFromUri(uri)) }
@@ -304,28 +308,28 @@ private fun SearchAlbum.toUnified(vm: SpotifyViewModel): UnifiedResult {
     )
 }
 
-private fun SearchPlaylist.toUnified(vm: SpotifyViewModel) = UnifiedResult(
+private fun SearchPlaylist.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
-    subtitle = listOfNotNull("Playlist", ownerName).joinToString(" · "),
+    subtitle = listOfNotNull(ctx.getString(R.string.search_subtitle_playlist), ownerName).joinToString(" · "),
     imageUrl = coverArtUrl,
     circular = false,
     onClick = { vm.openPlaylist(idFromUri(uri)) }
 )
 
-private fun SearchPodcast.toUnified() = UnifiedResult(
+private fun SearchPodcast.toUnified(ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
-    subtitle = listOfNotNull("Podcast", publisher).joinToString(" · "),
+    subtitle = listOfNotNull(ctx.getString(R.string.search_subtitle_podcast), publisher).joinToString(" · "),
     imageUrl = coverArtUrl,
     circular = false,
     onClick = { /* podcast detail not implemented yet */ }
 )
 
-private fun SearchUser.toUnified() = UnifiedResult(
+private fun SearchUser.toUnified(ctx: Context) = UnifiedResult(
     uri = uri,
     title = displayName,
-    subtitle = "Profile",
+    subtitle = ctx.getString(R.string.search_subtitle_profile),
     imageUrl = avatarUrl,
     circular = true,
     onClick = { /* user profile not implemented yet */ }
@@ -339,6 +343,7 @@ private fun CategorizedResults(
     onFilterChange: (SearchViewModel.SearchFilter) -> Unit
 ) {
     if (results == null) return
+    val ctx = LocalContext.current
 
     Column(Modifier.fillMaxSize()) {
         FilterChipRow(
@@ -353,19 +358,19 @@ private fun CategorizedResults(
                 // Top result is the first artist (Spotify usually features an
                 // artist as the top result for entity queries). Falls back to
                 // the first available item if there's no artist.
-                results.artists.items.forEach { add(it.toUnified(vm)) }
-                results.tracks.items.forEach { add(it.toUnified(vm)) }
+                results.artists.items.forEach { add(it.toUnified(vm, ctx)) }
+                results.tracks.items.forEach { add(it.toUnified(vm, ctx)) }
                 results.albums.items.forEach { add(it.toUnified(vm)) }
-                results.playlists.items.forEach { add(it.toUnified(vm)) }
-                results.podcasts.items.forEach { add(it.toUnified()) }
-                results.users.items.forEach { add(it.toUnified()) }
+                results.playlists.items.forEach { add(it.toUnified(vm, ctx)) }
+                results.podcasts.items.forEach { add(it.toUnified(ctx)) }
+                results.users.items.forEach { add(it.toUnified(ctx)) }
             }
-            SearchViewModel.SearchFilter.ARTISTS -> results.artists.items.map { it.toUnified(vm) }
+            SearchViewModel.SearchFilter.ARTISTS -> results.artists.items.map { it.toUnified(vm, ctx) }
             SearchViewModel.SearchFilter.ALBUMS -> results.albums.items.map { it.toUnified(vm) }
-            SearchViewModel.SearchFilter.SONGS -> results.tracks.items.map { it.toUnified(vm) }
-            SearchViewModel.SearchFilter.PLAYLISTS -> results.playlists.items.map { it.toUnified(vm) }
-            SearchViewModel.SearchFilter.PODCASTS -> results.podcasts.items.map { it.toUnified() }
-            SearchViewModel.SearchFilter.PROFILES -> results.users.items.map { it.toUnified() }
+            SearchViewModel.SearchFilter.SONGS -> results.tracks.items.map { it.toUnified(vm, ctx) }
+            SearchViewModel.SearchFilter.PLAYLISTS -> results.playlists.items.map { it.toUnified(vm, ctx) }
+            SearchViewModel.SearchFilter.PODCASTS -> results.podcasts.items.map { it.toUnified(ctx) }
+            SearchViewModel.SearchFilter.PROFILES -> results.users.items.map { it.toUnified(ctx) }
         }
 
         LazyColumn(
@@ -399,7 +404,7 @@ private fun FilterChipRow(
     ) {
         SearchViewModel.SearchFilter.entries.forEach { f ->
             FilterChip(
-                label = labelFor(f),
+                label = stringResource(labelFor(f)),
                 isSelected = selected == f,
                 onClick = { onSelect(f) }
             )
@@ -422,14 +427,14 @@ private fun FilterChip(label: String, isSelected: Boolean, onClick: () -> Unit) 
     }
 }
 
-private fun labelFor(filter: SearchViewModel.SearchFilter): String = when (filter) {
-    SearchViewModel.SearchFilter.ALL -> "All"
-    SearchViewModel.SearchFilter.ARTISTS -> "Artists"
-    SearchViewModel.SearchFilter.ALBUMS -> "Albums"
-    SearchViewModel.SearchFilter.SONGS -> "Songs"
-    SearchViewModel.SearchFilter.PLAYLISTS -> "Playlists"
-    SearchViewModel.SearchFilter.PODCASTS -> "Podcasts"
-    SearchViewModel.SearchFilter.PROFILES -> "Profiles"
+private fun labelFor(filter: SearchViewModel.SearchFilter): Int = when (filter) {
+    SearchViewModel.SearchFilter.ALL -> R.string.search_filter_all
+    SearchViewModel.SearchFilter.ARTISTS -> R.string.search_filter_artists
+    SearchViewModel.SearchFilter.ALBUMS -> R.string.search_filter_albums
+    SearchViewModel.SearchFilter.SONGS -> R.string.search_filter_songs
+    SearchViewModel.SearchFilter.PLAYLISTS -> R.string.search_filter_playlists
+    SearchViewModel.SearchFilter.PODCASTS -> R.string.search_filter_podcasts
+    SearchViewModel.SearchFilter.PROFILES -> R.string.search_filter_profiles
 }
 
 @Composable

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -38,9 +38,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
 import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.components.BottomNav
 import ch.snepilatch.app.ui.components.DevicesDialog
@@ -176,7 +178,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
             val playlists = library.filter { it.type == "playlist" }
             AlertDialog(
                 onDismissRequest = { vm.showPlaylistPicker.value = false },
-                title = { Text("Add to Playlist", color = SpotifyWhite) },
+                title = { Text(stringResource(R.string.add_to_playlist), color = SpotifyWhite) },
                 text = {
                     LazyColumn {
                         items(playlists.size) { i ->
@@ -211,7 +213,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
                 confirmButton = {},
                 dismissButton = {
                     TextButton(onClick = { vm.showPlaylistPicker.value = false }) {
-                        Text("Cancel", color = SpotifyLightGray)
+                        Text(stringResource(R.string.cancel), color = SpotifyLightGray)
                     }
                 }
             )
@@ -246,9 +248,9 @@ fun LoadingScreen(
 
                     Icon(Icons.Default.CloudOff, null, tint = SpotifyLightGray, modifier = Modifier.size(48.dp))
                     Spacer(Modifier.height(16.dp))
-                    Text("Rate limited", color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                    Text(stringResource(R.string.rate_limited), color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(Modifier.height(8.dp))
-                    Text("Retrying in ${cooldownSecondsRemaining}s", color = SpotifyLightGray, fontSize = 14.sp)
+                    Text(stringResource(R.string.retrying_in, cooldownSecondsRemaining), color = SpotifyLightGray, fontSize = 14.sp)
                     Spacer(Modifier.height(24.dp))
                     LinearProgressIndicator(
                         progress = { progress },
@@ -261,13 +263,13 @@ fun LoadingScreen(
                     )
                     Spacer(Modifier.height(24.dp))
                     TextButton(onClick = onLogin) {
-                        Text("Login with different account", color = SpotifyLightGray, fontSize = 13.sp)
+                        Text(stringResource(R.string.login_different_account), color = SpotifyLightGray, fontSize = 13.sp)
                     }
                 }
                 error != null -> {
                     Icon(Icons.Default.CloudOff, null, tint = SpotifyLightGray, modifier = Modifier.size(48.dp))
                     Spacer(Modifier.height(16.dp))
-                    Text("Connection failed", color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                    Text(stringResource(R.string.connection_failed), color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(Modifier.height(8.dp))
                     Text(error, color = SpotifyLightGray, fontSize = 13.sp)
                     Spacer(Modifier.height(24.dp))
@@ -276,17 +278,17 @@ fun LoadingScreen(
                         colors = ButtonDefaults.buttonColors(containerColor = SpotifyWhite),
                         shape = RoundedCornerShape(24.dp)
                     ) {
-                        Text("Retry", fontWeight = FontWeight.Bold, color = Color.Black)
+                        Text(stringResource(R.string.retry), fontWeight = FontWeight.Bold, color = Color.Black)
                     }
                     Spacer(Modifier.height(8.dp))
                     TextButton(onClick = onLogin) {
-                        Text("Login with different account", color = SpotifyLightGray, fontSize = 13.sp)
+                        Text(stringResource(R.string.login_different_account), color = SpotifyLightGray, fontSize = 13.sp)
                     }
                 }
                 else -> {
                     CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 3.dp)
                     Spacer(Modifier.height(20.dp))
-                    Text("Connecting to Spotify...", color = SpotifyLightGray, fontSize = 15.sp)
+                    Text(stringResource(R.string.connecting_to_spotify), color = SpotifyLightGray, fontSize = 15.sp)
                 }
             }
         }

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -99,4 +99,146 @@
     <!-- Notification -->
     <string name="added_to_liked">Zu de Lieblingssongs dezue</string>
     <string name="removed_from_liked">Vo de Lieblingssongs weg</string>
+
+    <!-- Playback -->
+    <string name="playback_ended">Wiedergab fertig</string>
+
+    <!-- Backfill -->
+    <string name="tidal_desc">Tidal — FLAC bis 1411 kbps</string>
+    <string name="qobuz_desc">Qobuz — FLAC bis 9216 kbps</string>
+
+    <!-- Common (added) -->
+    <string name="close">Zuetue</string>
+    <string name="retry">Nomal probiere</string>
+    <string name="placeholder_dots">…</string>
+    <string name="loading_dots">Am Lade…</string>
+
+    <!-- Account (added) -->
+    <string name="profile_image">Profil</string>
+    <string name="account_image">Konto</string>
+
+    <!-- Language -->
+    <string name="language">Sproch</string>
+    <string name="language_system_default">Systemstandard</string>
+
+    <!-- Settings (added) -->
+    <string name="lossless_off_spotify">Standardqualität (Spotify)</string>
+    <string name="tidal">Tidal</string>
+    <string name="qobuz">Qobuz</string>
+    <string name="tidal_short_desc">FLAC bis 1411 kbps</string>
+    <string name="qobuz_short_desc">FLAC bis 9216 kbps</string>
+    <string name="notification_button_left">Linki Taste</string>
+    <string name="notification_button_right">Rächti Taste</string>
+    <string name="notif_like_short_desc">Gfallt-mer umschalte</string>
+
+    <!-- Regions -->
+    <string name="region_us">Vereinigti Staate</string>
+    <string name="region_gb">Vereinigts Königriich</string>
+    <string name="region_de">Dütschland</string>
+    <string name="region_ch">Schwiiz</string>
+    <string name="region_fr">Frankriich</string>
+    <string name="region_jp">Japan</string>
+    <string name="region_kr">Südkorea</string>
+    <string name="region_au">Auschtralie</string>
+    <string name="region_br">Brasilie</string>
+    <string name="region_ca">Kanada</string>
+    <string name="region_se">Schwede</string>
+
+    <!-- Release Notes (added) -->
+    <string name="release_load_failed">Versionshinwiis chönd nöd glade werde</string>
+    <string name="release_load_failed_short">Lade gschiitered: %s</string>
+    <string name="release_load_generic_error">Lade gschiitered</string>
+    <string name="release_latest_badge">NÖISCHT</string>
+    <string name="release_fallback_title">Version %s</string>
+
+    <!-- Loading / Connection -->
+    <string name="rate_limited">Z viel Aafrage</string>
+    <string name="retrying_in">Nomal i %ds</string>
+    <string name="login_different_account">Mit anderem Konto aamälde</string>
+    <string name="connection_failed">Verbindig gschiitered</string>
+    <string name="connecting_to_spotify">Am Spotify verbinde…</string>
+
+    <!-- Update Dialog (added) -->
+    <string name="update_download_failed">Download gschiitered. Probier nomal.</string>
+
+    <!-- Devices (added) -->
+    <string name="connect">Verbinde</string>
+    <string name="this_smartphone">Das Händy</string>
+
+    <!-- Common Actions -->
+    <string name="search">Sueche</string>
+    <string name="back">Zrugg</string>
+    <string name="clear">Lösche</string>
+    <string name="more">Meh</string>
+    <string name="play">Abspiele</string>
+    <string name="play_pause">Abspiele/Pause</string>
+    <string name="previous">Vorhärige</string>
+    <string name="next">Nächschti</string>
+    <string name="save">Spichere</string>
+    <string name="shuffle">Zuefallswiedergab</string>
+    <string name="repeat">Wiederhole</string>
+    <string name="queue">Wartelischte</string>
+    <string name="audio_output">Audio-Uusgab</string>
+    <string name="equalizer">Equalizer</string>
+    <string name="lyrics">Lyrics</string>
+    <string name="view_queue">Wartelischte aaluege</string>
+    <string name="visit_artist">Künstler aaluege</string>
+    <string name="devices">Gräti</string>
+    <string name="share_track_chooser">Song teile</string>
+
+    <!-- Library Screen -->
+    <string name="library_title">Dini Bibliothek</string>
+    <string name="library_create">Mache</string>
+    <string name="library_toggle_view">Asicht wächsle</string>
+    <string name="library_filter_playlists">Playlists</string>
+    <string name="library_filter_artists">Künstler</string>
+    <string name="library_filter_albums">Albä</string>
+    <string name="library_sort">Sortiere</string>
+    <string name="library_sort_recent">Nöischti</string>
+    <string name="library_sort_alpha">Alphabetisch</string>
+    <string name="library_sort_by_type">Nach Typ</string>
+    <string name="library_create_playlist">Playlist mache</string>
+    <string name="library_playlist_name_hint">Playlist-Name</string>
+    <string name="library_create_button">Mache</string>
+    <string name="library_remove_title">Us Bibliothek näh</string>
+    <string name="library_remove_message">\"%s\" us dinere Bibliothek näh?</string>
+    <string name="library_remove_button">Näh</string>
+
+    <!-- Detail Screen extras -->
+    <string name="detail_likes">%s Likes</string>
+    <string name="detail_songs">%d Songs</string>
+    <string name="detail_minutes">%d Min</string>
+    <string name="detail_monthly_listeners">%s monatlichi Lostere</string>
+
+    <!-- Queue Screen -->
+    <string name="queue_next_up">Als Nächschts</string>
+    <string name="queue_empty">Wartelischte isch leer</string>
+
+    <!-- Lyrics Screen -->
+    <string name="lyrics_not_available">Kei Lyrics verfüegbar</string>
+
+    <!-- Now Playing -->
+    <string name="now_playing_playing_from">Lauft vo %s</string>
+    <string name="now_playing_not_playing">Nüt lauft</string>
+
+    <!-- Search (added) -->
+    <string name="search_title">Suechi</string>
+    <string name="search_field_placeholder">Sueche</string>
+    <string name="search_clear">Lösche</string>
+    <string name="search_browse_all">Alles aaluege</string>
+    <string name="search_subtitle_song">Song · %s</string>
+    <string name="search_subtitle_artist">Künstler</string>
+    <string name="search_subtitle_playlist">Playlist</string>
+    <string name="search_subtitle_podcast">Podcast</string>
+    <string name="search_subtitle_profile">Profil</string>
+    <string name="search_filter_all">Alli</string>
+    <string name="search_filter_artists">Künstler</string>
+    <string name="search_filter_albums">Albä</string>
+    <string name="search_filter_songs">Songs</string>
+    <string name="search_filter_playlists">Playlists</string>
+    <string name="search_filter_podcasts">Podcasts</string>
+    <string name="search_filter_profiles">Profil</string>
+
+    <!-- Login -->
+    <string name="login_title">Bi Spotify aamelde</string>
 </resources>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -99,4 +99,146 @@
     <!-- Notification -->
     <string name="added_to_liked">Zu Lieblingssongs hinzugefügt</string>
     <string name="removed_from_liked">Aus Lieblingssongs entfernt</string>
+
+    <!-- Playback -->
+    <string name="playback_ended">Wiedergabe beendet</string>
+
+    <!-- Backfill -->
+    <string name="tidal_desc">Tidal — FLAC bis 1411 kbps</string>
+    <string name="qobuz_desc">Qobuz — FLAC bis 9216 kbps</string>
+
+    <!-- Common (added) -->
+    <string name="close">Schließen</string>
+    <string name="retry">Erneut versuchen</string>
+    <string name="placeholder_dots">…</string>
+    <string name="loading_dots">Laden…</string>
+
+    <!-- Account (added) -->
+    <string name="profile_image">Profil</string>
+    <string name="account_image">Konto</string>
+
+    <!-- Language -->
+    <string name="language">Sprache</string>
+    <string name="language_system_default">Systemstandard</string>
+
+    <!-- Settings (added) -->
+    <string name="lossless_off_spotify">Standardqualität (Spotify)</string>
+    <string name="tidal">Tidal</string>
+    <string name="qobuz">Qobuz</string>
+    <string name="tidal_short_desc">FLAC bis 1411 kbps</string>
+    <string name="qobuz_short_desc">FLAC bis 9216 kbps</string>
+    <string name="notification_button_left">Linke Taste</string>
+    <string name="notification_button_right">Rechte Taste</string>
+    <string name="notif_like_short_desc">Gefällt-mir-Status umschalten</string>
+
+    <!-- Regions -->
+    <string name="region_us">Vereinigte Staaten</string>
+    <string name="region_gb">Vereinigtes Königreich</string>
+    <string name="region_de">Deutschland</string>
+    <string name="region_ch">Schweiz</string>
+    <string name="region_fr">Frankreich</string>
+    <string name="region_jp">Japan</string>
+    <string name="region_kr">Südkorea</string>
+    <string name="region_au">Australien</string>
+    <string name="region_br">Brasilien</string>
+    <string name="region_ca">Kanada</string>
+    <string name="region_se">Schweden</string>
+
+    <!-- Release Notes (added) -->
+    <string name="release_load_failed">Versionshinweise konnten nicht geladen werden</string>
+    <string name="release_load_failed_short">Laden fehlgeschlagen: %s</string>
+    <string name="release_load_generic_error">Laden fehlgeschlagen</string>
+    <string name="release_latest_badge">NEUSTE</string>
+    <string name="release_fallback_title">Version %s</string>
+
+    <!-- Loading / Connection -->
+    <string name="rate_limited">Ratenbegrenzung</string>
+    <string name="retrying_in">Neuer Versuch in %ds</string>
+    <string name="login_different_account">Mit anderem Konto anmelden</string>
+    <string name="connection_failed">Verbindung fehlgeschlagen</string>
+    <string name="connecting_to_spotify">Verbinde mit Spotify…</string>
+
+    <!-- Update Dialog (added) -->
+    <string name="update_download_failed">Download fehlgeschlagen. Bitte versuche es erneut.</string>
+
+    <!-- Devices (added) -->
+    <string name="connect">Verbinden</string>
+    <string name="this_smartphone">Dieses Smartphone</string>
+
+    <!-- Common Actions -->
+    <string name="search">Suchen</string>
+    <string name="back">Zurück</string>
+    <string name="clear">Löschen</string>
+    <string name="more">Mehr</string>
+    <string name="play">Abspielen</string>
+    <string name="play_pause">Abspielen/Pause</string>
+    <string name="previous">Vorheriger</string>
+    <string name="next">Nächster</string>
+    <string name="save">Speichern</string>
+    <string name="shuffle">Zufallswiedergabe</string>
+    <string name="repeat">Wiederholen</string>
+    <string name="queue">Warteschlange</string>
+    <string name="audio_output">Audio-Ausgabe</string>
+    <string name="equalizer">Equalizer</string>
+    <string name="lyrics">Lyrics</string>
+    <string name="view_queue">Warteschlange anzeigen</string>
+    <string name="visit_artist">Künstler anzeigen</string>
+    <string name="devices">Geräte</string>
+    <string name="share_track_chooser">Song teilen</string>
+
+    <!-- Library Screen -->
+    <string name="library_title">Deine Bibliothek</string>
+    <string name="library_create">Erstellen</string>
+    <string name="library_toggle_view">Ansicht wechseln</string>
+    <string name="library_filter_playlists">Playlists</string>
+    <string name="library_filter_artists">Künstler</string>
+    <string name="library_filter_albums">Alben</string>
+    <string name="library_sort">Sortieren</string>
+    <string name="library_sort_recent">Zuletzt</string>
+    <string name="library_sort_alpha">Alphabetisch</string>
+    <string name="library_sort_by_type">Nach Typ</string>
+    <string name="library_create_playlist">Playlist erstellen</string>
+    <string name="library_playlist_name_hint">Playlist-Name</string>
+    <string name="library_create_button">Erstellen</string>
+    <string name="library_remove_title">Aus Bibliothek entfernen</string>
+    <string name="library_remove_message">\"%s\" aus deiner Bibliothek entfernen?</string>
+    <string name="library_remove_button">Entfernen</string>
+
+    <!-- Detail Screen extras -->
+    <string name="detail_likes">%s Likes</string>
+    <string name="detail_songs">%d Songs</string>
+    <string name="detail_minutes">%d Min</string>
+    <string name="detail_monthly_listeners">%s monatliche Hörer</string>
+
+    <!-- Queue Screen -->
+    <string name="queue_next_up">Als Nächstes</string>
+    <string name="queue_empty">Warteschlange ist leer</string>
+
+    <!-- Lyrics Screen -->
+    <string name="lyrics_not_available">Keine Lyrics verfügbar</string>
+
+    <!-- Now Playing -->
+    <string name="now_playing_playing_from">Spielt von %s</string>
+    <string name="now_playing_not_playing">Nichts spielt</string>
+
+    <!-- Search (added) -->
+    <string name="search_title">Suche</string>
+    <string name="search_field_placeholder">Suchen</string>
+    <string name="search_clear">Löschen</string>
+    <string name="search_browse_all">Alles durchstöbern</string>
+    <string name="search_subtitle_song">Song · %s</string>
+    <string name="search_subtitle_artist">Künstler</string>
+    <string name="search_subtitle_playlist">Playlist</string>
+    <string name="search_subtitle_podcast">Podcast</string>
+    <string name="search_subtitle_profile">Profil</string>
+    <string name="search_filter_all">Alle</string>
+    <string name="search_filter_artists">Künstler</string>
+    <string name="search_filter_albums">Alben</string>
+    <string name="search_filter_songs">Songs</string>
+    <string name="search_filter_playlists">Playlists</string>
+    <string name="search_filter_podcasts">Podcasts</string>
+    <string name="search_filter_profiles">Profile</string>
+
+    <!-- Login -->
+    <string name="login_title">Bei Spotify anmelden</string>
 </resources>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -99,4 +99,146 @@
     <!-- Notification -->
     <string name="added_to_liked">Добавлено в любимые песни</string>
     <string name="removed_from_liked">Удалено из любимых песен</string>
+
+    <!-- Playback -->
+    <string name="playback_ended">Воспроизведение завершено</string>
+
+    <!-- Backfill -->
+    <string name="tidal_desc">Tidal — FLAC до 1411 кбит/с</string>
+    <string name="qobuz_desc">Qobuz — FLAC до 9216 кбит/с</string>
+
+    <!-- Common (added) -->
+    <string name="close">Закрыть</string>
+    <string name="retry">Повторить</string>
+    <string name="placeholder_dots">…</string>
+    <string name="loading_dots">Загрузка…</string>
+
+    <!-- Account (added) -->
+    <string name="profile_image">Профиль</string>
+    <string name="account_image">Аккаунт</string>
+
+    <!-- Language -->
+    <string name="language">Язык</string>
+    <string name="language_system_default">Системный</string>
+
+    <!-- Settings (added) -->
+    <string name="lossless_off_spotify">Стандартное качество (Spotify)</string>
+    <string name="tidal">Tidal</string>
+    <string name="qobuz">Qobuz</string>
+    <string name="tidal_short_desc">FLAC до 1411 кбит/с</string>
+    <string name="qobuz_short_desc">FLAC до 9216 кбит/с</string>
+    <string name="notification_button_left">Левая кнопка</string>
+    <string name="notification_button_right">Правая кнопка</string>
+    <string name="notif_like_short_desc">Переключить «нравится»</string>
+
+    <!-- Regions -->
+    <string name="region_us">США</string>
+    <string name="region_gb">Великобритания</string>
+    <string name="region_de">Германия</string>
+    <string name="region_ch">Швейцария</string>
+    <string name="region_fr">Франция</string>
+    <string name="region_jp">Япония</string>
+    <string name="region_kr">Южная Корея</string>
+    <string name="region_au">Австралия</string>
+    <string name="region_br">Бразилия</string>
+    <string name="region_ca">Канада</string>
+    <string name="region_se">Швеция</string>
+
+    <!-- Release Notes (added) -->
+    <string name="release_load_failed">Не удалось загрузить примечания к выпуску</string>
+    <string name="release_load_failed_short">Ошибка загрузки: %s</string>
+    <string name="release_load_generic_error">Не удалось загрузить</string>
+    <string name="release_latest_badge">ПОСЛЕДНЕЕ</string>
+    <string name="release_fallback_title">Версия %s</string>
+
+    <!-- Loading / Connection -->
+    <string name="rate_limited">Превышен лимит запросов</string>
+    <string name="retrying_in">Повтор через %d с</string>
+    <string name="login_different_account">Войти под другим аккаунтом</string>
+    <string name="connection_failed">Ошибка соединения</string>
+    <string name="connecting_to_spotify">Подключение к Spotify…</string>
+
+    <!-- Update Dialog (added) -->
+    <string name="update_download_failed">Загрузка не удалась. Попробуйте ещё раз.</string>
+
+    <!-- Devices (added) -->
+    <string name="connect">Подключение</string>
+    <string name="this_smartphone">Этот смартфон</string>
+
+    <!-- Common Actions -->
+    <string name="search">Поиск</string>
+    <string name="back">Назад</string>
+    <string name="clear">Очистить</string>
+    <string name="more">Ещё</string>
+    <string name="play">Играть</string>
+    <string name="play_pause">Играть/Пауза</string>
+    <string name="previous">Назад</string>
+    <string name="next">Вперёд</string>
+    <string name="save">Сохранить</string>
+    <string name="shuffle">Перемешать</string>
+    <string name="repeat">Повтор</string>
+    <string name="queue">Очередь</string>
+    <string name="audio_output">Аудиовыход</string>
+    <string name="equalizer">Эквалайзер</string>
+    <string name="lyrics">Текст</string>
+    <string name="view_queue">Показать очередь</string>
+    <string name="visit_artist">Перейти к исполнителю</string>
+    <string name="devices">Устройства</string>
+    <string name="share_track_chooser">Поделиться треком</string>
+
+    <!-- Library Screen -->
+    <string name="library_title">Ваша библиотека</string>
+    <string name="library_create">Создать</string>
+    <string name="library_toggle_view">Сменить вид</string>
+    <string name="library_filter_playlists">Плейлисты</string>
+    <string name="library_filter_artists">Исполнители</string>
+    <string name="library_filter_albums">Альбомы</string>
+    <string name="library_sort">Сортировка</string>
+    <string name="library_sort_recent">Недавние</string>
+    <string name="library_sort_alpha">По алфавиту</string>
+    <string name="library_sort_by_type">По типу</string>
+    <string name="library_create_playlist">Создать плейлист</string>
+    <string name="library_playlist_name_hint">Название плейлиста</string>
+    <string name="library_create_button">Создать</string>
+    <string name="library_remove_title">Удалить из библиотеки</string>
+    <string name="library_remove_message">Удалить «%s» из вашей библиотеки?</string>
+    <string name="library_remove_button">Удалить</string>
+
+    <!-- Detail Screen extras -->
+    <string name="detail_likes">%s лайков</string>
+    <string name="detail_songs">%d песен</string>
+    <string name="detail_minutes">%d мин</string>
+    <string name="detail_monthly_listeners">%s слушателей в месяц</string>
+
+    <!-- Queue Screen -->
+    <string name="queue_next_up">Далее</string>
+    <string name="queue_empty">Очередь пуста</string>
+
+    <!-- Lyrics Screen -->
+    <string name="lyrics_not_available">Текст недоступен</string>
+
+    <!-- Now Playing -->
+    <string name="now_playing_playing_from">Играет из %s</string>
+    <string name="now_playing_not_playing">Ничего не играет</string>
+
+    <!-- Search (added) -->
+    <string name="search_title">Поиск</string>
+    <string name="search_field_placeholder">Поиск</string>
+    <string name="search_clear">Очистить</string>
+    <string name="search_browse_all">Все категории</string>
+    <string name="search_subtitle_song">Песня · %s</string>
+    <string name="search_subtitle_artist">Исполнитель</string>
+    <string name="search_subtitle_playlist">Плейлист</string>
+    <string name="search_subtitle_podcast">Подкаст</string>
+    <string name="search_subtitle_profile">Профиль</string>
+    <string name="search_filter_all">Все</string>
+    <string name="search_filter_artists">Исполнители</string>
+    <string name="search_filter_albums">Альбомы</string>
+    <string name="search_filter_songs">Песни</string>
+    <string name="search_filter_playlists">Плейлисты</string>
+    <string name="search_filter_podcasts">Подкасты</string>
+    <string name="search_filter_profiles">Профили</string>
+
+    <!-- Login -->
+    <string name="login_title">Войти в Spotify</string>
 </resources>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -106,4 +106,139 @@
 
     <!-- Playback -->
     <string name="playback_ended">Playback ended</string>
+
+    <!-- Common (added) -->
+    <string name="close">Close</string>
+    <string name="retry">Retry</string>
+    <string name="placeholder_dots">…</string>
+    <string name="loading_dots">Loading…</string>
+
+    <!-- Account (added) -->
+    <string name="profile_image">Profile</string>
+    <string name="account_image">Account</string>
+
+    <!-- Language -->
+    <string name="language">Language</string>
+    <string name="language_system_default">System Default</string>
+
+    <!-- Settings (added) -->
+    <string name="lossless_off_spotify">Standard quality (Spotify)</string>
+    <string name="tidal">Tidal</string>
+    <string name="qobuz">Qobuz</string>
+    <string name="tidal_short_desc">FLAC up to 1411kbps</string>
+    <string name="qobuz_short_desc">FLAC up to 9216kbps</string>
+    <string name="notification_button_left">Left Button</string>
+    <string name="notification_button_right">Right Button</string>
+    <string name="notif_like_short_desc">Toggle liked state</string>
+
+    <!-- Regions -->
+    <string name="region_us">United States</string>
+    <string name="region_gb">United Kingdom</string>
+    <string name="region_de">Germany</string>
+    <string name="region_ch">Switzerland</string>
+    <string name="region_fr">France</string>
+    <string name="region_jp">Japan</string>
+    <string name="region_kr">South Korea</string>
+    <string name="region_au">Australia</string>
+    <string name="region_br">Brazil</string>
+    <string name="region_ca">Canada</string>
+    <string name="region_se">Sweden</string>
+
+    <!-- Release Notes (added) -->
+    <string name="release_load_failed">Failed to load release notes</string>
+    <string name="release_load_failed_short">Failed to load: %s</string>
+    <string name="release_load_generic_error">Failed to load</string>
+    <string name="release_latest_badge">LATEST</string>
+    <string name="release_fallback_title">Release %s</string>
+
+    <!-- Loading / Connection -->
+    <string name="rate_limited">Rate limited</string>
+    <string name="retrying_in">Retrying in %ds</string>
+    <string name="login_different_account">Login with different account</string>
+    <string name="connection_failed">Connection failed</string>
+    <string name="connecting_to_spotify">Connecting to Spotify…</string>
+
+    <!-- Update Dialog (added) -->
+    <string name="update_download_failed">Download failed. Please try again.</string>
+
+    <!-- Devices (added) -->
+    <string name="connect">Connect</string>
+    <string name="this_smartphone">This Smartphone</string>
+
+    <!-- Common Actions -->
+    <string name="search">Search</string>
+    <string name="back">Back</string>
+    <string name="clear">Clear</string>
+    <string name="more">More</string>
+    <string name="play">Play</string>
+    <string name="play_pause">Play/Pause</string>
+    <string name="previous">Previous</string>
+    <string name="next">Next</string>
+    <string name="save">Save</string>
+    <string name="shuffle">Shuffle</string>
+    <string name="repeat">Repeat</string>
+    <string name="queue">Queue</string>
+    <string name="audio_output">Audio Output</string>
+    <string name="equalizer">Equalizer</string>
+    <string name="lyrics">Lyrics</string>
+    <string name="view_queue">View Queue</string>
+    <string name="visit_artist">Visit Artist</string>
+    <string name="devices">Devices</string>
+    <string name="share_track_chooser">Share track</string>
+
+    <!-- Library Screen -->
+    <string name="library_title">Your Library</string>
+    <string name="library_create">Create</string>
+    <string name="library_toggle_view">Toggle view</string>
+    <string name="library_filter_playlists">Playlists</string>
+    <string name="library_filter_artists">Artists</string>
+    <string name="library_filter_albums">Albums</string>
+    <string name="library_sort">Sort</string>
+    <string name="library_sort_recent">Recent</string>
+    <string name="library_sort_alpha">Alphabetical</string>
+    <string name="library_sort_by_type">By Type</string>
+    <string name="library_create_playlist">Create Playlist</string>
+    <string name="library_playlist_name_hint">Playlist name</string>
+    <string name="library_create_button">Create</string>
+    <string name="library_remove_title">Remove from Library</string>
+    <string name="library_remove_message">Remove \"%s\" from your library?</string>
+    <string name="library_remove_button">Remove</string>
+
+    <!-- Detail Screen extras -->
+    <string name="detail_likes">%s likes</string>
+    <string name="detail_songs">%d songs</string>
+    <string name="detail_minutes">%d min</string>
+    <string name="detail_monthly_listeners">%s monthly listeners</string>
+
+    <!-- Queue Screen -->
+    <string name="queue_next_up">Next up</string>
+    <string name="queue_empty">Queue is empty</string>
+
+    <!-- Lyrics Screen -->
+    <string name="lyrics_not_available">No lyrics available</string>
+
+    <!-- Now Playing -->
+    <string name="now_playing_playing_from">Playing from %s</string>
+    <string name="now_playing_not_playing">Not Playing</string>
+
+    <!-- Search (added) -->
+    <string name="search_title">Search</string>
+    <string name="search_field_placeholder">Search</string>
+    <string name="search_clear">Clear</string>
+    <string name="search_browse_all">Browse All</string>
+    <string name="search_subtitle_song">Song · %s</string>
+    <string name="search_subtitle_artist">Artist</string>
+    <string name="search_subtitle_playlist">Playlist</string>
+    <string name="search_subtitle_podcast">Podcast</string>
+    <string name="search_subtitle_profile">Profile</string>
+    <string name="search_filter_all">All</string>
+    <string name="search_filter_artists">Artists</string>
+    <string name="search_filter_albums">Albums</string>
+    <string name="search_filter_songs">Songs</string>
+    <string name="search_filter_playlists">Playlists</string>
+    <string name="search_filter_podcasts">Podcasts</string>
+    <string name="search_filter_profiles">Profiles</string>
+
+    <!-- Login -->
+    <string name="login_title">Login to Spotify</string>
 </resources>

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <SmellBaseline>
-  <ManuallySuppressedIssues></ManuallySuppressedIssues>
+  <ManuallySuppressedIssues/>
   <CurrentIssues>
     <ID>AnnotationOnSeparateLine:MediaButtonReceiver.kt$MediaButtonReceiver$@Suppress("DEPRECATION") intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT)</ID>
     <ID>BlockCommentInitialStarAlignment:Theme.kt$/* Other default colors to override background = Color(0xFFFFFBFE), surface = Color(0xFFFFFBFE), onPrimary = Color.White, onSecondary = Color.White, onTertiary = Color.White, onBackground = Color(0xFF1C1B1F), onSurface = Color(0xFF1C1B1F), */</ID>
@@ -63,10 +63,8 @@
     <ID>MaximumLineLength:NowPlayingScreen.kt$ </ID>
     <ID>MaximumLineLength:QueueScreen.kt$ </ID>
     <ID>MaximumLineLength:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
-    <ID>MultiLineIfElse:AccountScreen.kt$"FLAC via ${if (audioSource == "tidal") "Tidal" else "Qobuz"}"</ID>
-    <ID>MultiLineIfElse:AccountScreen.kt$"Qobuz — FLAC up to 9216kbps"</ID>
-    <ID>MultiLineIfElse:AccountScreen.kt$"Standard quality (Spotify)"</ID>
-    <ID>MultiLineIfElse:AccountScreen.kt$"Tidal — FLAC up to 1411kbps"</ID>
+    <ID>MultiLineIfElse:AccountScreen.kt$stringResource(R.string.qobuz_desc)</ID>
+    <ID>MultiLineIfElse:AccountScreen.kt$stringResource(R.string.tidal_desc)</ID>
     <ID>MultiLineIfElse:BottomNav.kt$Modifier</ID>
     <ID>MultiLineIfElse:BottomNav.kt$Modifier.border(2.dp, SpotifyWhite, CircleShape)</ID>
     <ID>MultiLineIfElse:DetailScreen.kt$String.format("%,d", detail.followers)</ID>
@@ -97,6 +95,7 @@
     <ID>NoMultipleSpaces:MusicPlaybackService.kt$MusicPlaybackService$ </ID>
     <ID>NoMultipleSpaces:ReleaseNotesScreen.kt$ </ID>
     <ID>NoMultipleSpaces:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
+    <ID>PropertyWrapping:AccountScreen.kt$val losslessOnText = stringResource(R.string.lossless_on, if (audioSource == "tidal") tidalLabel else qobuzLabel)</ID>
     <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$catch</ID>
     <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$finally</ID>
     <ID>SpacingBetweenDeclarationsWithAnnotations:SessionHolder.kt$SessionHolder$@Volatile var cdnResolver: SpotifyCdnResolver? = null</ID>
@@ -112,7 +111,6 @@
     <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Notification button preferences: "like", "shuffle", "repeat"</ID>
     <ID>StringTemplate:DetailScreen.kt$${totalMin}</ID>
     <ID>ThrowsCount:SpotifyViewModel.kt$SpotifyViewModel$fun togglePlayPause()</ID>
-    <ID>ThrowsCount:SpotifyViewModel.kt$SpotifyViewModel$private fun wireTransportCallbacks(svc: MusicPlaybackService)</ID>
     <ID>TooGenericExceptionThrown:ReleaseNotesScreen.kt$throw Exception("HTTP ${response.code}")</ID>
     <ID>UseCheckOrError:SpotifyCdnResolver.kt$SpotifyCdnResolver$throw IllegalStateException("No CDN mirrors for fileId=$fileId")</ID>
     <ID>UseCheckOrError:SpotifyViewModel.kt$SpotifyViewModel$throw IllegalStateException("CdnResolver not initialized")</ID>
@@ -121,10 +119,17 @@
     <ID>VariableNaming:SpotifyViewModel.kt$SpotifyViewModel$private val TAG = "SpotifyVM"</ID>
     <ID>Wrapping:AccountScreen.kt$(</ID>
     <ID>Wrapping:AccountScreen.kt$;</ID>
-    <ID>Wrapping:AccountScreen.kt$Text( if (audioSource == "tidal") "Tidal — FLAC up to 1411kbps" else "Qobuz — FLAC up to 9216kbps", color = SpotifyLightGray )</ID>
-    <ID>Wrapping:AccountScreen.kt$Text( if (canvasOn) "Looping video behind album art" else "Off", color = SpotifyLightGray )</ID>
-    <ID>Wrapping:AccountScreen.kt$Text( if (isLossless) "FLAC via ${if (audioSource == "tidal") "Tidal" else "Qobuz"}" else "Standard quality (Spotify)", color = SpotifyLightGray )</ID>
-    <ID>Wrapping:AccountScreen.kt$Text( when { isChecking -&gt; "Checking..." upToDate -&gt; "You're on the latest version" else -&gt; "Tap to check for new versions" }, color = if (upToDate) animatedPrimary else SpotifyLightGray )</ID>
+    <ID>Wrapping:AccountScreen.kt$Text( if (audioSource == "tidal") stringResource(R.string.tidal_desc) else stringResource(R.string.qobuz_desc), color = SpotifyLightGray )</ID>
+    <ID>Wrapping:AccountScreen.kt$Text( if (canvasOn) stringResource(R.string.canvas_on) else stringResource(R.string.canvas_off), color = SpotifyLightGray )</ID>
+    <ID>Wrapping:AccountScreen.kt$Text( if (isLossless) losslessOnText else losslessOffText, color = SpotifyLightGray )</ID>
+    <ID>Wrapping:AccountScreen.kt$Text( when { isChecking -&gt; stringResource(R.string.checking) upToDate -&gt; stringResource(R.string.up_to_date) else -&gt; stringResource(R.string.tap_to_check) }, color = if (upToDate) animatedPrimary else SpotifyLightGray )</ID>
+    <ID>Wrapping:AccountScreen.kt$Text(stringResource(R.string.cancel), color = SpotifyLightGray)</ID>
+    <ID>Wrapping:AccountScreen.kt$TextButton(onClick = { showLanguagePicker = false }) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) }</ID>
+    <ID>Wrapping:AccountScreen.kt$TextButton(onClick = { showLeftPicker = false }) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) }</ID>
+    <ID>Wrapping:AccountScreen.kt$TextButton(onClick = { showRightPicker = false }) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) }</ID>
+    <ID>Wrapping:AccountScreen.kt$showLanguagePicker = false</ID>
+    <ID>Wrapping:AccountScreen.kt$showLeftPicker = false</ID>
+    <ID>Wrapping:AccountScreen.kt$showRightPicker = false</ID>
     <ID>Wrapping:DetailScreen.kt$(</ID>
     <ID>Wrapping:DetailScreen.kt$;</ID>
     <ID>Wrapping:DetailScreen.kt$showMenu = false; vm.showPlaylistPickerForTrack(track.uri)</ID>


### PR DESCRIPTION
Closes #124

Replaces hardcoded English literals across 16 UI files with `stringResource(R.string.X)` calls so the de / ru / b+gsw translations actually take effect (`stringResource` was used 0 times before this PR).

## Scope
- 16 UI files swept: Account, ReleaseNotes, SpfyApp, UpdateDialog, DevicesDialog, BottomNav, Library, Detail, NowPlaying, Queue, Lyrics, MiniPlayer, Home, Search, Login, SharedComponents.
- 4 `strings.xml` files (en, de, ru, gsw) extended from ~108 → ~180 keys, identical key set across locales.
- Backfilled `tidal_desc`, `qobuz_desc`, `playback_ended` in the 3 non-English locales (were EN-only).
- Detekt baseline regenerated where literal-bearing IDs were invalidated by extraction.

## Approach
Three parallel worktree agents owned disjoint UI slices to avoid file-level conflicts. A merge pass reconciled the 4 `strings.xml` files (collisions: `close`, `more`, `visit_artist` — identical values across slices).

## Intentionally left alone
- Brand/proper names ("Snepilatch", "Cinnabar 🧼", "Tidal", "Qobuz", "YouTube Music")
- Language autonyms ("English", "Deutsch", "Русский", "Schwiizerdütsch")
- BrowseCategory genre names passed verbatim to server search
- Library filter state-key strings (logical keys, not user-facing)
- Log strings, JSON keys, URLs

## Verify
- [x] `:app:assembleDebug` green
- [x] `:app:testDebugUnitTest` green
- [x] `detekt` green
- [ ] Visual sanity-check on device (next step)