### PR TITLE
Add dev/prod product flavors for side-by-side builds

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -100,12 +100,12 @@ jobs:
         working-directory: ./src
         run: |
           chmod +x ./gradlew
-          ./gradlew assembleRelease
+          ./gradlew assembleProdRelease
 
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts
-          cp src/app/build/outputs/apk/release/app-release.apk artifacts/snepilatch-${{ github.ref_name }}.apk
+          cp src/app/build/outputs/apk/prod/release/app-prod-release.apk artifacts/snepilatch-${{ github.ref_name }}.apk
 
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v4

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,7 +77,7 @@ Rules:
 
 ## Tests
 
-Unit tests live in `app/src/test/`. Run with `./gradlew :app:testDebugUnitTest`.
+Unit tests live in `app/src/test/`. Run with `./gradlew :app:testProdDebugUnitTest` (or `:app:test` for every variant). The test source set is shared across flavors, so prod and dev run the same tests.
 
 - **Pure helpers** (`util/`) get straightforward JUnit tests. See `SpotifyImageUrlTest`, `FormatUtilsTest`.
 - **ViewModel handlers** use `PlaybackTestRig` which mocks `MusicPlaybackService.instance` via `mockk` and swaps the Main dispatcher. See `RemotePlayPauseHandlerTest`.
@@ -87,8 +87,9 @@ When you fix a playback bug, **add a test that would have caught it.** The "brow
 
 ## Build
 
-- `./gradlew :app:assembleDebug` — debug APK
-- `./gradlew :app:testDebugUnitTest` — unit tests
+- Two product flavors on the `environment` dimension: **prod** (`ch.snepilatch.app`, "Snepilatch") and **dev** (`ch.snepilatch.app.dev`, "Snepilatch Dev", `-dev` versionName). They differ only in identity — same code — so a dev build installs alongside the shipped app. Variants are `{prod,dev}{Debug,Release}`.
+- `./gradlew :app:assembleDebug` — both debug APKs (`assembleProdDebug` / `assembleDevDebug` for one)
+- `./gradlew :app:testProdDebugUnitTest` — unit tests (`:app:test` for every variant)
 - KotifyClient is consumed as a local jar: `app/libs/KotifyClient.jar`. Rebuild with `cd ../KotifyClient && ./gradlew obfuscate` and copy `build/libs/KotifyClient-obfuscated.jar` over.
 - Two `.so` files per ABI in `app/src/main/jniLibs/<abi>/` are required at runtime: `libtls_client_go.so` (the Go TLS engine) and `libjnidispatch.so` (JNA's native dispatcher — JNA can't extract its own `.so` at runtime on Android due to W^X). CI re-fetches both on every release build; for local dev, the committed copies are fine unless KotifyClient bumps its kotlin-tls-client or JNA version. See `CLAUDE.md` for the bump procedure.
 - Local logs go to Loki when `loki.endpoint` is set in `local.properties` (gitignored). Otherwise logs are local.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,17 @@ CI (`.github/workflows/build-and-release.yml`) re-fetches the latest natives rel
 ```sh
 cd src
 ./gradlew :app:assembleDebug
-./gradlew :app:testDebugUnitTest
+./gradlew :app:testProdDebugUnitTest
 ./gradlew detekt
 ```
 
 All three must be green. The test rig + detekt baseline catch most regressions before they reach a phone.
+
+## Build flavors
+
+There are two product flavors on the `environment` dimension: **prod** (`ch.snepilatch.app`, "Snepilatch" — what ships) and **dev** (`ch.snepilatch.app.dev`, "Snepilatch Dev", `-dev` versionName suffix). They differ only in identity, not behaviour, so a dev build installs side-by-side with the production app.
+
+Variant task names are flavor-qualified: `assembleProdDebug` / `assembleDevDebug`, `testProdDebugUnitTest` / `testDevDebugUnitTest`. The umbrella `assembleDebug` still builds both; there is no `testDebugUnitTest` anymore — use `:app:testProdDebugUnitTest` or `:app:test`. The dev `app_name` override lives in `app/src/dev/res/values/strings.xml`. The release pipeline builds `assembleProdRelease`.
 
 ## Test rig
 

--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -72,6 +72,22 @@ android {
             )
         }
     }
+
+    // Two environments so a Dev build can sit side-by-side with the shipped app.
+    // "prod" is the default and what the release pipeline builds; "dev" gets its
+    // own applicationId/name/version suffix and overrides app_name via the
+    // src/dev/ source set. No behavioural difference between the two.
+    flavorDimensions += "environment"
+    productFlavors {
+        create("prod") {
+            dimension = "environment"
+        }
+        create("dev") {
+            dimension = "environment"
+            applicationIdSuffix = ".dev"
+            versionNameSuffix = "-dev"
+        }
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11

--- a/src/app/src/dev/res/values/strings.xml
+++ b/src/app/src/dev/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Overrides the main app_name for the dev flavor so the Dev build is
+         visually distinct on-device and can be installed alongside prod. -->
+    <string name="app_name">Snepilatch Dev</string>
+</resources>


### PR DESCRIPTION
Closes #285.

## What
Adds an `environment` flavor dimension with two product flavors so a **Dev** build installs alongside the shipped app:

| Flavor | applicationId | App name | versionName |
|--------|---------------|----------|-------------|
| **prod** (default) | `ch.snepilatch.app` | Snepilatch | `2.4.3` |
| **dev** | `ch.snepilatch.app.dev` | Snepilatch Dev | `2.4.3-dev` |

Separate installable variant only — no runtime/behavioural changes; both flavors share the same code and test source set.

## Changes
- `src/app/build.gradle.kts` — `flavorDimensions += "environment"` + `prod`/`dev` flavors (dev gets `applicationIdSuffix = ".dev"`, `versionNameSuffix = "-dev"`).
- `src/app/src/dev/res/values/strings.xml` — overrides `app_name` to "Snepilatch Dev" for the dev flavor only.
- `.github/workflows/build-and-release.yml` — release build now runs `assembleProdRelease` and ships the prod-flavor APK (variant output paths changed).
- `CLAUDE.md` / `ARCHITECTURE.md` — document the flavors and the new variant task names (`testDebugUnitTest` is gone → `:app:testProdDebugUnitTest` / `:app:test`).

## Verification
- `./gradlew :app:assembleDebug` → builds both `assembleDevDebug` + `assembleProdDebug` ✅
- `aapt dump badging` on both APKs confirms the appId / label / versionName above ✅
- `./gradlew :app:test` (both flavor unit tests) ✅
- `./gradlew detekt` ✅