### PR TITLE
Guard against committing KotifyClient.jar

### DIFF
--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -1,0 +1,24 @@
+name: Guard
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  no-committed-jars:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # KotifyClient.jar (and any jar under src/app/libs) must NEVER be committed.
+      # It is downloaded from KotifyClient's release and baked into the app by
+      # the release pipeline. A committed copy bloats history and goes stale.
+      - name: Reject committed jars under src/app/libs
+        run: |
+          jars="$(git ls-files 'src/app/libs/*.jar')"
+          if [ -n "$jars" ]; then
+            echo "::error::A jar is committed under src/app/libs — these are baked in by the release pipeline and must never be committed:"
+            echo "$jars"
+            exit 1
+          fi
+          echo "OK: no committed jars under src/app/libs"

--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ src/key.properties
 *.jks
 *.keystore
 
-# KotifyClient JAR (external dependency, not committed)
-src/app/libs/KotifyClient.jar
+# KotifyClient JAR and any other jar — baked in by the release pipeline, never committed
+src/app/libs/*.jar
 
 # OS files
 .DS_Store
@@ -29,5 +29,4 @@ Thumbs.db
 
 # AI Plans
 docs/superpowers/
-src/app/libs/KotifyClient.jar
 cur.png


### PR DESCRIPTION
KotifyClient.jar (and any jar under src/app/libs) must never be committed — the release pipeline downloads it from KotifyClient's release and bakes it in at build time. Broadens the gitignore to src/app/libs/*.jar and adds a Guard workflow (runs on push + PR) that fails if any jar is tracked there. Verified it catches even a git add -f bypass.

Note: this does NOT rewrite history — per discussion, the 44 MB jar in old history (#92→#108) is left as-is; this just prevents it happening again.

Closes #279