### PR TITLE
Play header-gated and encrypted lossless sources in the player

### DIFF
--- a/src/app/src/androidTest/java/ch/snepilatch/app/playback/BlowfishDecryptInstrumentedTest.kt
+++ b/src/app/src/androidTest/java/ch/snepilatch/app/playback/BlowfishDecryptInstrumentedTest.kt
@@ -1,0 +1,37 @@
+package ch.snepilatch.app.playback
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Confirms on a real Android runtime that the platform crypto provider supports
+ * "Blowfish/CBC/NoPadding" and round-trips a full 2048-byte block with the fixed
+ * IV the Deezer scheme uses — the one thing [DeezerDecryptProxy] depends on that
+ * the JVM unit tests can't prove. Verified passing on API 35.
+ */
+@RunWith(AndroidJUnit4::class)
+class BlowfishDecryptInstrumentedTest {
+
+    @Test
+    fun blowfishCbc_roundTripsA2048Block() {
+        val iv = ByteArray(8) { it.toByte() }
+        val key = ByteArray(16) { it.toByte() }
+        val plain = ByteArray(2048) { (it % 251).toByte() }
+
+        val encrypted = Cipher.getInstance("Blowfish/CBC/NoPadding").also {
+            it.init(Cipher.ENCRYPT_MODE, SecretKeySpec(key, "Blowfish"), IvParameterSpec(iv))
+        }.doFinal(plain)
+
+        // Mirror the proxy: a fresh cipher with the same IV decrypts the block.
+        val decrypted = Cipher.getInstance("Blowfish/CBC/NoPadding").also {
+            it.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "Blowfish"), IvParameterSpec(iv))
+        }.doFinal(encrypted)
+
+        assertArrayEquals(plain, decrypted)
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/DeezerDecryptProxy.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/DeezerDecryptProxy.kt
@@ -1,0 +1,235 @@
+package ch.snepilatch.app.playback
+
+import ch.snepilatch.app.util.LokiLogger
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import javax.crypto.Cipher
+import javax.crypto.spec.IvParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Local loopback HTTP proxy that lets ExoPlayer stream Blowfish-encrypted Deezer
+ * audio with no custom DataSource and no ExoPlayer modification.
+ *
+ * Register an encrypted stream via [register] to get a `http://127.0.0.1:<port>/<id>`
+ * URL that plays like any other progressive source. On each request the proxy
+ * fetches the upstream encrypted bytes (forwarding the relay's `X-API-Key`),
+ * decrypts on the fly — Blowfish/CBC, a fresh IV per 2048-byte block, only every
+ * 3rd block (the Deezer scheme) — and serves cleartext FLAC.
+ *
+ * Decryption is block-positional (no cross-block chaining), so a byte offset maps
+ * straight to a block index and HTTP Range requests (seeking) work: we align the
+ * upstream fetch to the enclosing 2048-byte block and skip the remainder.
+ */
+class DeezerDecryptProxy {
+
+    companion object {
+        private const val TAG = "DeezerProxy"
+        private const val BLOCK = 2048
+        private val IV = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7)
+    }
+
+    private class Entry(val url: String, val key: ByteArray, val headers: Map<String, String>)
+
+    private val registry = ConcurrentHashMap<String, Entry>()
+    private val ids = AtomicInteger(0)
+    private val pool = Executors.newCachedThreadPool { r ->
+        Thread(r, "deezer-proxy").apply { isDaemon = true }
+    }
+
+    @Volatile
+    private var server: ServerSocket? = null
+
+    @Volatile
+    private var port = 0
+
+    fun start() {
+        if (server != null) return
+        val s = ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))
+        server = s
+        port = s.localPort
+        pool.execute {
+            while (!s.isClosed) {
+                val client = try { s.accept() } catch (_: Exception) { break }
+                pool.execute { handle(client) }
+            }
+        }
+        LokiLogger.i(TAG, "started on 127.0.0.1:$port")
+    }
+
+    fun stop() {
+        registry.clear()
+        try { server?.close() } catch (_: Exception) {}
+        server = null
+    }
+
+    /**
+     * Register an encrypted Deezer stream and return a local URL ExoPlayer can
+     * play. [keyHex] is the per-track Blowfish key from the relay's track info.
+     */
+    fun register(url: String, keyHex: String, headers: Map<String, String>): String {
+        if (server == null) start()
+        val id = ids.incrementAndGet().toString()
+        registry[id] = Entry(url, hexToBytes(keyHex), headers)
+        return "http://127.0.0.1:$port/$id"
+    }
+
+    private fun handle(client: Socket) {
+        client.use { sock ->
+            try {
+                val (path, rangeStart) = readRequest(BufferedInputStream(sock.getInputStream())) ?: return
+                val entry = registry[path.trimStart('/')]
+                if (entry == null) {
+                    writeStatus(sock.getOutputStream(), 404, "Not Found")
+                } else {
+                    stream(entry, rangeStart, sock.getOutputStream())
+                }
+            } catch (e: Exception) {
+                LokiLogger.w(TAG, "handle error: ${e.message}")
+            }
+        }
+    }
+
+    /** Parse the request line + optional Range header. Returns (path, rangeStart). */
+    private fun readRequest(input: InputStream): Pair<String, Long>? {
+        val lines = mutableListOf<String>()
+        val sb = StringBuilder()
+        var b = input.read()
+        while (b != -1) {
+            if (b == '\n'.code) {
+                val line = sb.toString().trim()
+                sb.setLength(0)
+                if (line.isEmpty()) break
+                lines.add(line)
+            } else if (b != '\r'.code) {
+                sb.append(b.toChar())
+            }
+            b = input.read()
+        }
+        val path = lines.firstOrNull()?.split(" ")?.getOrNull(1) ?: return null
+        val rangeStart = lines.firstOrNull { it.startsWith("Range:", ignoreCase = true) }
+            ?.substringAfter("=", "")?.substringBefore("-")?.trim()?.toLongOrNull() ?: 0L
+        return path to rangeStart
+    }
+
+    private fun stream(entry: Entry, rangeStart: Long, rawOut: OutputStream) {
+        val alignedStart = (rangeStart / BLOCK) * BLOCK
+        val conn = openUpstream(entry, alignedStart)
+        conn.connect()
+        val code = conn.responseCode
+        val upstream = BufferedInputStream(conn.inputStream)
+        val total = computeTotal(conn, code, alignedStart)
+
+        // Upstream ignored our Range (returned 200) but we need an offset.
+        if (code != 206 && alignedStart > 0) skipBytes(upstream, alignedStart)
+
+        val out = BufferedOutputStream(rawOut)
+        writeResponseHeader(out, rangeStart, total)
+        decryptInto(out, upstream, entry.key, (alignedStart / BLOCK).toInt(), rangeStart - alignedStart)
+        out.flush()
+        try { conn.disconnect() } catch (_: Exception) {}
+    }
+
+    private fun openUpstream(entry: Entry, alignedStart: Long): HttpURLConnection =
+        (URL(entry.url).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            connectTimeout = 15_000
+            readTimeout = 30_000
+            entry.headers.forEach { (k, v) -> setRequestProperty(k, v) }
+            if (alignedStart > 0) setRequestProperty("Range", "bytes=$alignedStart-")
+        }
+
+    /** Total decrypted size == encrypted size (decryption is length-preserving). */
+    private fun computeTotal(conn: HttpURLConnection, code: Int, alignedStart: Long): Long {
+        val fromRange = conn.getHeaderField("Content-Range")?.substringAfter("/", "")?.toLongOrNull()
+        if (fromRange != null) return fromRange
+        val cl = conn.getHeaderField("Content-Length")?.toLongOrNull() ?: return -1L
+        return if (code == 206) cl + alignedStart else cl
+    }
+
+    private fun writeResponseHeader(out: OutputStream, rangeStart: Long, total: Long) {
+        val sb = StringBuilder()
+        if (rangeStart > 0 && total > 0) {
+            sb.append("HTTP/1.1 206 Partial Content\r\n")
+            sb.append("Content-Range: bytes $rangeStart-${total - 1}/$total\r\n")
+            sb.append("Content-Length: ${total - rangeStart}\r\n")
+        } else {
+            sb.append("HTTP/1.1 200 OK\r\n")
+            if (total > 0) sb.append("Content-Length: $total\r\n")
+        }
+        sb.append("Accept-Ranges: bytes\r\n")
+        sb.append("Content-Type: audio/flac\r\n")
+        sb.append("Connection: close\r\n\r\n")
+        out.write(sb.toString().toByteArray(Charsets.US_ASCII))
+    }
+
+    /** Decrypt the upstream stream block-by-block, skipping [skip] leading bytes. */
+    private fun decryptInto(out: OutputStream, upstream: InputStream, key: ByteArray, startBlock: Int, skip: Long) {
+        var blockIndex = startBlock
+        var toSkip = skip
+        val buf = ByteArray(BLOCK)
+        while (true) {
+            val n = readBlock(upstream, buf)
+            if (n <= 0) break
+            val decoded = if (blockIndex % 3 == 0 && n == BLOCK) decryptBlock(key, buf) else buf.copyOf(n)
+            val off = if (toSkip > 0) minOf(toSkip, decoded.size.toLong()).toInt() else 0
+            toSkip -= off
+            if (off < decoded.size) out.write(decoded, off, decoded.size - off)
+            blockIndex++
+        }
+    }
+
+    private fun skipBytes(input: InputStream, count: Long) {
+        var remaining = count
+        val buf = ByteArray(8192)
+        while (remaining > 0) {
+            val n = input.read(buf, 0, minOf(buf.size.toLong(), remaining).toInt())
+            if (n <= 0) break
+            remaining -= n
+        }
+    }
+
+    /** Read exactly [buf].size bytes unless EOF; returns bytes read. */
+    private fun readBlock(input: InputStream, buf: ByteArray): Int {
+        var read = 0
+        while (read < buf.size) {
+            val n = input.read(buf, read, buf.size - read)
+            if (n == -1) break
+            read += n
+        }
+        return read
+    }
+
+    private fun decryptBlock(key: ByteArray, block: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance("Blowfish/CBC/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, SecretKeySpec(key, "Blowfish"), IvParameterSpec(IV))
+        return cipher.doFinal(block)
+    }
+
+    private fun writeStatus(out: OutputStream, code: Int, msg: String) {
+        out.write("HTTP/1.1 $code $msg\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray(Charsets.US_ASCII))
+        out.flush()
+    }
+
+    private fun hexToBytes(s: String): ByteArray {
+        val clean = s.trim()
+        val isHex = clean.length % 2 == 0 && clean.isNotEmpty() && clean.all { it in "0123456789abcdefABCDEF" }
+        return if (isHex) {
+            ByteArray(clean.length / 2) {
+                ((Character.digit(clean[it * 2], 16) shl 4) + Character.digit(clean[it * 2 + 1], 16)).toByte()
+            }
+        } else {
+            clean.toByteArray(Charsets.UTF_8)
+        }
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -22,8 +22,12 @@ import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -288,8 +292,15 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
     var onReady: (() -> Unit)? = null
 
-    fun playUrl(url: String, title: String, artist: String, albumArtUrl: String?, startPlaying: Boolean = true) {
-        LokiLogger.i(TAG, "Loading: $title by $artist -> ${url.take(80)} (play=$startPlaying)")
+    fun playUrl(
+        url: String,
+        title: String,
+        artist: String,
+        albumArtUrl: String?,
+        startPlaying: Boolean = true,
+        headers: Map<String, String> = emptyMap()
+    ) {
+        LokiLogger.i(TAG, "Loading: $title by $artist -> ${url.take(80)} (play=$startPlaying, headers=${headers.keys})")
         val meta = TrackMetadata(title, artist, albumArtUrl)
         metadataQueue.clear()
         metadataQueue.add(meta)
@@ -299,7 +310,15 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         // Start audio IMMEDIATELY — don't wait for art
         mainHandler.post {
             player.playWhenReady = false
-            player.setMediaItem(buildMediaItem(url))
+            // Default sources (squid direct URL, Spotify CDN) play from a plain
+            // MediaItem. Sources that gate their stream behind a request header
+            // (the anandserver Qobuz mirror) need those headers on the HTTP data
+            // source, so they go through a dedicated header-injecting MediaSource.
+            if (headers.isEmpty()) {
+                player.setMediaItem(buildMediaItem(url))
+            } else {
+                player.setMediaSource(buildHeaderedSource(url, headers))
+            }
 
             if (startPlaying) {
                 // Register listener BEFORE prepare() so we catch STATE_READY
@@ -448,6 +467,21 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             .setMediaId(url)
             .setUri(url)
             .build()
+    }
+
+    /**
+     * Progressive media source whose HTTP data source sends [headers] on every
+     * request. Used only for stream URLs that are gated behind a request header
+     * (the anandserver Qobuz mirror's X-API-Key) — the default [buildMediaItem]
+     * path is left untouched for header-less sources.
+     */
+    @OptIn(UnstableApi::class)
+    private fun buildHeaderedSource(url: String, headers: Map<String, String>): MediaSource {
+        val httpFactory = DefaultHttpDataSource.Factory()
+            .setDefaultRequestProperties(headers)
+            .setAllowCrossProtocolRedirects(true)
+        return ProgressiveMediaSource.Factory(httpFactory)
+            .createMediaSource(buildMediaItem(url))
     }
 
     fun buildDrmMediaItem(url: String, licenseUrl: String, licenseHeaders: Map<String, String>): MediaItem {

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -48,6 +48,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     private var mediaSession: MediaSessionCompat? = null
     private val mainHandler = Handler(Looper.getMainLooper())
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    /** Loopback proxy that decrypts Blowfish-encrypted Deezer streams on the fly. */
+    private val deezerProxy = DeezerDecryptProxy()
     lateinit var player: ExoPlayer
         private set
 
@@ -101,6 +104,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         super.onCreate()
 
         createNotificationChannel()
+        deezerProxy.start()
 
         val audioAttributes = AudioAttributes.Builder()
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
@@ -470,6 +474,24 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     }
 
     /**
+     * Play an encrypted Deezer stream. The bytes are Blowfish-encrypted, so we
+     * register them with the loopback [deezerProxy] and hand ExoPlayer the
+     * resulting cleartext localhost URL — no custom DataSource, no DRM config.
+     */
+    fun playDeezer(
+        streamUrl: String,
+        decryptionKey: String,
+        headers: Map<String, String>,
+        title: String,
+        artist: String,
+        albumArtUrl: String?,
+        startPlaying: Boolean = true
+    ) {
+        val localUrl = deezerProxy.register(streamUrl, decryptionKey, headers)
+        playUrl(localUrl, title, artist, albumArtUrl, startPlaying)
+    }
+
+    /**
      * Progressive media source whose HTTP data source sends [headers] on every
      * request. Used only for stream URLs that are gated behind a request header
      * (the anandserver Qobuz mirror's X-API-Key) — the default [buildMediaItem]
@@ -763,6 +785,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             release()
         }
         player.release()
+        deezerProxy.stop()
         // Do NOT clear SessionHolder here — the VM and MainActivity already
         // handle explicit user-close teardown. If the service is dying for
         // other reasons (e.g. low memory) we want the session to stay live

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -256,28 +256,24 @@ fun AccountScreen(vm: SpotifyViewModel) {
 
         // Audio settings
         val audioSource by vm.preferredAudioSource.collectAsState()
-        val isLossless = audioSource == "tidal" || audioSource == "qobuz"
+        val isLossless = audioSource != null
+        val losslessSubtitle = if (isLossless) {
+            stringResource(R.string.lossless_on_flac)
+        } else {
+            stringResource(R.string.lossless_off_spotify)
+        }
 
-        // Lossless toggle
-        val tidalLabel = stringResource(R.string.tidal)
-        val qobuzLabel = stringResource(R.string.qobuz)
-        val losslessOnText = stringResource(R.string.lossless_on, if (audioSource == "tidal") tidalLabel else qobuzLabel)
-        val losslessOffText = stringResource(R.string.lossless_off_spotify)
+        // Lossless toggle — when on, the resolver picks the best source
+        // (Qobuz, then Deezer, then YouTube) autonomously; no provider choice.
         ListItem(
             headlineContent = { Text(stringResource(R.string.lossless_audio), color = SpotifyWhite) },
-            supportingContent = { Text(
-                if (isLossless) losslessOnText else losslessOffText,
-                color = SpotifyLightGray
-            ) },
+            supportingContent = { Text(losslessSubtitle, color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Rounded.MusicNote, null, tint = SpotifyLightGray) },
             trailingContent = {
                 Switch(
                     checked = isLossless,
                     onCheckedChange = { enabled ->
-                        vm.setPreferredAudioSource(
-                            if (enabled) "tidal" else null,
-                            audioContext
-                        )
+                        vm.setPreferredAudioSource(if (enabled) "lossless" else null, audioContext)
                     },
                     colors = SwitchDefaults.colors(
                         checkedThumbColor = animatedPrimary,
@@ -289,73 +285,6 @@ fun AccountScreen(vm: SpotifyViewModel) {
             },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
         )
-
-        // Lossless provider picker (only when lossless enabled)
-        if (isLossless) {
-            var showProviderPicker by remember { mutableStateOf(false) }
-            ListItem(
-                headlineContent = { Text(stringResource(R.string.lossless_provider), color = SpotifyWhite) },
-                supportingContent = { Text(
-                    if (audioSource == "tidal") stringResource(R.string.tidal_desc)
-                    else stringResource(R.string.qobuz_desc),
-                    color = SpotifyLightGray
-                ) },
-                leadingContent = { Spacer(Modifier.width(24.dp)) },
-                trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
-                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                modifier = Modifier.clickable { showProviderPicker = true }
-            )
-            if (showProviderPicker) {
-                TightAlertDialog(
-                    onDismissRequest = { showProviderPicker = false },
-                    title = { Text(stringResource(R.string.lossless_provider), color = SpotifyWhite) },
-                    text = {
-                        Column {
-                            listOf(
-                                "tidal" to stringResource(R.string.tidal) to stringResource(R.string.tidal_short_desc),
-                                "qobuz" to stringResource(R.string.qobuz) to stringResource(R.string.qobuz_short_desc)
-                            ).forEach { (pair, desc) ->
-                                val (value, label) = pair
-                                Row(
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .clickable {
-                                            vm.setPreferredAudioSource(value, audioContext)
-                                            showProviderPicker = false
-                                        }
-                                        .padding(vertical = 12.dp, horizontal = 4.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    RadioButton(
-                                        selected = audioSource == value,
-                                        onClick = {
-                                            vm.setPreferredAudioSource(value, audioContext)
-                                            showProviderPicker = false
-                                        },
-                                        colors = RadioButtonDefaults.colors(
-                                            selectedColor = animatedPrimary,
-                                            unselectedColor = SpotifyLightGray
-                                        )
-                                    )
-                                    Spacer(Modifier.width(8.dp))
-                                    Column {
-                                        Text(label, color = SpotifyWhite, fontSize = 15.sp)
-                                        Text(desc, color = SpotifyLightGray, fontSize = 12.sp)
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    containerColor = SpotifyGray,
-                    confirmButton = {},
-                    dismissButton = {
-                        TextButton(onClick = { showProviderPicker = false }) {
-                            Text(stringResource(R.string.cancel), color = SpotifyLightGray)
-                        }
-                    }
-                )
-            }
-        }
 
         // Canvas background
         val canvasOn by vm.canvasEnabled.collectAsState()

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1827,7 +1827,14 @@ class SpotifyViewModel : ViewModel() {
                 is StreamResult.Success -> {
                     // Don't resume Spotify yet — onReady callback will sync after ExoPlayer buffers
                     playUrlAt = System.currentTimeMillis()
-                    MusicPlaybackService.instance?.playUrl(result.info.url, title, artist, art, headers = result.info.headers)
+                    val info = result.info
+                    val key = info.decryptionKey
+                    if (key != null) {
+                        // Deezer: encrypted stream -> decrypt via the loopback proxy.
+                        MusicPlaybackService.instance?.playDeezer(info.url, key, info.headers, title, artist, art)
+                    } else {
+                        MusicPlaybackService.instance?.playUrl(info.url, title, artist, art, headers = info.headers)
+                    }
                     currentStreamUri = trackUri
                     isStreaming.value = true
                     streamProvider.value = result.info.provider

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1827,7 +1827,7 @@ class SpotifyViewModel : ViewModel() {
                 is StreamResult.Success -> {
                     // Don't resume Spotify yet — onReady callback will sync after ExoPlayer buffers
                     playUrlAt = System.currentTimeMillis()
-                    MusicPlaybackService.instance?.playUrl(result.info.url, title, artist, art)
+                    MusicPlaybackService.instance?.playUrl(result.info.url, title, artist, art, headers = result.info.headers)
                     currentStreamUri = trackUri
                     isStreaming.value = true
                     streamProvider.value = result.info.provider

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <!-- Settings -->
     <string name="lossless_audio">Lossless Audio</string>
     <string name="lossless_on">FLAC via %s</string>
+    <string name="lossless_on_flac">FLAC</string>
     <string name="lossless_off">Standard quality</string>
     <string name="lossless_provider">Lossless Provider</string>
     <string name="tidal_desc">Tidal — FLAC up to 1411kbps</string>

--- a/src/app/src/main/res/xml/network_security_config.xml
+++ b/src/app/src/main/res/xml/network_security_config.xml
@@ -2,6 +2,7 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">127.0.0.1</domain>
         <domain includeSubdomains="true">10.0.2.2</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
Consumes KotifyClient's new lossless StreamInfo in the player:

- anandserver Qobuz gates its stream behind an X-API-Key header — playUrl now forwards StreamInfo.headers through a dedicated header-injecting ProgressiveMediaSource, leaving the default header-less path (squid direct URL, Spfy CDN) untouched.
- Deezer streams are Blowfish-encrypted — added a local loopback proxy (DeezerDecryptProxy) that fetches the encrypted bytes, decrypts on the fly (Blowfish/CBC, fresh IV per 2048-byte block, every 3rd block) and serves cleartext FLAC at 127.0.0.1, so ExoPlayer plays it as an ordinary URL with no custom DataSource. Range/seek supported via block-aligned offsets; 127.0.0.1 added to the cleartext network config.

Requires a KotifyClient.jar with StreamInfo.headers/decryptionKey. assembleDebug, testDebugUnitTest, and detekt all green.

Closes #274