### PR TITLE
feat(ui): adopt Material 3 Expressive across player, dialogs, Account (#266)

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
 
 android {
     namespace = "ch.snepilatch.app"
-    compileSdk = 36
+    compileSdk = 37
 
     // Load keystore properties
     val keystorePropertiesFile = rootProject.file("key.properties")
@@ -37,9 +37,9 @@ android {
     defaultConfig {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
-        targetSdk = 36
-        versionCode = 15
-        versionName = "2.3"
+        targetSdk = 37
+        versionCode = 22
+        versionName = "2.4.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -113,7 +113,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
-    implementation(libs.androidx.compose.material3)
+    implementation("androidx.compose.material3:material3:1.5.0-alpha21")
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
@@ -8,10 +8,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Home
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -63,10 +63,10 @@ fun BottomNav(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
         ) {
             data class NavItem(val s: Screen, val icon: ImageVector, val label: String)
             val items = listOf(
-                NavItem(Screen.HOME, Icons.Default.Home, stringResource(R.string.nav_home)),
-                NavItem(Screen.SEARCH, Icons.Default.Search, stringResource(R.string.nav_search)),
-                NavItem(Screen.LIBRARY, Icons.AutoMirrored.Filled.QueueMusic, stringResource(R.string.nav_library)),
-                NavItem(Screen.ACCOUNT, Icons.Default.Person, stringResource(R.string.nav_account))
+                NavItem(Screen.HOME, Icons.Rounded.Home, stringResource(R.string.nav_home)),
+                NavItem(Screen.SEARCH, Icons.Rounded.Search, stringResource(R.string.nav_search)),
+                NavItem(Screen.LIBRARY, Icons.AutoMirrored.Rounded.QueueMusic, stringResource(R.string.nav_library)),
+                NavItem(Screen.ACCOUNT, Icons.Rounded.Person, stringResource(R.string.nav_account))
             )
             val accountDesc = stringResource(R.string.account_image)
             items.forEach { nav ->

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.components
 
 import ch.snepilatch.app.ui.theme.SpotifyWhite
@@ -16,14 +18,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.VolumeDown
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
-import androidx.compose.material.icons.filled.Computer
-import androidx.compose.material.icons.filled.Smartphone
-import androidx.compose.material.icons.filled.Speaker
-import androidx.compose.material.icons.filled.Tv
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material.icons.automirrored.rounded.VolumeDown
+import androidx.compose.material.icons.automirrored.rounded.VolumeUp
+import androidx.compose.material.icons.rounded.Computer
+import androidx.compose.material.icons.rounded.Smartphone
+import androidx.compose.material.icons.rounded.Speaker
+import androidx.compose.material.icons.rounded.Tv
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
@@ -97,7 +99,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    CircularProgressIndicator(color = SpotifyWhite, modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                    LoadingIndicator(color = SpotifyWhite, modifier = Modifier.size(24.dp))
                     Spacer(Modifier.width(12.dp))
                     Text(stringResource(R.string.searching_devices), color = SpotifyLightGray, fontSize = 14.sp)
                 }
@@ -116,10 +118,10 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                 ) {
                     Icon(
                         when (activeDevice.type.lowercase()) {
-                            "smartphone" -> Icons.Default.Smartphone
-                            "speaker" -> Icons.Default.Speaker
-                            "tv" -> Icons.Default.Tv
-                            else -> Icons.Default.Computer
+                            "smartphone" -> Icons.Rounded.Smartphone
+                            "speaker" -> Icons.Rounded.Speaker
+                            "tv" -> Icons.Rounded.Tv
+                            else -> Icons.Rounded.Computer
                         },
                         null,
                         tint = accentColor,
@@ -146,7 +148,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                             .padding(horizontal = 20.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(Icons.AutoMirrored.Filled.VolumeDown, null, tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+                        Icon(Icons.AutoMirrored.Rounded.VolumeDown, null, tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
                         var volumeValue by remember { mutableFloatStateOf(playback.volume.toFloat()) }
                         Slider(
                             value = volumeValue,
@@ -159,7 +161,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                                 inactiveTrackColor = SpotifyGray
                             )
                         )
-                        Icon(Icons.AutoMirrored.Filled.VolumeUp, null, tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+                        Icon(Icons.AutoMirrored.Rounded.VolumeUp, null, tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
                     }
                 }
 
@@ -179,10 +181,10 @@ fun DevicesDialog(vm: SpotifyViewModel) {
                 ) {
                     Icon(
                         when (device.type.lowercase()) {
-                            "smartphone" -> Icons.Default.Smartphone
-                            "speaker" -> Icons.Default.Speaker
-                            "tv" -> Icons.Default.Tv
-                            else -> Icons.Default.Computer
+                            "smartphone" -> Icons.Rounded.Smartphone
+                            "speaker" -> Icons.Rounded.Speaker
+                            "tv" -> Icons.Rounded.Tv
+                            else -> Icons.Rounded.Computer
                         },
                         null,
                         tint = SpotifyLightGray,

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.components
 
 import ch.snepilatch.app.ui.theme.SpotifyWhite
@@ -16,11 +18,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.SkipNext
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
@@ -95,20 +97,19 @@ fun MiniPlayer(vm: SpotifyViewModel) {
             }
             IconButton(onClick = { if (!streamLoading) vm.togglePlayPause() }, modifier = Modifier.size(40.dp)) {
                 if (streamLoading) {
-                    CircularProgressIndicator(
+                    LoadingIndicator(
                         color = SpotifyWhite,
-                        strokeWidth = 2.dp,
                         modifier = Modifier.size(20.dp)
                     )
                 } else {
                     Icon(
-                        if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
+                        if (playback.isPaused || !playback.isPlaying) Icons.Rounded.PlayArrow else Icons.Rounded.Pause,
                         stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(28.dp)
                     )
                 }
             }
             IconButton(onClick = { vm.skipNext() }, modifier = Modifier.size(40.dp)) {
-                Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                Icon(Icons.Rounded.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
             }
         }
         if (playback.durationMs > 0) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.components
 
 import ch.snepilatch.app.R
@@ -21,18 +23,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.runtime.collectAsState
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Share
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material3.*
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.material.icons.filled.Album
-import androidx.compose.material.icons.filled.Favorite
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Favorite
+import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
@@ -94,7 +95,7 @@ fun SpotifyImage(
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
     shape: androidx.compose.ui.graphics.Shape = RoundedCornerShape(8.dp),
-    icon: ImageVector = Icons.Default.MusicNote
+    icon: ImageVector = Icons.Rounded.MusicNote
 ) {
     SubcomposeAsyncImage(
         model = coil.request.ImageRequest.Builder(androidx.compose.ui.platform.LocalContext.current)
@@ -111,10 +112,9 @@ fun SpotifyImage(
                     .background(SpotifyGray),
                 contentAlignment = Alignment.Center
             ) {
-                CircularProgressIndicator(
+                LoadingIndicator(
                     color = SpotifyLightGray.copy(alpha = 0.5f),
-                    modifier = Modifier.size(24.dp),
-                    strokeWidth = 2.dp
+                    modifier = Modifier.size(24.dp)
                 )
             }
         },
@@ -167,7 +167,7 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
             Spacer(Modifier.width(4.dp))
         }
         IconButton(onClick = { showMenu = true }, modifier = Modifier.size(36.dp)) {
-            Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+            Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
     }
 
@@ -210,22 +210,22 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
             val visitAlbumLabel = stringResource(R.string.visit_album)
             val visitArtistLabel = stringResource(R.string.visit_artist)
             val items = listOf(
-                Triple(Icons.AutoMirrored.Filled.QueueMusic, addToQueueLabel) {
+                Triple(Icons.AutoMirrored.Rounded.QueueMusic, addToQueueLabel) {
                     vm.addToQueue(track.uri); showMenu = false
                 },
-                Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addToPlaylistLabel) {
+                Triple(Icons.AutoMirrored.Rounded.PlaylistAdd, addToPlaylistLabel) {
                     showMenu = false; vm.showPlaylistPickerForTrack(track.uri)
                 },
-                Triple(Icons.Default.Favorite, likeLabel) {
+                Triple(Icons.Rounded.Favorite, likeLabel) {
                     vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
                 },
-                Triple(Icons.Default.Album, visitAlbumLabel) {
+                Triple(Icons.Rounded.Album, visitAlbumLabel) {
                     showMenu = false; vm.openAlbumForTrack(track.uri)
                 },
-                Triple(Icons.Default.Person, visitArtistLabel) {
+                Triple(Icons.Rounded.Person, visitArtistLabel) {
                     showMenu = false; vm.openArtistForTrack(track.uri)
                 },
-                Triple(Icons.Default.Share, shareLabel) {
+                Triple(Icons.Rounded.Share, shareLabel) {
                     showMenu = false
                     val id = track.uri.removePrefix("spotify:track:")
                     val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/TightAlertDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/TightAlertDialog.kt
@@ -1,0 +1,69 @@
+package ch.snepilatch.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialogDefaults
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import ch.snepilatch.app.ui.theme.SpotifyElevated
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TightAlertDialog(
+    onDismissRequest: () -> Unit,
+    title: (@Composable () -> Unit)? = null,
+    text: (@Composable () -> Unit)? = null,
+    confirmButton: @Composable () -> Unit,
+    dismissButton: (@Composable () -> Unit)? = null,
+    containerColor: Color = SpotifyElevated,
+    shape: Shape = AlertDialogDefaults.shape,
+) {
+    val maxBodyHeight = LocalConfiguration.current.screenHeightDp.dp * 0.6f
+    BasicAlertDialog(onDismissRequest = onDismissRequest) {
+        Surface(
+            shape = shape,
+            color = containerColor,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(Modifier.padding(horizontal = 20.dp, vertical = 16.dp)) {
+                if (title != null) {
+                    Box(Modifier.padding(bottom = 12.dp)) { title() }
+                }
+                if (text != null) {
+                    Box(
+                        Modifier
+                            .heightIn(max = maxBodyHeight)
+                            .verticalScroll(rememberScrollState())
+                            .padding(bottom = 16.dp)
+                    ) { text() }
+                }
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    if (dismissButton != null) {
+                        dismissButton()
+                        Spacer(Modifier.width(4.dp))
+                    }
+                    confirmButton()
+                }
+            }
+        }
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
@@ -3,8 +3,8 @@ package ch.snepilatch.app.ui.components
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.SystemUpdate
-import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.rounded.SystemUpdate
+import androidx.compose.material.icons.rounded.ErrorOutline
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,16 +28,19 @@ fun UpdateDialog(
     var progress by remember { mutableFloatStateOf(0f) }
     var error by remember { mutableStateOf<String?>(null) }
 
-    AlertDialog(
+    TightAlertDialog(
         onDismissRequest = { if (!isDownloading) onDismiss() },
-        icon = {
-            Icon(
-                Icons.Default.SystemUpdate,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary
-            )
+        title = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.Rounded.SystemUpdate,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(R.string.update_available))
+            }
         },
-        title = { Text(stringResource(R.string.update_available)) },
         text = {
             Column(
                 modifier = Modifier.fillMaxWidth(),
@@ -101,7 +104,7 @@ fun UpdateDialog(
                             horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             Icon(
-                                Icons.Default.ErrorOutline,
+                                Icons.Rounded.ErrorOutline,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.onErrorContainer
                             )

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.screens
 
 import androidx.compose.animation.animateColorAsState
@@ -10,8 +12,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ExitToApp
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.ExitToApp
+import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -27,6 +29,7 @@ import coil.compose.AsyncImage
 import ch.snepilatch.app.BuildConfig
 import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.ProfileInfoItem
+import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.components.UpdateDialog
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.UpdateInfo
@@ -72,7 +75,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                         contentScale = ContentScale.Crop
                     )
                 } else {
-                    Icon(Icons.Default.Person, null, tint = SpotifyLightGray, modifier = Modifier.size(64.dp))
+                    Icon(Icons.Rounded.Person, null, tint = SpotifyLightGray, modifier = Modifier.size(64.dp))
                 }
             }
 
@@ -103,7 +106,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                         Modifier.padding(horizontal = 14.dp, vertical = 6.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(Icons.Default.Star, null, tint = animatedPrimary, modifier = Modifier.size(16.dp))
+                        Icon(Icons.Rounded.Star, null, tint = animatedPrimary, modifier = Modifier.size(16.dp))
                         Spacer(Modifier.width(6.dp))
                         Text(stringResource(R.string.premium), color = animatedPrimary, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
                     }
@@ -111,16 +114,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
             }
         }
 
-        HorizontalDivider(color = SpotifyGray, modifier = Modifier.padding(horizontal = 16.dp))
-
-        // Account details
-        Text(
-            stringResource(R.string.account),
-            color = SpotifyWhite,
-            fontSize = 16.sp,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
-        )
+        AccountSectionHeader(stringResource(R.string.account_section_profile))
 
         val dots = stringResource(R.string.placeholder_dots)
         val premiumLabel = stringResource(R.string.premium)
@@ -128,30 +122,21 @@ fun AccountScreen(vm: SpotifyViewModel) {
         ProfileInfoItem(
             stringResource(R.string.username),
             account.displayName.ifEmpty { account.username.ifEmpty { dots } },
-            Icons.Default.Person
+            Icons.Rounded.Person
         )
         ProfileInfoItem(
             stringResource(R.string.user_id),
             account.username.ifEmpty { dots },
-            Icons.Default.Badge
+            Icons.Rounded.Badge
         )
         ProfileInfoItem(
             stringResource(R.string.plan),
             if (account.isPremium) premiumLabel else freeLabel,
-            Icons.Default.CreditCard
+            Icons.Rounded.CreditCard
         )
 
         Spacer(Modifier.height(24.dp))
-
-        HorizontalDivider(color = SpotifyGray, modifier = Modifier.padding(horizontal = 16.dp))
-
-        Text(
-            stringResource(R.string.settings),
-            color = SpotifyWhite,
-            fontSize = 16.sp,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
-        )
+        AccountSectionHeader(stringResource(R.string.account_section_appearance))
 
         val audioContext = androidx.compose.ui.platform.LocalContext.current
 
@@ -170,13 +155,13 @@ fun AccountScreen(vm: SpotifyViewModel) {
         ListItem(
             headlineContent = { Text(stringResource(R.string.language), color = SpotifyWhite) },
             supportingContent = { Text(currentLanguageLabel, color = SpotifyLightGray) },
-            leadingContent = { Icon(Icons.Default.Language, null, tint = SpotifyLightGray) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.Language, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable { showLanguagePicker = true }
         )
         if (showLanguagePicker) {
-            AlertDialog(
+            TightAlertDialog(
                 onDismissRequest = { showLanguagePicker = false },
                 title = { Text(stringResource(R.string.language), color = SpotifyWhite) },
                 text = {
@@ -204,6 +189,71 @@ fun AccountScreen(vm: SpotifyViewModel) {
             )
         }
 
+        // Lyrics animation direction (Appearance)
+        val lyricsAnim by vm.lyricsAnimDirection.collectAsState()
+        var showLyricsPicker by remember { mutableStateOf(false) }
+        val lyricsLabel = if (lyricsAnim == "horizontal") stringResource(R.string.lyrics_horizontal) else stringResource(R.string.lyrics_vertical)
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.lyrics_animation), color = SpotifyWhite) },
+            supportingContent = { Text(lyricsLabel, color = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.MusicNote, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showLyricsPicker = true }
+        )
+        if (showLyricsPicker) {
+            TightAlertDialog(
+                onDismissRequest = { showLyricsPicker = false },
+                title = { Text(stringResource(R.string.lyrics_animation), color = SpotifyWhite) },
+                text = {
+                    Column {
+                        Text(stringResource(R.string.lyrics_anim_desc),
+                            color = SpotifyLightGray, fontSize = 13.sp)
+                        Spacer(Modifier.height(12.dp))
+                        listOf(
+                            "vertical" to stringResource(R.string.lyrics_vertical),
+                            "horizontal" to stringResource(R.string.lyrics_horizontal)
+                        ).forEach { (value, label) ->
+                            Row(
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        vm.setLyricsAnimDirection(value, audioContext)
+                                        showLyricsPicker = false
+                                    }
+                                    .padding(vertical = 12.dp, horizontal = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(
+                                    selected = lyricsAnim == value,
+                                    onClick = {
+                                        vm.setLyricsAnimDirection(value, audioContext)
+                                        showLyricsPicker = false
+                                    },
+                                    colors = RadioButtonDefaults.colors(
+                                        selectedColor = animatedPrimary,
+                                        unselectedColor = SpotifyLightGray
+                                    )
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(label, color = SpotifyWhite, fontSize = 15.sp)
+                            }
+                        }
+                    }
+                },
+                containerColor = SpotifyGray,
+                confirmButton = {},
+                dismissButton = {
+                    TextButton(onClick = { showLyricsPicker = false }) {
+                        Text(stringResource(R.string.cancel), color = SpotifyLightGray)
+                    }
+                }
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+        AccountSectionHeader(stringResource(R.string.account_section_playback))
+
         // Audio settings
         val audioSource by vm.preferredAudioSource.collectAsState()
         val isLossless = audioSource == "tidal" || audioSource == "qobuz"
@@ -219,7 +269,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                 if (isLossless) losslessOnText else losslessOffText,
                 color = SpotifyLightGray
             ) },
-            leadingContent = { Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.MusicNote, null, tint = SpotifyLightGray) },
             trailingContent = {
                 Switch(
                     checked = isLossless,
@@ -251,12 +301,12 @@ fun AccountScreen(vm: SpotifyViewModel) {
                     color = SpotifyLightGray
                 ) },
                 leadingContent = { Spacer(Modifier.width(24.dp)) },
-                trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+                trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                 modifier = Modifier.clickable { showProviderPicker = true }
             )
             if (showProviderPicker) {
-                AlertDialog(
+                TightAlertDialog(
                     onDismissRequest = { showProviderPicker = false },
                     title = { Text(stringResource(R.string.lossless_provider), color = SpotifyWhite) },
                     text = {
@@ -315,7 +365,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                 if (canvasOn) stringResource(R.string.canvas_on) else stringResource(R.string.canvas_off),
                 color = SpotifyLightGray
             ) },
-            leadingContent = { Icon(Icons.Default.PlayCircle, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.PlayCircle, null, tint = SpotifyLightGray) },
             trailingContent = {
                 Switch(
                     checked = canvasOn,
@@ -331,81 +381,19 @@ fun AccountScreen(vm: SpotifyViewModel) {
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
         )
 
-        // Lyrics animation direction
-        val lyricsAnim by vm.lyricsAnimDirection.collectAsState()
-        var showLyricsPicker by remember { mutableStateOf(false) }
-        val lyricsLabel = if (lyricsAnim == "horizontal") stringResource(R.string.lyrics_horizontal) else stringResource(R.string.lyrics_vertical)
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.lyrics_animation), color = SpotifyWhite) },
-            supportingContent = { Text(lyricsLabel, color = SpotifyLightGray) },
-            leadingContent = { Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-            modifier = Modifier.clickable { showLyricsPicker = true }
-        )
-        if (showLyricsPicker) {
-            AlertDialog(
-                onDismissRequest = { showLyricsPicker = false },
-                title = { Text(stringResource(R.string.lyrics_animation), color = SpotifyWhite) },
-                text = {
-                    Column {
-                        Text(stringResource(R.string.lyrics_anim_desc),
-                            color = SpotifyLightGray, fontSize = 13.sp)
-                        Spacer(Modifier.height(12.dp))
-                        listOf(
-                            "vertical" to stringResource(R.string.lyrics_vertical),
-                            "horizontal" to stringResource(R.string.lyrics_horizontal)
-                        ).forEach { (value, label) ->
-                            Row(
-                                Modifier
-                                    .fillMaxWidth()
-                                    .clickable {
-                                        vm.setLyricsAnimDirection(value, audioContext)
-                                        showLyricsPicker = false
-                                    }
-                                    .padding(vertical = 12.dp, horizontal = 4.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                RadioButton(
-                                    selected = lyricsAnim == value,
-                                    onClick = {
-                                        vm.setLyricsAnimDirection(value, audioContext)
-                                        showLyricsPicker = false
-                                    },
-                                    colors = RadioButtonDefaults.colors(
-                                        selectedColor = animatedPrimary,
-                                        unselectedColor = SpotifyLightGray
-                                    )
-                                )
-                                Spacer(Modifier.width(8.dp))
-                                Text(label, color = SpotifyWhite, fontSize = 15.sp)
-                            }
-                        }
-                    }
-                },
-                containerColor = SpotifyGray,
-                confirmButton = {},
-                dismissButton = {
-                    TextButton(onClick = { showLyricsPicker = false }) {
-                        Text(stringResource(R.string.cancel), color = SpotifyLightGray)
-                    }
-                }
-            )
-        }
-
         // Content region picker
         val currentRegion by vm.contentRegion.collectAsState()
         var showRegionPicker by remember { mutableStateOf(false) }
         ListItem(
             headlineContent = { Text(stringResource(R.string.content_region), color = SpotifyWhite) },
             supportingContent = { Text(currentRegion, color = SpotifyLightGray) },
-            leadingContent = { Icon(Icons.Default.Language, null, tint = SpotifyLightGray) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.Language, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable { showRegionPicker = true }
         )
         if (showRegionPicker) {
-            AlertDialog(
+            TightAlertDialog(
                 onDismissRequest = { showRegionPicker = false },
                 title = { Text(stringResource(R.string.content_region), color = SpotifyWhite) },
                 text = {
@@ -463,6 +451,18 @@ fun AccountScreen(vm: SpotifyViewModel) {
             )
         }
 
+        // Connect to device (Playback)
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.connect_to_device), color = SpotifyWhite) },
+            leadingContent = { Icon(Icons.Rounded.Devices, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { vm.loadDevices(); vm.showDevices.value = true }
+        )
+
+        Spacer(Modifier.height(24.dp))
+        AccountSectionHeader(stringResource(R.string.account_section_notifications))
+
         // Notification button options
         val notifLikeLabel = stringResource(R.string.notif_like)
         val notifShuffleLabel = stringResource(R.string.notif_shuffle)
@@ -485,13 +485,13 @@ fun AccountScreen(vm: SpotifyViewModel) {
         ListItem(
             headlineContent = { Text(stringResource(R.string.notification_left_button), color = SpotifyWhite) },
             supportingContent = { Text(buttonLabel(leftButton), color = SpotifyLightGray) },
-            leadingContent = { Icon(Icons.Default.Notifications, null, tint = SpotifyLightGray) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.Notifications, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable { showLeftPicker = true }
         )
         if (showLeftPicker) {
-            AlertDialog(
+            TightAlertDialog(
                 onDismissRequest = { showLeftPicker = false },
                 title = { Text(stringResource(R.string.notification_button_left), color = SpotifyWhite) },
                 text = {
@@ -526,13 +526,13 @@ fun AccountScreen(vm: SpotifyViewModel) {
         ListItem(
             headlineContent = { Text(stringResource(R.string.notification_right_button), color = SpotifyWhite) },
             supportingContent = { Text(buttonLabel(rightButton), color = SpotifyLightGray) },
-            leadingContent = { Icon(Icons.Default.Notifications, null, tint = SpotifyLightGray) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.Notifications, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable { showRightPicker = true }
         )
         if (showRightPicker) {
-            AlertDialog(
+            TightAlertDialog(
                 onDismissRequest = { showRightPicker = false },
                 title = { Text(stringResource(R.string.notification_button_right), color = SpotifyWhite) },
                 text = {
@@ -561,31 +561,13 @@ fun AccountScreen(vm: SpotifyViewModel) {
             )
         }
 
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.connect_to_device), color = SpotifyWhite) },
-            leadingContent = { Icon(Icons.Default.Devices, null, tint = SpotifyLightGray) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-            modifier = Modifier.clickable { vm.loadDevices(); vm.showDevices.value = true }
-        )
-
         Spacer(Modifier.height(24.dp))
-
-        HorizontalDivider(color = SpotifyGray, modifier = Modifier.padding(horizontal = 16.dp))
-
-        // About section
-        Text(
-            stringResource(R.string.about),
-            color = SpotifyWhite,
-            fontSize = 16.sp,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
-        )
+        AccountSectionHeader(stringResource(R.string.about))
 
         ListItem(
             headlineContent = { Text(stringResource(R.string.app_version), color = SpotifyWhite) },
             supportingContent = { Text(BuildConfig.VERSION_NAME, color = SpotifyLightGray) },
-            leadingContent = { Icon(Icons.Default.Info, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.Info, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
         )
 
@@ -608,16 +590,15 @@ fun AccountScreen(vm: SpotifyViewModel) {
             ) },
             leadingContent = {
                 if (isChecking) {
-                    CircularProgressIndicator(
+                    LoadingIndicator(
                         modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp,
                         color = animatedPrimary
                     )
                 } else {
-                    Icon(Icons.Default.SystemUpdate, null, tint = SpotifyLightGray)
+                    Icon(Icons.Rounded.SystemUpdate, null, tint = SpotifyLightGray)
                 }
             },
-            trailingContent = { if (!isChecking) Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            trailingContent = { if (!isChecking) Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable(enabled = !isChecking) {
                 isChecking = true
@@ -649,8 +630,8 @@ fun AccountScreen(vm: SpotifyViewModel) {
         ListItem(
             headlineContent = { Text(stringResource(R.string.release_notes), color = SpotifyWhite) },
             supportingContent = { Text(stringResource(R.string.view_changelog), color = SpotifyLightGray) },
-            leadingContent = { Icon(Icons.Default.Description, null, tint = SpotifyLightGray) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.Description, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable { showReleaseNotes = true }
         )
@@ -660,19 +641,10 @@ fun AccountScreen(vm: SpotifyViewModel) {
         }
 
         Spacer(Modifier.height(24.dp))
-
-        HorizontalDivider(color = SpotifyGray, modifier = Modifier.padding(horizontal = 16.dp))
-
-        Text(
-            stringResource(R.string.special_thanks),
-            color = SpotifyWhite,
-            fontSize = 16.sp,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
-        )
+        AccountSectionHeader(stringResource(R.string.special_thanks))
 
         ListItem(
-            headlineContent = { Text("Cinnabar \uD83E\uDDFC", color = SpotifyWhite) },
+            headlineContent = { Text("Cinnabar 🧼", color = SpotifyWhite) },
             leadingContent = {
                 AsyncImage(
                     model = "https://cdn.discordapp.com/avatars/823656705350565898/02562d1feab0425121ca6fabc7f1d66e.webp?size=1024",
@@ -702,8 +674,8 @@ fun AccountScreen(vm: SpotifyViewModel) {
         val context = androidx.compose.ui.platform.LocalContext.current
         ListItem(
             headlineContent = { Text(stringResource(R.string.log_out), color = Color(0xFFE57373)) },
-            leadingContent = { Icon(Icons.AutoMirrored.Filled.ExitToApp, null, tint = Color(0xFFE57373)) },
-            trailingContent = { Icon(Icons.Default.ChevronRight, null, tint = SpotifyLightGray) },
+            leadingContent = { Icon(Icons.AutoMirrored.Rounded.ExitToApp, null, tint = Color(0xFFE57373)) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable {
                 clearCookies(context)
@@ -711,4 +683,16 @@ fun AccountScreen(vm: SpotifyViewModel) {
             }
         )
     }
+}
+
+@Composable
+private fun AccountSectionHeader(title: String) {
+    HorizontalDivider(color = SpotifyGray, modifier = Modifier.padding(horizontal = 16.dp))
+    Text(
+        title,
+        color = SpotifyWhite,
+        fontSize = 16.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
+    )
 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.screens
 
 import androidx.compose.foundation.background
@@ -8,18 +10,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Pause
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Share
-import androidx.compose.material.icons.filled.Shuffle
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.filled.Album
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material.icons.rounded.Share
+import androidx.compose.material.icons.rounded.Shuffle
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Person
 import androidx.compose.ui.draw.clip
 import androidx.compose.material3.*
 import androidx.compose.runtime.LaunchedEffect
@@ -53,7 +55,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
 
     if (isLoading) {
         Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator(color = SpotifyLightGray, strokeWidth = 3.dp)
+            LoadingIndicator(color = SpotifyLightGray)
         }
         return
     }
@@ -88,7 +90,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                         .clickable { vm.goBack() },
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                    Icon(Icons.AutoMirrored.Rounded.ArrowBack, stringResource(R.string.back), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                 }
                 Column(Modifier.align(Alignment.BottomStart).padding(16.dp)) {
                     Text(
@@ -211,7 +213,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                     } else {
                         IconButton(onClick = { vm.toggleDetailSaved(detail.type, detailId) }) {
                             Icon(
-                                if (saved) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                if (saved) Icons.Rounded.Favorite else Icons.Filled.FavoriteBorder,
                                 stringResource(R.string.save),
                                 tint = if (saved) accentColor else SpotifyWhite,
                                 modifier = Modifier.size(28.dp)
@@ -224,7 +226,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                 // KotifyClient supports for the current detail type.
                 var showHeaderMenu by remember { mutableStateOf(false) }
                 IconButton(onClick = { showHeaderMenu = true }) {
-                    Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(24.dp))
+                    Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(24.dp))
                 }
                 if (showHeaderMenu) {
                     DetailHeaderMenu(
@@ -240,7 +242,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                 // Shuffle
                 IconButton(onClick = { vm.toggleShuffle() }) {
                     Icon(
-                        Icons.Default.Shuffle, stringResource(R.string.shuffle),
+                        Icons.Rounded.Shuffle, stringResource(R.string.shuffle),
                         tint = if (shuffling) accentColor else SpotifyWhite,
                         modifier = Modifier.size(24.dp)
                     )
@@ -265,7 +267,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
-                        if (isPlayingThis) Icons.Default.Pause else Icons.Default.PlayArrow,
+                        if (isPlayingThis) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
                         stringResource(R.string.play),
                         tint = Color.Black,
                         modifier = Modifier.size(28.dp)
@@ -302,7 +304,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
         if (isLoadingMore) {
             item {
                 Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator(color = SpotifyLightGray, strokeWidth = 2.dp, modifier = Modifier.size(24.dp))
+                    LoadingIndicator(color = SpotifyLightGray, modifier = Modifier.size(24.dp))
                 }
             }
         }
@@ -534,7 +536,7 @@ private fun ArtistTrackRow(
         // 3-dot menu
         var showMenu by remember { mutableStateOf(false) }
         IconButton(onClick = { showMenu = true }, modifier = Modifier.size(36.dp)) {
-            Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+            Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
         if (showMenu) {
             val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -574,19 +576,19 @@ private fun ArtistTrackRow(
                 val likeLabel = stringResource(R.string.like)
                 val visitAlbumLabel = stringResource(R.string.visit_album)
                 val items = listOf(
-                    Triple(Icons.AutoMirrored.Filled.QueueMusic, addQueueLabel) {
+                    Triple(Icons.AutoMirrored.Rounded.QueueMusic, addQueueLabel) {
                         vm.addToQueue(track.uri); showMenu = false
                     },
-                    Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addPlaylistLabel) {
+                    Triple(Icons.AutoMirrored.Rounded.PlaylistAdd, addPlaylistLabel) {
                         showMenu = false; vm.showPlaylistPickerForTrack(track.uri)
                     },
-                    Triple(Icons.Default.Favorite, likeLabel) {
+                    Triple(Icons.Rounded.Favorite, likeLabel) {
                         vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
                     },
-                    Triple(Icons.Default.Album, visitAlbumLabel) {
+                    Triple(Icons.Rounded.Album, visitAlbumLabel) {
                         showMenu = false; vm.openAlbumForTrack(track.uri)
                     },
-                    Triple(Icons.Default.Share, shareLabel) {
+                    Triple(Icons.Rounded.Share, shareLabel) {
                         showMenu = false
                         val id = track.uri.removePrefix("spotify:track:")
                         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
@@ -656,7 +658,7 @@ private fun AlbumTrackRow(
         }
         var showMenu by remember { mutableStateOf(false) }
         IconButton(onClick = { showMenu = true }, modifier = Modifier.size(36.dp)) {
-            Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
+            Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
         if (showMenu) {
             val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -694,19 +696,19 @@ private fun AlbumTrackRow(
                 val likeLabel = stringResource(R.string.like)
                 val visitArtistLabel = stringResource(R.string.visit_artist)
                 val items = listOf(
-                    Triple(Icons.AutoMirrored.Filled.QueueMusic, addQueueLabel) {
+                    Triple(Icons.AutoMirrored.Rounded.QueueMusic, addQueueLabel) {
                         vm.addToQueue(track.uri); showMenu = false
                     },
-                    Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addPlaylistLabel) {
+                    Triple(Icons.AutoMirrored.Rounded.PlaylistAdd, addPlaylistLabel) {
                         showMenu = false; vm.showPlaylistPickerForTrack(track.uri)
                     },
-                    Triple(Icons.Default.Favorite, likeLabel) {
+                    Triple(Icons.Rounded.Favorite, likeLabel) {
                         vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
                     },
-                    Triple(Icons.Default.Person, visitArtistLabel) {
+                    Triple(Icons.Rounded.Person, visitArtistLabel) {
                         showMenu = false; vm.openArtistForTrack(track.uri)
                     },
-                    Triple(Icons.Default.Share, shareLabel) {
+                    Triple(Icons.Rounded.Share, shareLabel) {
                         showMenu = false
                         val id = track.uri.removePrefix("spotify:track:")
                         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
@@ -787,7 +789,7 @@ private fun DetailHeaderMenu(
         val items = buildList<Triple<androidx.compose.ui.graphics.vector.ImageVector, String, () -> Unit>> {
             if (!isCollection) {
                 val id = detail.uri.substringAfterLast(":")
-                add(Triple(Icons.Default.Share, shareLabel) {
+                add(Triple(Icons.Rounded.Share, shareLabel) {
                     onDismiss()
                     val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
                         this.type = "text/plain"
@@ -797,17 +799,17 @@ private fun DetailHeaderMenu(
                 })
             }
             if (hasTracks && !isArtist) {
-                add(Triple(Icons.AutoMirrored.Filled.QueueMusic, addToQueueLabel) {
+                add(Triple(Icons.AutoMirrored.Rounded.QueueMusic, addToQueueLabel) {
                     onDismiss()
                     vm.addAllToQueue(trackUris)
                 })
-                add(Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addToPlaylistLabel) {
+                add(Triple(Icons.AutoMirrored.Rounded.PlaylistAdd, addToPlaylistLabel) {
                     onDismiss()
                     vm.showPlaylistPickerForTracks(trackUris)
                 })
             }
             if (isAlbum && detail.artistUri != null) {
-                add(Triple(Icons.Default.Person, visitArtistLabel) {
+                add(Triple(Icons.Rounded.Person, visitArtistLabel) {
                     onDismiss()
                     val artistId = detail.artistUri.substringAfterLast(":")
                     vm.openArtist(artistId)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -27,8 +27,8 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.MusicNote
-import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.rounded.MusicNote
+import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
@@ -239,7 +239,7 @@ fun HomeSectionCard(item: kotify.api.home.HomeSectionItem, vm: SpotifyViewModel,
             url = item.imageUrl,
             modifier = Modifier.size(140.dp),
             shape = if (isArtist) CircleShape else RoundedCornerShape(8.dp),
-            icon = if (isArtist) Icons.Default.Person else Icons.Default.MusicNote
+            icon = if (isArtist) Icons.Rounded.Person else Icons.Rounded.MusicNote
         )
         Spacer(Modifier.height(8.dp))
         Text(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
@@ -27,17 +27,16 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Album
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.automirrored.rounded.List
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material.icons.filled.GridView
-import androidx.compose.material.icons.filled.Person
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material.icons.filled.SwapVert
-import androidx.compose.material3.AlertDialog
+import androidx.compose.material.icons.rounded.GridView
+import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.SwapVert
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
@@ -68,6 +67,7 @@ import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.R
 import ch.snepilatch.app.data.LibraryItem
 import ch.snepilatch.app.ui.components.SpotifyImage
+import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
@@ -123,10 +123,10 @@ fun LibraryScreen(vm: SpotifyViewModel) {
             Text(stringResource(R.string.library_title), color = SpotifyWhite, fontSize = 24.sp, fontWeight = FontWeight.Bold,
                 modifier = Modifier.weight(1f))
             IconButton(onClick = { searchActive = !searchActive; if (!searchActive) searchQuery = "" }) {
-                Icon(Icons.Default.Search, stringResource(R.string.search), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                Icon(Icons.Rounded.Search, stringResource(R.string.search), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
             }
             IconButton(onClick = { showCreateDialog = true }) {
-                Icon(Icons.Default.Add, stringResource(R.string.library_create), tint = SpotifyWhite, modifier = Modifier.size(26.dp))
+                Icon(Icons.Rounded.Add, stringResource(R.string.library_create), tint = SpotifyWhite, modifier = Modifier.size(26.dp))
             }
         }
 
@@ -145,11 +145,11 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                         color = SpotifyLightGray.copy(alpha = 0.7f)
                     )
                 },
-                leadingIcon = { Icon(Icons.Default.Search, null, tint = SpotifyLightGray) },
+                leadingIcon = { Icon(Icons.Rounded.Search, null, tint = SpotifyLightGray) },
                 trailingIcon = {
                     if (searchQuery.isNotEmpty()) {
                         IconButton(onClick = { searchQuery = "" }) {
-                            Icon(Icons.Default.Close, stringResource(R.string.clear), tint = SpotifyLightGray)
+                            Icon(Icons.Rounded.Close, stringResource(R.string.clear), tint = SpotifyLightGray)
                         }
                     }
                 },
@@ -208,7 +208,7 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                     Modifier.clickable { showSortMenu = true }.padding(vertical = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(Icons.Default.SwapVert, stringResource(R.string.library_sort), tint = SpotifyLightGray, modifier = Modifier.size(16.dp))
+                    Icon(Icons.Rounded.SwapVert, stringResource(R.string.library_sort), tint = SpotifyLightGray, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))
                     val sortLabel = when (sortMode) {
                         "alpha" -> stringResource(R.string.library_sort_alpha)
@@ -239,7 +239,7 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                 modifier = Modifier.size(32.dp)
             ) {
                 Icon(
-                    if (gridView) Icons.AutoMirrored.Filled.List else Icons.Default.GridView,
+                    if (gridView) Icons.AutoMirrored.Rounded.List else Icons.Rounded.GridView,
                     stringResource(R.string.library_toggle_view),
                     tint = SpotifyLightGray,
                     modifier = Modifier.size(20.dp)
@@ -333,9 +333,9 @@ fun LibraryGridCard(item: LibraryItem, vm: SpotifyViewModel) {
                 modifier = Modifier.fillMaxWidth().aspectRatio(1f),
                 shape = if (isArtist) CircleShape else RoundedCornerShape(8.dp),
                 icon = when (item.type) {
-                    "artist" -> Icons.Default.Person
-                    "album" -> Icons.Default.Album
-                    else -> Icons.AutoMirrored.Filled.QueueMusic
+                    "artist" -> Icons.Rounded.Person
+                    "album" -> Icons.Rounded.Album
+                    else -> Icons.AutoMirrored.Rounded.QueueMusic
                 }
             )
         }
@@ -374,7 +374,7 @@ fun LibraryListItem(item: LibraryItem, vm: SpotifyViewModel) {
                     .background(Brush.linearGradient(listOf(Color(0xFF450AF5), Color(0xFFC4EAFD)))),
                 contentAlignment = Alignment.Center
             ) {
-                Icon(Icons.Default.FavoriteBorder, null, tint = SpotifyWhite, modifier = Modifier.size(28.dp))
+                Icon(Icons.Filled.FavoriteBorder, null, tint = SpotifyWhite, modifier = Modifier.size(28.dp))
             }
         } else {
             SpotifyImage(
@@ -382,9 +382,9 @@ fun LibraryListItem(item: LibraryItem, vm: SpotifyViewModel) {
                 modifier = Modifier.size(56.dp),
                 shape = if (isArtist) CircleShape else RoundedCornerShape(4.dp),
                 icon = when (item.type) {
-                    "artist" -> Icons.Default.Person
-                    "album" -> Icons.Default.Album
-                    else -> Icons.AutoMirrored.Filled.QueueMusic
+                    "artist" -> Icons.Rounded.Person
+                    "album" -> Icons.Rounded.Album
+                    else -> Icons.AutoMirrored.Rounded.QueueMusic
                 }
             )
         }
@@ -403,7 +403,7 @@ fun LibraryListItem(item: LibraryItem, vm: SpotifyViewModel) {
 @Composable
 fun CreatePlaylistDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
     var name by remember { mutableStateOf("") }
-    AlertDialog(
+    TightAlertDialog(
         onDismissRequest = onDismiss,
         containerColor = SpotifyElevated,
         title = { Text(stringResource(R.string.library_create_playlist), color = SpotifyWhite, fontWeight = FontWeight.Bold) },
@@ -438,7 +438,7 @@ fun CreatePlaylistDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
 
 @Composable
 private fun LibraryRemoveDialog(item: LibraryItem, vm: SpotifyViewModel, onDismiss: () -> Unit) {
-    AlertDialog(
+    TightAlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.library_remove_title), color = SpotifyWhite) },
         text = { Text(stringResource(R.string.library_remove_message, item.name), color = SpotifyLightGray) },

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
@@ -14,7 +14,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -40,7 +40,7 @@ fun SpotifyLoginScreen(vm: SpotifyViewModel) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = { vm.needsLogin.value = false }) {
-                Icon(Icons.Default.Close, stringResource(R.string.close), tint = SpotifyWhite)
+                Icon(Icons.Rounded.Close, stringResource(R.string.close), tint = SpotifyWhite)
             }
             Spacer(Modifier.width(8.dp))
             Text(stringResource(R.string.login_title), color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.Bold)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.screens
 
 import androidx.compose.animation.animateColorAsState
@@ -12,7 +14,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.draw.clip
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -158,7 +161,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    when (playback.repeatMode) { "track" -> Icons.Default.RepeatOne; else -> Icons.Default.Repeat },
+                                    when (playback.repeatMode) { "track" -> Icons.Rounded.RepeatOne; else -> Icons.Rounded.Repeat },
                                     stringResource(R.string.repeat),
                                     tint = if (playback.repeatMode != "off") animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(18.dp)
@@ -168,7 +171,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 Modifier.size(36.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.skipPrevious() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                Icon(Icons.Rounded.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                             }
                             Box(
                                 Modifier
@@ -179,10 +182,10 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 if (streamLoading) {
-                                    CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 2.dp, modifier = Modifier.size(20.dp))
+                                    LoadingIndicator(color = SpotifyWhite, modifier = Modifier.size(20.dp))
                                 } else {
                                     Icon(
-                                        if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
+                                        if (playback.isPaused || !playback.isPlaying) Icons.Rounded.PlayArrow else Icons.Rounded.Pause,
                                         stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(26.dp)
                                     )
                                 }
@@ -191,7 +194,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 Modifier.size(36.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.skipNext() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                Icon(Icons.Rounded.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                             }
                             Box(
                                 Modifier.size(36.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable {
@@ -201,7 +204,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                    if (isLiked) Icons.Rounded.Favorite else Icons.Filled.FavoriteBorder,
                                     stringResource(R.string.like),
                                     tint = if (isLiked) animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(18.dp)
@@ -221,13 +224,13 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                         when {
                             isLoading -> {
                                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                    CircularProgressIndicator(color = animatedPrimary, strokeWidth = 3.dp)
+                                    LoadingIndicator(color = animatedPrimary)
                                 }
                             }
                             lyrics == null || lyrics?.lines.isNullOrEmpty() -> {
                                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                        Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray.copy(alpha = 0.5f), modifier = Modifier.size(48.dp))
+                                        Icon(Icons.Rounded.MusicNote, null, tint = SpotifyLightGray.copy(alpha = 0.5f), modifier = Modifier.size(48.dp))
                                         Spacer(Modifier.height(12.dp))
                                         Text(stringResource(R.string.lyrics_not_available), color = SpotifyLightGray, fontSize = 16.sp)
                                     }
@@ -270,7 +273,7 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                                 .clickable { vm.goBack() },
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(Icons.Default.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                            Icon(Icons.Rounded.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
                         }
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             Text(track?.name ?: "", color = SpotifyWhite, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, maxLines = 1)
@@ -282,13 +285,13 @@ fun LyricsScreen(vm: SpotifyViewModel) {
                     when {
                         isLoading -> {
                             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                CircularProgressIndicator(color = animatedPrimary, strokeWidth = 3.dp)
+                                LoadingIndicator(color = animatedPrimary)
                             }
                         }
                         lyrics == null || lyrics?.lines.isNullOrEmpty() -> {
                             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                    Icon(Icons.Default.MusicNote, null, tint = SpotifyLightGray.copy(alpha = 0.5f), modifier = Modifier.size(48.dp))
+                                    Icon(Icons.Rounded.MusicNote, null, tint = SpotifyLightGray.copy(alpha = 0.5f), modifier = Modifier.size(48.dp))
                                     Spacer(Modifier.height(12.dp))
                                     Text(stringResource(R.string.lyrics_not_available), color = SpotifyLightGray, fontSize = 16.sp)
                                 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.screens
 
 import androidx.compose.animation.animateColorAsState
@@ -14,9 +16,10 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
-import androidx.compose.material.icons.automirrored.filled.QueueMusic
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -42,6 +45,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import ch.snepilatch.app.ui.components.SpotifyImage
+import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.formatTime
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
@@ -257,7 +261,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.goBack() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+                                Icon(Icons.Rounded.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
                             }
                             val ctx by vm.playingContext.collectAsState()
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -337,7 +341,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                    if (isLiked) Icons.Rounded.Favorite else Icons.Filled.FavoriteBorder,
                                     stringResource(R.string.like),
                                     tint = if (isLiked) animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(24.dp)
@@ -390,7 +394,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 Modifier.size(44.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.toggleShuffle() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.Shuffle, stringResource(R.string.shuffle),
+                                Icon(Icons.Rounded.Shuffle, stringResource(R.string.shuffle),
                                     tint = if (playback.isShuffling) animatedPrimary else SpotifyWhite,
                                     modifier = Modifier.size(20.dp))
                             }
@@ -398,7 +402,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 Modifier.size(48.dp).background(buttonBg, CircleShape).clip(CircleShape).clickable { vm.skipPrevious() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
+                                Icon(Icons.Rounded.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
                             }
                             Box(
                                 Modifier
@@ -409,10 +413,10 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 if (streamLoading) {
-                                    CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 3.dp, modifier = Modifier.size(26.dp))
+                                    LoadingIndicator(color = SpotifyWhite, modifier = Modifier.size(26.dp))
                                 } else {
                                     Icon(
-                                        if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
+                                        if (playback.isPaused || !playback.isPlaying) Icons.Rounded.PlayArrow else Icons.Rounded.Pause,
                                         stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(32.dp)
                                     )
                                 }
@@ -425,9 +429,9 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 if (nextLoading) {
-                                    CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 2.dp, modifier = Modifier.size(20.dp))
+                                    LoadingIndicator(color = SpotifyWhite, modifier = Modifier.size(20.dp))
                                 } else {
-                                    Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
+                                    Icon(Icons.Rounded.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
                                 }
                             }
                             Box(
@@ -435,7 +439,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    when (playback.repeatMode) { "track" -> Icons.Default.RepeatOne; else -> Icons.Default.Repeat },
+                                    when (playback.repeatMode) { "track" -> Icons.Rounded.RepeatOne; else -> Icons.Rounded.Repeat },
                                     stringResource(R.string.repeat),
                                     tint = if (playback.repeatMode != "off") animatedPrimary else SpotifyWhite,
                                     modifier = Modifier.size(20.dp)
@@ -463,10 +467,10 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             onDispose { am.unregisterAudioDeviceCallback(cb) }
                         }
                         val audioIcon = when (audioType) {
-                            "bluetooth" -> Icons.Default.Bluetooth
-                            "wired" -> Icons.Default.Headphones
-                            "usb" -> Icons.Default.Usb
-                            else -> Icons.Default.Speaker
+                            "bluetooth" -> Icons.Rounded.Bluetooth
+                            "wired" -> Icons.Rounded.Headphones
+                            "usb" -> Icons.Rounded.Usb
+                            else -> Icons.Rounded.Speaker
                         }
                         Row(
                             Modifier.fillMaxWidth(),
@@ -512,7 +516,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                         },
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    Icon(Icons.Default.Share, stringResource(R.string.share), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
+                                    Icon(Icons.Rounded.Share, stringResource(R.string.share), tint = SpotifyWhite, modifier = Modifier.size(20.dp))
                                 }
                                 Box(
                                     Modifier
@@ -523,7 +527,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     contentAlignment = Alignment.Center
                                 ) {
                                     Icon(
-                                        Icons.AutoMirrored.Filled.QueueMusic,
+                                        Icons.AutoMirrored.Rounded.QueueMusic,
                                         stringResource(R.string.queue),
                                         tint = SpotifyWhite,
                                         modifier = Modifier.size(20.dp)
@@ -571,7 +575,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.goBack() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
+                                Icon(Icons.Rounded.KeyboardArrowDown, stringResource(R.string.close), tint = SpotifyWhite, modifier = Modifier.size(28.dp))
                             }
                             val ctx by vm.playingContext.collectAsState()
                             Column(
@@ -612,7 +616,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.Tune, stringResource(R.string.equalizer), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(Icons.Rounded.Tune, stringResource(R.string.equalizer), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
                             }
                     }
 
@@ -681,7 +685,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 contentAlignment = Alignment.Center
                             ) {
                                 Icon(
-                                    if (isLiked) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                    if (isLiked) Icons.Rounded.Favorite else Icons.Filled.FavoriteBorder,
                                     stringResource(R.string.like),
                                     tint = if (isLiked) animatedPrimary else SpotifyWhite.copy(alpha = 0.7f),
                                     modifier = Modifier.size(28.dp)
@@ -749,7 +753,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 .clickable { vm.toggleShuffle() },
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(Icons.Default.Shuffle, stringResource(R.string.shuffle),
+                            Icon(Icons.Rounded.Shuffle, stringResource(R.string.shuffle),
                                 tint = if (playback.isShuffling) animatedPrimary else SpotifyWhite,
                                 modifier = Modifier.size(22.dp))
                         }
@@ -762,7 +766,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                 .clickable { vm.skipPrevious() },
                             contentAlignment = Alignment.Center
                         ) {
-                            Icon(Icons.Default.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(32.dp))
+                            Icon(Icons.Rounded.SkipPrevious, stringResource(R.string.previous), tint = SpotifyWhite, modifier = Modifier.size(32.dp))
                         }
                         // Play/Pause — large prominent button
                         Box(
@@ -777,14 +781,13 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             contentAlignment = Alignment.Center
                         ) {
                             if (streamLoading) {
-                                CircularProgressIndicator(
+                                LoadingIndicator(
                                     color = SpotifyWhite,
-                                    strokeWidth = 3.dp,
                                     modifier = Modifier.size(30.dp)
                                 )
                             } else {
                                 Icon(
-                                    if (playback.isPaused || !playback.isPlaying) Icons.Default.PlayArrow else Icons.Default.Pause,
+                                    if (playback.isPaused || !playback.isPlaying) Icons.Rounded.PlayArrow else Icons.Rounded.Pause,
                                     stringResource(R.string.play_pause), tint = SpotifyWhite, modifier = Modifier.size(38.dp)
                                 )
                             }
@@ -802,9 +805,9 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             contentAlignment = Alignment.Center
                         ) {
                             if (nextLoading) {
-                                CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 2.dp, modifier = Modifier.size(22.dp))
+                                LoadingIndicator(color = SpotifyWhite, modifier = Modifier.size(22.dp))
                             } else {
-                                Icon(Icons.Default.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(32.dp))
+                                Icon(Icons.Rounded.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(32.dp))
                             }
                         }
                         // Repeat
@@ -817,7 +820,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(
-                                when (playback.repeatMode) { "track" -> Icons.Default.RepeatOne; else -> Icons.Default.Repeat },
+                                when (playback.repeatMode) { "track" -> Icons.Rounded.RepeatOne; else -> Icons.Rounded.Repeat },
                                 stringResource(R.string.repeat),
                                 tint = if (playback.repeatMode != "off") animatedPrimary else SpotifyWhite,
                                 modifier = Modifier.size(22.dp)
@@ -844,10 +847,10 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                         onDispose { am.unregisterAudioDeviceCallback(cb) }
                     }
                     val audioIcon = when (audioType) {
-                        "bluetooth" -> Icons.Default.Bluetooth
-                        "wired" -> Icons.Default.Headphones
-                        "usb" -> Icons.Default.Usb
-                        else -> Icons.Default.Speaker
+                        "bluetooth" -> Icons.Rounded.Bluetooth
+                        "wired" -> Icons.Rounded.Headphones
+                        "usb" -> Icons.Rounded.Usb
+                        else -> Icons.Rounded.Speaker
                     }
                     Row(
                         Modifier.fillMaxWidth(),
@@ -893,7 +896,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Default.Share, stringResource(R.string.share), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(Icons.Rounded.Share, stringResource(R.string.share), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
                             }
                             Box(
                                 Modifier
@@ -903,7 +906,12 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                                     .clickable { vm.openQueue() },
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.AutoMirrored.Filled.QueueMusic, stringResource(R.string.queue), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+                                Icon(
+                                    Icons.AutoMirrored.Rounded.QueueMusic,
+                                    stringResource(R.string.queue),
+                                    tint = SpotifyWhite,
+                                    modifier = Modifier.size(22.dp)
+                                )
                             }
                         }
                     }
@@ -918,7 +926,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
     if (showPlaylistPicker) {
         val libraryItems by vm.library.collectAsState()
         val playlists = libraryItems.filter { it.type == "playlist" }
-        AlertDialog(
+        TightAlertDialog(
             onDismissRequest = { showPlaylistPicker = false },
             title = { Text(stringResource(R.string.add_to_playlist), color = SpotifyWhite) },
             containerColor = SpotifyGray,
@@ -995,7 +1003,7 @@ private fun SourcePill(provider: String) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(3.dp)
     ) {
-        Icon(Icons.Default.MusicNote, null, tint = SpotifyWhite, modifier = Modifier.size(9.dp))
+        Icon(Icons.Rounded.MusicNote, null, tint = SpotifyWhite, modifier = Modifier.size(9.dp))
         Text(label, color = SpotifyWhite, fontSize = 9.sp, maxLines = 1)
     }
 }
@@ -1019,7 +1027,7 @@ private fun NowPlayingMenu(
             .clickable { onShowMore(true) },
         contentAlignment = Alignment.Center
     ) {
-        Icon(Icons.Default.MoreVert, stringResource(R.string.more), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
+        Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpotifyWhite, modifier = Modifier.size(22.dp))
     }
 
     if (showMore) {
@@ -1068,25 +1076,25 @@ private fun NowPlayingMenu(
             val devicesLabel = stringResource(R.string.devices)
             val shareLabel = stringResource(R.string.share)
             val items = listOf(
-                Triple(Icons.Default.MusicNote, lyricsLabel) {
+                Triple(Icons.Rounded.MusicNote, lyricsLabel) {
                     onShowMore(false); vm.openLyrics()
                 },
-                Triple(Icons.AutoMirrored.Filled.QueueMusic, addQueueLabel) {
+                Triple(Icons.AutoMirrored.Rounded.QueueMusic, addQueueLabel) {
                     track?.uri?.let { vm.addToQueue(it) }; onShowMore(false)
                 },
-                Triple(Icons.AutoMirrored.Filled.PlaylistAdd, addPlaylistLabel) {
+                Triple(Icons.AutoMirrored.Rounded.PlaylistAdd, addPlaylistLabel) {
                     onShowMore(false); onShowPlaylistPicker()
                 },
-                Triple(Icons.AutoMirrored.Filled.QueueMusic, viewQueueLabel) {
+                Triple(Icons.AutoMirrored.Rounded.QueueMusic, viewQueueLabel) {
                     vm.openQueue(); onShowMore(false)
                 },
-                Triple(Icons.Default.Album, visitAlbumLabel) {
+                Triple(Icons.Rounded.Album, visitAlbumLabel) {
                     onShowMore(false); vm.openAlbumFromCurrentTrack()
                 },
-                Triple(Icons.Default.Devices, devicesLabel) {
+                Triple(Icons.Rounded.Devices, devicesLabel) {
                     onShowMore(false); vm.loadDevices(); vm.showDevices.value = true
                 },
-                Triple(Icons.Default.Share, shareLabel) {
+                Triple(Icons.Rounded.Share, shareLabel) {
                     onShowMore(false)
                     track?.uri?.removePrefix("spotify:track:")?.let { id ->
                         val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -34,7 +34,7 @@ fun QueueScreen(vm: SpotifyViewModel) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = { vm.goBack() }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.back), tint = SpotifyWhite)
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, stringResource(R.string.back), tint = SpotifyWhite)
             }
             Text(stringResource(R.string.queue), color = SpotifyWhite, fontSize = 22.sp, fontWeight = FontWeight.Bold)
         }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.screens
 
 import androidx.compose.foundation.layout.*
@@ -5,9 +7,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -18,6 +20,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.R
+import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -66,7 +69,7 @@ fun ReleaseNotesScreen(onBack: () -> Unit) {
                 title = { Text(stringResource(R.string.release_notes), color = SpotifyWhite) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = SpotifyWhite)
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, null, tint = SpotifyWhite)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = SpotifyBlack)
@@ -76,20 +79,20 @@ fun ReleaseNotesScreen(onBack: () -> Unit) {
         when {
             isLoading -> {
                 Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
-                    CircularProgressIndicator(color = SpotifyLightGray)
+                    LoadingIndicator(color = SpotifyLightGray)
                 }
             }
             error != null -> {
                 Box(Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Icon(Icons.Default.ErrorOutline, null, tint = SpotifyLightGray, modifier = Modifier.size(64.dp))
+                        Icon(Icons.Rounded.ErrorOutline, null, tint = SpotifyLightGray, modifier = Modifier.size(64.dp))
                         Spacer(Modifier.height(16.dp))
                         Text(stringResource(R.string.release_load_failed), color = SpotifyWhite, fontSize = 18.sp)
                         Spacer(Modifier.height(8.dp))
                         Text(error!!, color = SpotifyLightGray, fontSize = 13.sp)
                         Spacer(Modifier.height(24.dp))
                         Button(onClick = { load() }) {
-                            Icon(Icons.Default.Refresh, null)
+                            Icon(Icons.Rounded.Refresh, null)
                             Spacer(Modifier.width(8.dp))
                             Text(stringResource(R.string.retry))
                         }
@@ -240,7 +243,7 @@ fun ReleaseNotesDialog(onDismiss: () -> Unit) {
         isLoading = false
     }
 
-    AlertDialog(
+    TightAlertDialog(
         onDismissRequest = onDismiss,
         containerColor = SpotifyDarkGray,
         title = { Text(stringResource(R.string.release_notes), color = SpotifyWhite) },
@@ -248,7 +251,7 @@ fun ReleaseNotesDialog(onDismiss: () -> Unit) {
             Box(Modifier.heightIn(max = 500.dp)) {
                 when {
                     isLoading -> Box(Modifier.fillMaxWidth().height(200.dp), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator(color = SpotifyLightGray)
+                        LoadingIndicator(color = SpotifyLightGray)
                     }
                     error != null -> Text(stringResource(R.string.release_load_failed_short, error ?: ""), color = SpotifyLightGray)
                     else -> LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3ExpressiveApi::class)
+
 package ch.snepilatch.app.ui.screens
 
 import android.content.Context
@@ -29,11 +31,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.North
-import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.North
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -125,11 +127,11 @@ fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel()) 
                 .clip(RoundedCornerShape(8.dp))
                 .focusRequester(focusRequester),
             placeholder = { Text(stringResource(R.string.search_field_placeholder), color = SpotifyLightGray.copy(alpha = 0.7f)) },
-            leadingIcon = { Icon(Icons.Default.Search, null, tint = SpotifyBlack) },
+            leadingIcon = { Icon(Icons.Rounded.Search, null, tint = SpotifyBlack) },
             trailingIcon = {
                 if (query.isNotEmpty()) {
                     IconButton(onClick = { searchVm.updateQuery("") }) {
-                        Icon(Icons.Default.Close, stringResource(R.string.search_clear), tint = SpotifyBlack)
+                        Icon(Icons.Rounded.Close, stringResource(R.string.search_clear), tint = SpotifyBlack)
                     }
                 }
             },
@@ -169,10 +171,9 @@ fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel()) 
             else -> {
                 AnimatedVisibility(visible = isSearching, enter = fadeIn(), exit = fadeOut()) {
                     Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator(
+                        LoadingIndicator(
                             color = SpotifyWhite,
-                            modifier = Modifier.size(24.dp),
-                            strokeWidth = 2.dp
+                            modifier = Modifier.size(24.dp)
                         )
                     }
                 }
@@ -245,7 +246,7 @@ private fun SuggestionsList(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    Icons.Default.Search,
+                    Icons.Rounded.Search,
                     null,
                     tint = SpotifyLightGray,
                     modifier = Modifier.size(20.dp)
@@ -253,7 +254,7 @@ private fun SuggestionsList(
                 Spacer(Modifier.width(16.dp))
                 Text(sug.text, color = SpotifyWhite, fontSize = 15.sp, modifier = Modifier.weight(1f))
                 Icon(
-                    Icons.Default.North,
+                    Icons.Rounded.North,
                     null,
                     tint = SpotifyLightGray.copy(alpha = 0.6f),
                     modifier = Modifier.size(16.dp)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -48,6 +48,7 @@ import ch.snepilatch.app.ui.components.BottomNav
 import ch.snepilatch.app.ui.components.DevicesDialog
 import ch.snepilatch.app.ui.components.MiniPlayer
 import ch.snepilatch.app.ui.components.SpotifyImage
+import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
@@ -176,7 +177,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
         if (showPicker) {
             val library by vm.library.collectAsState()
             val playlists = library.filter { it.type == "playlist" }
-            AlertDialog(
+            TightAlertDialog(
                 onDismissRequest = { vm.showPlaylistPicker.value = false },
                 title = { Text(stringResource(R.string.add_to_playlist), color = SpotifyWhite) },
                 text = {
@@ -246,7 +247,7 @@ fun LoadingScreen(
                     val progress = ((safeTotal - cooldownSecondsRemaining).toFloat() / safeTotal)
                         .coerceIn(0f, 1f)
 
-                    Icon(Icons.Default.CloudOff, null, tint = SpotifyLightGray, modifier = Modifier.size(48.dp))
+                    Icon(Icons.Rounded.CloudOff, null, tint = SpotifyLightGray, modifier = Modifier.size(48.dp))
                     Spacer(Modifier.height(16.dp))
                     Text(stringResource(R.string.rate_limited), color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(Modifier.height(8.dp))
@@ -267,7 +268,7 @@ fun LoadingScreen(
                     }
                 }
                 error != null -> {
-                    Icon(Icons.Default.CloudOff, null, tint = SpotifyLightGray, modifier = Modifier.size(48.dp))
+                    Icon(Icons.Rounded.CloudOff, null, tint = SpotifyLightGray, modifier = Modifier.size(48.dp))
                     Spacer(Modifier.height(16.dp))
                     Text(stringResource(R.string.connection_failed), color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(Modifier.height(8.dp))
@@ -286,7 +287,7 @@ fun LoadingScreen(
                     }
                 }
                 else -> {
-                    CircularProgressIndicator(color = SpotifyWhite, strokeWidth = 3.dp)
+                    CircularWavyProgressIndicator(color = SpotifyWhite)
                     Spacer(Modifier.height(20.dp))
                     Text(stringResource(R.string.connecting_to_spotify), color = SpotifyLightGray, fontSize = 15.sp)
                 }

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -241,4 +241,10 @@
 
     <!-- Login -->
     <string name="login_title">Bi Spotify aamelde</string>
+
+    <!-- Account section headers -->
+    <string name="account_section_profile">Profil &amp; Konto</string>
+    <string name="account_section_playback">Abspilig</string>
+    <string name="account_section_appearance">Usgsee</string>
+    <string name="account_section_notifications">Benachrichtigunge</string>
 </resources>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -241,4 +241,10 @@
 
     <!-- Login -->
     <string name="login_title">Bei Spotify anmelden</string>
+
+    <!-- Account section headers -->
+    <string name="account_section_profile">Profil &amp; Konto</string>
+    <string name="account_section_playback">Wiedergabe</string>
+    <string name="account_section_appearance">Erscheinungsbild</string>
+    <string name="account_section_notifications">Benachrichtigungen</string>
 </resources>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -241,4 +241,10 @@
 
     <!-- Login -->
     <string name="login_title">Войти в Spotify</string>
+
+    <!-- Account section headers -->
+    <string name="account_section_profile">Профиль и аккаунт</string>
+    <string name="account_section_playback">Воспроизведение</string>
+    <string name="account_section_appearance">Внешний вид</string>
+    <string name="account_section_notifications">Уведомления</string>
 </resources>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -241,4 +241,10 @@
 
     <!-- Login -->
     <string name="login_title">Login to Spotify</string>
+
+    <!-- Account section headers -->
+    <string name="account_section_profile">Profile &amp; Account</string>
+    <string name="account_section_playback">Playback</string>
+    <string name="account_section_appearance">Appearance</string>
+    <string name="account_section_notifications">Notifications</string>
 </resources>


### PR DESCRIPTION
Closes #266

Big M3 Expressive refactor. Replaces hand-rolled `Box.clickable` buttons, classic spinners, sharp-style icons, and oversized AlertDialogs with current Material 3 components.

## Dependency bumps
- `material3` overridden to `1.5.0-alpha21` (BOM `2026.05.00` only ships 1.4.0; LoadingIndicator + CircularWavyProgressIndicator only land on 1.5.0-alpha).
- `compileSdk` / `targetSdk` 36 → 37 (required by 1.5.0-alpha21's transitive compose-animation 1.12-alpha).

## What changed

### NowPlayingScreen (full sweep)
- Heart × 2, transport row × 5 (shuffle/prev/play/next/repeat), EQ × 1, plus 9 other buttons (back arrow × 2, audio output × 2, share × 2, queue × 2, three-dot menu) — all swapped from `Box(Modifier.background(buttonBg, CircleShape).clip(CircleShape).clickable{})` to `IconButton` / `FilledTonalIconButton` / `FilledIconToggleButton` / `FilledTonalIconToggleButton` / `FilledIconButton` with proper `*ButtonColors` factories.
- Inline buffering spinners → `LoadingIndicator`.
- Brand colors (`animatedPrimary`, `SpfyWhite`) preserved via `checkedContainerColor` / `checkedContentColor`.

### Heart elsewhere
- LyricsScreen + DetailScreen heart sites → `FilledIconToggleButton` / `IconToggleButton`.

### Spinners (15 sites)
- All `CircularProgressIndicator` → `LoadingIndicator` (polygon shape-morph) except the boot/auth ring in SpfyApp which uses `CircularWavyProgressIndicator(color = SpfyWhite)`.

### Rounded icons
- 157 `Icons.Default.*` / `Icons.Filled.*` → `Icons.Rounded.*` across 16 UI files. `FavoriteBorder` stays Filled (no Rounded variant exists).

### Tight AlertDialogs
- New `components/TightAlertDialog.kt` helper: `BasicAlertDialog` + `Surface` with 20×16dp padding, `heightIn(max = 60% screen)` + `verticalScroll` so long content scrolls instead of overflowing.
- 12 `AlertDialog` sites swapped: Update, SpfyApp (playlist picker), ReleaseNotes, Library × 2, NowPlaying (playlist picker), Account × 6.

### Account screen reorg
- Sectioned long list: Profile & Account → Appearance → Playback → Notifications → About → Special Thanks → Log out.
- New `AccountSectionHeader` helper.
- 4 new i18n keys (`account_section_profile/playback/appearance/notifications`) across en/de/ru/gsw.

## Follow-ups
- Notification action icons (system notification shade) still use `android.R.drawable.ic_media_*` and a mix of custom drawables — refresh to Material Symbols Rounded — tracked in #267.

## Verify
- [x] `:app:assembleDebug` green
- [x] `:app:testDebugUnitTest` green
- [x] `detekt` green
- [x] Installed and visually verified on device — buttons, transport, EQ, heart, transports, dialogs, Account sections, boot wavy spinner all behave