### PR TITLE
Mark Lossless as Beta; add Nearest content region (default)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -313,9 +313,14 @@ fun AccountScreen(vm: SpotifyViewModel) {
         // Content region picker
         val currentRegion by vm.contentRegion.collectAsState()
         var showRegionPicker by remember { mutableStateOf(false) }
+        val regionLabel = if (currentRegion == "nearest") {
+            stringResource(R.string.region_nearest)
+        } else {
+            currentRegion
+        }
         ListItem(
             headlineContent = { Text(stringResource(R.string.content_region), color = SpotifyWhite) },
-            supportingContent = { Text(currentRegion, color = SpotifyLightGray) },
+            supportingContent = { Text(regionLabel, color = SpotifyLightGray) },
             leadingContent = { Icon(Icons.Rounded.Language, null, tint = SpotifyLightGray) },
             trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
@@ -328,6 +333,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
                 text = {
                     Column {
                         listOf(
+                            "nearest" to stringResource(R.string.region_nearest),
                             "US" to stringResource(R.string.region_us),
                             "GB" to stringResource(R.string.region_gb),
                             "DE" to stringResource(R.string.region_de),

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -202,7 +202,7 @@ class SpotifyViewModel : ViewModel() {
     val notificationLeftButton = MutableStateFlow("repeat")
     val notificationRightButton = MutableStateFlow("like")
     // Content region for CDN resolution
-    val contentRegion = MutableStateFlow("US")
+    val contentRegion = MutableStateFlow("nearest")
     // Canvas background
     val canvasEnabled = MutableStateFlow(false)
     val canvasUrl = MutableStateFlow<String?>(null)
@@ -986,7 +986,7 @@ class SpotifyViewModel : ViewModel() {
                     .filter { it.isNotBlank() && it != "Unknown" }
                     .joinToString(" ")
                 val result = cdn.resolveStreamUrl(
-                    trackId, region = contentRegion.value,
+                    trackId, region = effectiveRegion(),
                     searchQuery = query, preferredSource = preferredAudioSource.value
                 )
                 if (result is StreamResult.Success) {
@@ -1430,6 +1430,19 @@ class SpotifyViewModel : ViewModel() {
             .edit().putString("content_region", region).apply()
     }
 
+    /**
+     * The 2-letter region passed to the CDN resolver. "nearest" resolves to the
+     * device's region at call time (from the system config, so the in-app
+     * language setting doesn't skew it); any other value is used as-is.
+     */
+    private fun effectiveRegion(): String {
+        if (contentRegion.value != "nearest") return contentRegion.value
+        val deviceCountry = android.content.res.Resources.getSystem().configuration.locales[0].country
+        val region = deviceCountry.takeIf { it.isNotBlank() } ?: "US"
+        LokiLogger.i(TAG, "Content region 'nearest' -> device country '$deviceCountry' -> using $region")
+        return region
+    }
+
     fun setLyricsAnimDirection(direction: String, context: Context) {
         lyricsAnimDirection.value = direction
         context.getSharedPreferences("kotify_prefs", Context.MODE_PRIVATE)
@@ -1474,7 +1487,7 @@ class SpotifyViewModel : ViewModel() {
             context.resources.updateConfiguration(config, context.resources.displayMetrics)
         }
         canvasEnabled.value = prefs.getBoolean("canvas_enabled", false)
-        contentRegion.value = prefs.getString("content_region", "US") ?: "US"
+        contentRegion.value = prefs.getString("content_region", "nearest") ?: "nearest"
         notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"
         notificationRightButton.value = prefs.getString("notification_right_button", "like") ?: "like"
     }
@@ -1880,7 +1893,7 @@ class SpotifyViewModel : ViewModel() {
         }
 
         try {
-            val result = cdn.resolveFromTrack(event, region = contentRegion.value, preferredSource = preferredAudioSource.value)
+            val result = cdn.resolveFromTrack(event, region = effectiveRegion(), preferredSource = preferredAudioSource.value)
             when (result) {
                 is StreamResult.Success -> {
                     // Don't resume Spotify yet — onReady callback will sync after ExoPlayer buffers
@@ -1940,7 +1953,7 @@ class SpotifyViewModel : ViewModel() {
                 val art = normalizeSpotifyImageUrl(track.imageLargeUrl ?: track.imageUrl)
 
                 val result = cdn.resolveStreamUrl(
-                    trackId, region = contentRegion.value,
+                    trackId, region = effectiveRegion(),
                     searchQuery = searchQuery, preferredSource = preferredAudioSource.value
                 )
                 when (result) {
@@ -1998,7 +2011,7 @@ class SpotifyViewModel : ViewModel() {
                 .joinToString(" ").takeIf { it.isNotBlank() }
 
             LokiLogger.i(TAG, "Pre-resolving next: $title by $artist")
-            val result = cdn.resolveStreamUrl(nextId, region = contentRegion.value, searchQuery = searchQuery, preferredSource = preferredAudioSource.value)
+            val result = cdn.resolveStreamUrl(nextId, region = effectiveRegion(), searchQuery = searchQuery, preferredSource = preferredAudioSource.value)
             if (result is StreamResult.Success) {
                 val info = result.info
                 val key = info.decryptionKey

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1432,14 +1432,26 @@ class SpotifyViewModel : ViewModel() {
 
     /**
      * The 2-letter region passed to the CDN resolver. "nearest" resolves to the
-     * device's region at call time (from the system config, so the in-app
-     * language setting doesn't skew it); any other value is used as-is.
+     * device's real country at call time, preferring the mobile-network country
+     * (where you physically are, roaming-aware), then the SIM's home country,
+     * then the system locale region. The telephony signals are tried first
+     * because the locale region only reflects the language/region *setting* — a
+     * user in Switzerland with an English phone would otherwise resolve to the
+     * wrong region. Any value other than "nearest" is used as-is.
      */
     private fun effectiveRegion(): String {
         if (contentRegion.value != "nearest") return contentRegion.value
-        val deviceCountry = android.content.res.Resources.getSystem().configuration.locales[0].country
-        val region = deviceCountry.takeIf { it.isNotBlank() } ?: "US"
-        LokiLogger.i(TAG, "Content region 'nearest' -> device country '$deviceCountry' -> using $region")
+        val tm = appContext?.getSystemService(Context.TELEPHONY_SERVICE) as? android.telephony.TelephonyManager
+        val net = tm?.networkCountryIso
+        val sim = tm?.simCountryIso
+        val locale = android.content.res.Resources.getSystem().configuration.locales[0].country
+        // Keep only letters so a dual-SIM phone's "ch," collapses to "ch", then
+        // take the first signal that yields a 2-letter code.
+        val region = listOf(net, sim, locale)
+            .firstNotNullOfOrNull { it?.filter(Char::isLetter)?.take(2)?.takeIf { c -> c.length == 2 } }
+            ?.uppercase(java.util.Locale.ROOT)
+            ?: "US"
+        LokiLogger.i(TAG, "Content region 'nearest' -> net='$net' sim='$sim' locale='$locale' -> $region")
         return region
     }
 

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -53,7 +53,7 @@
     <string name="log_out">Abmelde</string>
 
     <!-- Settings -->
-    <string name="lossless_audio">Verlustfreii Audio</string>
+    <string name="lossless_audio">Verlustfreii Audio (Beta)</string>
     <string name="lossless_on">FLAC über %s</string>
     <string name="lossless_off">Standardqualität</string>
     <string name="lossless_provider">Verlustfreii Quelle</string>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -53,7 +53,7 @@
     <string name="log_out">Abmelden</string>
 
     <!-- Settings -->
-    <string name="lossless_audio">Verlustfreies Audio</string>
+    <string name="lossless_audio">Verlustfreies Audio (Beta)</string>
     <string name="lossless_on">FLAC über %s</string>
     <string name="lossless_off">Standardqualität</string>
     <string name="lossless_provider">Verlustfreier Anbieter</string>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -53,7 +53,7 @@
     <string name="log_out">Выйти</string>
 
     <!-- Settings -->
-    <string name="lossless_audio">Без потерь</string>
+    <string name="lossless_audio">Без потерь (Beta)</string>
     <string name="lossless_on">FLAC через %s</string>
     <string name="lossless_off">Стандартное качество</string>
     <string name="lossless_provider">Источник без потерь</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -55,7 +55,7 @@
     <string name="log_out">Log out</string>
 
     <!-- Settings -->
-    <string name="lossless_audio">Lossless Audio</string>
+    <string name="lossless_audio">Lossless Audio (Beta)</string>
     <string name="lossless_on">FLAC via %s</string>
     <string name="lossless_on_flac">FLAC</string>
     <string name="lossless_off">Standard quality</string>
@@ -133,6 +133,7 @@
     <string name="notif_like_short_desc">Toggle liked state</string>
 
     <!-- Regions -->
+    <string name="region_nearest">Nearest (auto)</string>
     <string name="region_us">United States</string>
     <string name="region_gb">United Kingdom</string>
     <string name="region_de">Germany</string>


### PR DESCRIPTION
Two Account-settings tweaks:
- Label the Lossless Audio toggle '(Beta)'.
- Add a 'Nearest (auto)' content-region option that resolves to the device's region at resolve time (via the system config, so the in-app language doesn't skew it), and make it the default for new installs.

assembleDebug + detekt green. UI verified on emulator (the '(Beta)' label and the 'Nearest (auto)' picker entry both render).

Closes #283