### PR TITLE
fix(playback): pause Spfy side on audio focus loss (#261)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -89,6 +89,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     var notificationLeftButton: String = "repeat"
     var notificationRightButton: String = "like"
 
+    /** True while playback is paused because another app holds transient audio focus.
+     *  Used to auto-resume Spotify when focus returns. */
+    private var wasSuppressedByFocus = false
+
     override fun onCreate() {
         super.onCreate()
 
@@ -145,6 +149,35 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                     LokiLogger.i(TAG, "Closing audio effect session")
                     broadcastAudioEffectAction(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION)
                     openAudioEffectSession = false
+                }
+
+                // Full (permanent) audio focus loss — e.g. phone call answered.
+                // ExoPlayer flips playWhenReady to false. Mirror to Spotify side.
+                if (!playWhenReady && reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS) {
+                    LokiLogger.i(TAG, "Pausing Spotify side due to audio focus loss")
+                    onPause?.invoke()
+                }
+            }
+
+            override fun onPlaybackSuppressionReasonChanged(playbackSuppressionReason: Int) {
+                // Transient focus loss (e.g. Instagram video starts) — ExoPlayer keeps
+                // playWhenReady = true but suppresses playback. Spotify's cloud position
+                // keeps advancing though, so we must mirror the pause to the Spotify side
+                // — otherwise the muted track ends and the next one auto-plays over the
+                // focus-stealing app. Resume both sides when focus returns.
+                when (playbackSuppressionReason) {
+                    Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS -> {
+                        LokiLogger.i(TAG, "Pausing Spotify side due to transient focus loss")
+                        wasSuppressedByFocus = true
+                        onPause?.invoke()
+                    }
+                    Player.PLAYBACK_SUPPRESSION_REASON_NONE -> {
+                        if (wasSuppressedByFocus) {
+                            wasSuppressedByFocus = false
+                            LokiLogger.i(TAG, "Resuming Spotify side — transient focus restored")
+                            onPlay?.invoke()
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Closes #261

When another app grabs audio focus (e.g. an Instagram video starts), ExoPlayer used to silently suppress or pause locally — but Spfy's cloud-side position kept advancing. When the silent track reached its natural end, the cloud auto-advanced to the next track, which then started playing audibly over the focus-stealing app.

## Fix
Mirror the local pause to the Spfy side via the existing `onPause` callback in two cases:

- **Full focus loss** (e.g. phone call answered) — ExoPlayer sets `playWhenReady = false` with `reason = PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS`. The `onPlayWhenReadyChanged` listener fires `onPause`.
- **Transient focus loss** (e.g. Instagram video) — ExoPlayer keeps `playWhenReady = true` but suppresses playback. The new `onPlaybackSuppressionReasonChanged` listener catches `PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS` and fires `onPause`; on focus restore (`PLAYBACK_SUPPRESSION_REASON_NONE`) it fires `onPlay` to auto-resume. A `wasSuppressedByFocus` flag gates the auto-resume so it only triggers after we caused the pause ourselves.

Background: with `ExoPlayer.setAudioAttributes(audioAttributes, true)` (auto focus handling), the SDK uses `playWhenReady` for permanent loss and `playbackSuppressionReason` for transient. We need to wire both to keep cloud + local in sync.

## Verify
- [x] assembleDebug / tests / detekt green
- [x] Installed and reproduced fix on device with Instagram (music pauses, resumes when leaving Insta)