### PR TITLE
feat(notification): use rounded vector drawables for transport actions (#267)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -589,10 +589,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             PendingIntent.FLAG_IMMUTABLE
         )
 
-        val playPauseIcon = if (isPlaying)
-            android.R.drawable.ic_media_pause
-        else
-            android.R.drawable.ic_media_play
+        val playPauseIcon = if (isPlaying) R.drawable.ic_pause_rounded else R.drawable.ic_play_arrow_rounded
 
         fun buttonIcon(type: String) = when (type) {
             "like" -> if (isLiked) R.drawable.ic_heart_filled else R.drawable.ic_heart_outline
@@ -622,9 +619,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             .setOngoing(isPlaying)
             .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
             .addAction(buttonIcon(notificationLeftButton), buttonLabel(notificationLeftButton), leftIntent)
-            .addAction(android.R.drawable.ic_media_previous, "Previous", prevIntent)
+            .addAction(R.drawable.ic_skip_previous_rounded, "Previous", prevIntent)
             .addAction(playPauseIcon, if (isPlaying) "Pause" else "Play", playPauseIntent)
-            .addAction(android.R.drawable.ic_media_next, "Next", nextIntent)
+            .addAction(R.drawable.ic_skip_next_rounded, "Next", nextIntent)
             .addAction(buttonIcon(notificationRightButton), buttonLabel(notificationRightButton), rightIntent)
             .setStyle(
                 androidx.media.app.NotificationCompat.MediaStyle()

--- a/src/app/src/main/res/drawable/ic_pause_rounded.xml
+++ b/src/app/src/main/res/drawable/ic_pause_rounded.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M8,5h1c0.55,0 1,0.45 1,1v12c0,0.55 -0.45,1 -1,1H8c-0.55,0 -1,-0.45 -1,-1V6C7,5.45 7.45,5 8,5zM15,5h1c0.55,0 1,0.45 1,1v12c0,0.55 -0.45,1 -1,1h-1c-0.55,0 -1,-0.45 -1,-1V6C14,5.45 14.45,5 15,5z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_play_arrow_rounded.xml
+++ b/src/app/src/main/res/drawable/ic_play_arrow_rounded.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M8,6.82v10.36c0,0.79 0.87,1.27 1.54,0.84l8.14,-5.18c0.62,-0.39 0.62,-1.29 0,-1.69L9.54,5.98C8.87,5.55 8,6.03 8,6.82z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_skip_next_rounded.xml
+++ b/src/app/src/main/res/drawable/ic_skip_next_rounded.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6.58,18.89L14.5,13.06c0.74,-0.5 0.74,-1.62 0,-2.12L6.58,5.11C5.93,4.58 5,5.05 5,5.88v12.24C5,18.95 5.93,19.42 6.58,18.89zM18,6h-1c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h1c0.55,0 1,-0.45 1,-1V7C19,6.45 18.55,6 18,6z" />
+</vector>

--- a/src/app/src/main/res/drawable/ic_skip_previous_rounded.xml
+++ b/src/app/src/main/res/drawable/ic_skip_previous_rounded.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M6,18h1c0.55,0 1,-0.45 1,-1V7C8,6.45 7.55,6 7,6H6c-0.55,0 -1,0.45 -1,1v10C5,17.55 5.45,18 6,18zM17.42,5.11L9.5,10.94c-0.74,0.5 -0.74,1.62 0,2.12l7.92,5.83c0.65,0.53 1.58,0.06 1.58,-0.77V5.88C19,5.05 18.07,4.58 17.42,5.11z" />
+</vector>


### PR DESCRIPTION
Closes #267

Replaces the system AOSP icons (`android.R.drawable.ic_media_play/pause/previous/next`) on the media-style notification with our own M3 Rounded vector drawables so they match the in-app icon style from #266.

## Changes
- Added 4 new vector drawables in `res/drawable/` with Rounded-style paths and white fill (system applies action tint):
  - `ic_play_arrow_rounded.xml`
  - `ic_pause_rounded.xml`
  - `ic_skip_next_rounded.xml`
  - `ic_skip_previous_rounded.xml`
- Wired them in `MusicPlaybackService.kt` (lines 593, 625, 627).

## Out of scope
- Heart/shuffle/repeat custom drawables already use Spfy brand colors and look fine — left as-is.

## Verify
- [x] assembleDebug / tests / detekt green
- [x] Installed and visually confirmed on device