### PR TITLE
Make lossless playback reliable: resume-from-idle, gapless headers, drop YouTube

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -302,9 +302,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         artist: String,
         albumArtUrl: String?,
         startPlaying: Boolean = true,
-        headers: Map<String, String> = emptyMap()
+        headers: Map<String, String> = emptyMap(),
+        startPositionMs: Long = 0L
     ) {
-        LokiLogger.i(TAG, "Loading: $title by $artist -> ${url.take(80)} (play=$startPlaying, headers=${headers.keys})")
+        LokiLogger.i(TAG, "Loading: $title by $artist -> ${url.take(80)} (play=$startPlaying, headers=${headers.keys}, pos=${startPositionMs}ms)")
         val meta = TrackMetadata(title, artist, albumArtUrl)
         metadataQueue.clear()
         metadataQueue.add(meta)
@@ -318,10 +319,11 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             // MediaItem. Sources that gate their stream behind a request header
             // (the anandserver Qobuz mirror) need those headers on the HTTP data
             // source, so they go through a dedicated header-injecting MediaSource.
+            // Both accept a start position so resume-from-idle seeks on load.
             if (headers.isEmpty()) {
-                player.setMediaItem(buildMediaItem(url))
+                player.setMediaItem(buildMediaItem(url), startPositionMs)
             } else {
-                player.setMediaSource(buildHeaderedSource(url, headers))
+                player.setMediaSource(buildHeaderedSource(url, headers), startPositionMs)
             }
 
             if (startPlaying) {
@@ -485,10 +487,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         title: String,
         artist: String,
         albumArtUrl: String?,
-        startPlaying: Boolean = true
+        startPositionMs: Long = 0L
     ) {
         val localUrl = deezerProxy.register(streamUrl, decryptionKey, headers)
-        playUrl(localUrl, title, artist, albumArtUrl, startPlaying)
+        playUrl(localUrl, title, artist, albumArtUrl, startPlaying = true, startPositionMs = startPositionMs)
     }
 
     /**

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -445,8 +445,15 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         }
     }
 
-    fun setNextUrl(url: String, title: String, artist: String, albumArtUrl: String?) {
-        LokiLogger.i(TAG, "Next: $title by $artist")
+    @OptIn(UnstableApi::class)
+    fun setNextUrl(
+        url: String,
+        title: String,
+        artist: String,
+        albumArtUrl: String?,
+        headers: Map<String, String> = emptyMap()
+    ) {
+        LokiLogger.i(TAG, "Next: $title by $artist (headers=${headers.keys})")
         val meta = TrackMetadata(title, artist, albumArtUrl)
 
         // Keep only the current track's metadata, replace any queued next
@@ -464,7 +471,13 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             if (player.mediaItemCount > 1) {
                 player.removeMediaItems(1, player.mediaItemCount)
             }
-            player.addMediaItem(buildMediaItem(url))
+            // Header-gated sources (anandserver Qobuz) must be enqueued as a
+            // header-injecting MediaSource, or the gapless advance hits a 401.
+            if (headers.isEmpty()) {
+                player.addMediaItem(buildMediaItem(url))
+            } else {
+                player.addMediaSource(buildHeaderedSource(url, headers))
+            }
         }
     }
 
@@ -493,17 +506,24 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         playUrl(localUrl, title, artist, albumArtUrl, startPlaying = true, startPositionMs = startPositionMs)
     }
 
+    /** Register an encrypted Deezer stream with the proxy; returns a playable local URL. */
+    fun proxyUrlForDeezer(streamUrl: String, decryptionKey: String, headers: Map<String, String>): String =
+        deezerProxy.register(streamUrl, decryptionKey, headers)
+
     /**
      * Progressive media source whose HTTP data source sends [headers] on every
      * request. Used only for stream URLs that are gated behind a request header
      * (the anandserver Qobuz mirror's X-API-Key) — the default [buildMediaItem]
-     * path is left untouched for header-less sources.
+     * path is left untouched for header-less sources. Timeouts are generous
+     * because the relay can be slow to first byte.
      */
     @OptIn(UnstableApi::class)
     private fun buildHeaderedSource(url: String, headers: Map<String, String>): MediaSource {
         val httpFactory = DefaultHttpDataSource.Factory()
             .setDefaultRequestProperties(headers)
             .setAllowCrossProtocolRedirects(true)
+            .setConnectTimeoutMs(30_000)
+            .setReadTimeoutMs(30_000)
         return ProgressiveMediaSource.Factory(httpFactory)
             .createMediaSource(buildMediaItem(url))
     }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -264,7 +264,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
         }
 
         // Lossless toggle — when on, the resolver picks the best source
-        // (Qobuz, then Deezer, then YouTube) autonomously; no provider choice.
+        // (Qobuz, then Deezer) autonomously; no provider choice.
         ListItem(
             headlineContent = { Text(stringResource(R.string.lossless_audio), color = SpotifyWhite) },
             supportingContent = { Text(losslessSubtitle, color = SpotifyLightGray) },

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -1003,9 +1003,8 @@ private fun InfoPill(icon: androidx.compose.ui.graphics.vector.ImageVector, text
 @Composable
 private fun SourcePill(provider: String) {
     val label = when (provider) {
-        "tidal" -> "Tidal"
         "qobuz" -> "Qobuz"
-        "youtube" -> "YouTube Music"
+        "deezer" -> "Deezer"
         else -> provider.replaceFirstChar { it.uppercase() }
     }
     Row(

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -83,6 +83,10 @@ class SpotifyViewModel : ViewModel() {
     private var nextStreamUrl: String? = null
     private var nextTrackInfo: TrackInfo? = null
     private var nextStreamProvider: String? = null
+
+    // Request headers the pre-resolved next stream needs (anandserver X-API-Key);
+    // empty for direct URLs and Deezer (which is pre-registered with the proxy).
+    private var nextStreamHeaders: Map<String, String> = emptyMap()
     private var nextCdnUrl: String? = null      // Pre-resolved Spotify CDN URL (DRM)
     private var nextCdnFileId: String? = null   // File ID for the pre-resolved CDN track
     private var lastCommandTs: Long = 0L  // timing: when last user command was sent
@@ -182,7 +186,7 @@ class SpotifyViewModel : ViewModel() {
     val audioOutputName = MutableStateFlow<String?>(null)
     val audioOutputType = MutableStateFlow("speaker") // "speaker", "bluetooth", "wired", "usb"
 
-    // Audio source preference: null = auto (default chain), or "tidal", "qobuz", "youtube"
+    // Audio source preference: null = Spotify (default), "lossless" = third-party FLAC chain.
     val preferredAudioSource = MutableStateFlow<String?>(null)
     // Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"
     val lyricsAnimDirection = MutableStateFlow("vertical")
@@ -973,7 +977,7 @@ class SpotifyViewModel : ViewModel() {
                     .joinToString(" ")
                 val result = cdn.resolveStreamUrl(
                     trackId, region = contentRegion.value,
-                    youtubeSearchQuery = query, preferredSource = preferredAudioSource.value
+                    searchQuery = query, preferredSource = preferredAudioSource.value
                 )
                 if (result is StreamResult.Success) {
                     val info = result.info
@@ -1767,7 +1771,7 @@ class SpotifyViewModel : ViewModel() {
             LokiLogger.i(TAG, "Using pre-resolved stream for $trackUri")
             // Don't resume Spotify yet — onReady callback will sync after ExoPlayer buffers
             playUrlAt = System.currentTimeMillis()
-            MusicPlaybackService.instance?.playUrl(preResolvedUrl, title, artist, art)
+            MusicPlaybackService.instance?.playUrl(preResolvedUrl, title, artist, art, headers = nextStreamHeaders)
             currentStreamUri = trackUri
             isStreaming.value = true
             isStreamLoading.value = false
@@ -1775,6 +1779,7 @@ class SpotifyViewModel : ViewModel() {
             nextStreamUrl = null
             nextTrackInfo = null
             nextStreamProvider = null
+            nextStreamHeaders = emptyMap()
             preResolveNextTrack()
             return
         }
@@ -1880,12 +1885,6 @@ class SpotifyViewModel : ViewModel() {
                     streamProvider.value = result.info.provider
                     LokiLogger.i(TAG, "Streaming: ${result.info.provider} -> ${result.info.url.take(80)}")
                 }
-                is StreamResult.YouTubeFallback -> {
-                    LokiLogger.w(TAG, "YouTube fallback: ${result.url}")
-                    MusicPlaybackService.instance?.stop()
-                    isStreaming.value = false
-                    streamProvider.value = null
-                }
                 is StreamResult.Failure -> {
                     LokiLogger.e(TAG, "Stream resolve failed: ${result.message}")
                     MusicPlaybackService.instance?.stop()
@@ -1927,7 +1926,10 @@ class SpotifyViewModel : ViewModel() {
             try {
                 val art = normalizeSpotifyImageUrl(track.imageLargeUrl ?: track.imageUrl)
 
-                val result = cdn.resolveStreamUrl(trackId, region = contentRegion.value, youtubeSearchQuery = searchQuery, preferredSource = preferredAudioSource.value)
+                val result = cdn.resolveStreamUrl(
+                    trackId, region = contentRegion.value,
+                    searchQuery = searchQuery, preferredSource = preferredAudioSource.value
+                )
                 when (result) {
                     is StreamResult.Success -> {
                         playUrlAt = System.currentTimeMillis()
@@ -1942,11 +1944,6 @@ class SpotifyViewModel : ViewModel() {
                         isStreaming.value = true
                         streamProvider.value = result.info.provider
                         LokiLogger.i(TAG, "Initial stream: ${result.info.provider} (playing=$shouldPlay)")
-                    }
-                    is StreamResult.YouTubeFallback -> {
-                        LokiLogger.w(TAG, "resolveCurrentTrack: YouTube fallback, not streaming")
-                        isStreaming.value = false
-                        streamProvider.value = null
                     }
                     is StreamResult.Failure -> {
                         LokiLogger.e(TAG, "resolveCurrentTrack: stream resolution failed: ${result.message}")
@@ -1988,14 +1985,31 @@ class SpotifyViewModel : ViewModel() {
                 .joinToString(" ").takeIf { it.isNotBlank() }
 
             LokiLogger.i(TAG, "Pre-resolving next: $title by $artist")
-            val result = cdn.resolveStreamUrl(nextId, region = contentRegion.value, youtubeSearchQuery = searchQuery, preferredSource = preferredAudioSource.value)
+            val result = cdn.resolveStreamUrl(nextId, region = contentRegion.value, searchQuery = searchQuery, preferredSource = preferredAudioSource.value)
             if (result is StreamResult.Success) {
-                nextStreamUrl = result.info.url
-                nextTrackInfo = TrackInfo(uri = nextUri, name = title, artist = artist, albumArt = art)
-                nextStreamProvider = result.info.provider
-                MusicPlaybackService.instance?.setNextUrl(result.info.url, title, artist, art)
-                isNextReady.value = true
-                LokiLogger.i(TAG, "Next track pre-resolved: ${result.info.provider}")
+                val info = result.info
+                val key = info.decryptionKey
+                // Deezer is encrypted — pre-register it with the proxy so the
+                // enqueued URL is a plaintext localhost URL (no headers). Other
+                // sources keep their request headers (anandserver X-API-Key).
+                val playable: String?
+                val headers: Map<String, String>
+                if (key != null) {
+                    playable = MusicPlaybackService.instance?.proxyUrlForDeezer(info.url, key, info.headers)
+                    headers = emptyMap()
+                } else {
+                    playable = info.url
+                    headers = info.headers
+                }
+                if (playable != null) {
+                    nextStreamUrl = playable
+                    nextStreamHeaders = headers
+                    nextTrackInfo = TrackInfo(uri = nextUri, name = title, artist = artist, albumArt = art)
+                    nextStreamProvider = info.provider
+                    MusicPlaybackService.instance?.setNextUrl(playable, title, artist, art, headers)
+                    isNextReady.value = true
+                    LokiLogger.i(TAG, "Next track pre-resolved: ${info.provider}")
+                }
             }
         } catch (e: Exception) {
             LokiLogger.e(TAG, "preResolveNextTrack failed", e)

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -962,6 +962,46 @@ class SpotifyViewModel : ViewModel() {
 
         try {
             val resolver = cdnResolver ?: throw IllegalStateException("CdnResolver not initialized")
+
+            // Lossless mode: resolve via the third-party chain (Qobuz → Deezer →
+            // YouTube) and play locally instead of Spotify's Widevine CDN, so
+            // resume-from-idle stays consistent with the rest of the lossless flow.
+            if (preferredAudioSource.value != null) {
+                val trackId = trackUri.removePrefix("spotify:track:")
+                val query = listOf(artist, title)
+                    .filter { it.isNotBlank() && it != "Unknown" }
+                    .joinToString(" ")
+                val result = cdn.resolveStreamUrl(
+                    trackId, region = contentRegion.value,
+                    youtubeSearchQuery = query, preferredSource = preferredAudioSource.value
+                )
+                if (result is StreamResult.Success) {
+                    val info = result.info
+                    playUrlAt = System.currentTimeMillis()
+                    withContext(Dispatchers.Main) {
+                        val svc = MusicPlaybackService.instance
+                        val key = info.decryptionKey
+                        if (key != null) {
+                            svc?.playDeezer(
+                                info.url, key, info.headers, title, artist, art,
+                                startPositionMs = savedPositionAtEntry
+                            )
+                        } else {
+                            svc?.playUrl(
+                                info.url, title, artist, art,
+                                startPlaying = true, headers = info.headers, startPositionMs = savedPositionAtEntry
+                            )
+                        }
+                    }
+                    currentStreamUri = trackUri
+                    isStreaming.value = true
+                    streamProvider.value = info.provider
+                    LokiLogger.i(TAG, "[ColdStart] lossless (${info.provider}) loading at ${savedPositionAtEntry}ms")
+                    return
+                }
+                LokiLogger.w(TAG, "[ColdStart] lossless resolve failed, falling back to Spotify CDN")
+            }
+
             val stream = resolver.resolveForFileId(fileId)
             LokiLogger.i(TAG, "[ColdStart] resolved ${stream.mirrorCount} CDN mirrors")
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -968,7 +968,7 @@ class SpotifyViewModel : ViewModel() {
             val resolver = cdnResolver ?: throw IllegalStateException("CdnResolver not initialized")
 
             // Lossless mode: resolve via the third-party chain (Qobuz → Deezer →
-            // YouTube) and play locally instead of Spotify's Widevine CDN, so
+            // Deezer) and play locally instead of Spotify's Widevine CDN, so
             // resume-from-idle stays consistent with the rest of the lossless flow.
             if (preferredAudioSource.value != null) {
                 val trackId = trackUri.removePrefix("spotify:track:")


### PR DESCRIPTION
Three fixes to the lossless playback path (verified end-to-end on a Pixel 6 / API 35):

1. Resume-from-idle now resolves via the lossless chain instead of Spfy's Widevine CDN, seeking to the saved position.
2. The gapless pre-resolve now carries the anandserver X-API-Key header (and pre-registers Deezer with the proxy), fixing the 401 on auto-advanced/gapless tracks.
3. Remove the dead YouTube fallback handling (KotifyClient removed it) and update to the new jar.

Requires a KotifyClient.jar with the YouTube fallback removed. assembleDebug, testDebugUnitTest, detekt all green.

Closes #276
Closes #278