### PR TITLE
Bump GitHub Actions to latest majors (Node 24)

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -105,7 +105,11 @@ jobs:
       - name: Prepare artifacts
         run: |
           mkdir -p artifacts
-          cp src/app/build/outputs/apk/prod/release/app-prod-release.apk artifacts/snepilatch-${{ github.ref_name }}.apk
+          # Sanitize the ref name so a slash in a branch (e.g. feature/x on a
+          # workflow_dispatch dry run) doesn't make cp treat it as a directory.
+          # Tags used for real releases have no slash and are unaffected.
+          safe_ref="${GITHUB_REF_NAME//\//-}"
+          cp src/app/build/outputs/apk/prod/release/app-prod-release.apk "artifacts/snepilatch-${safe_ref}.apk"
 
       - name: Upload Android artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -108,7 +108,7 @@ jobs:
           cp src/app/build/outputs/apk/prod/release/app-prod-release.apk artifacts/snepilatch-${{ github.ref_name }}.apk
 
       - name: Upload Android artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-build
           path: artifacts/
@@ -119,10 +119,10 @@ jobs:
     if: github.event_name == 'release'
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
 
       - name: Upload Assets to Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             android-build/snepilatch-${{ github.ref_name }}.apk

--- a/.github/workflows/guard.yml
+++ b/.github/workflows/guard.yml
@@ -8,7 +8,7 @@ jobs:
   no-committed-jars:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # KotifyClient.jar (and any jar under src/app/libs) must NEVER be committed.
       # It is downloaded from KotifyClient's release and baked into the app by

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,8 +11,8 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: release-drafter/release-drafter@v6
+      - uses: actions/checkout@v6
+      - uses: release-drafter/release-drafter@v7
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '18'
 
@@ -71,7 +71,7 @@ jobs:
           git push origin "v${{ steps.new_version.outputs.version }}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: "v${{ steps.new_version.outputs.version }}"
           name: "Snepilatch v${{ steps.new_version.outputs.version }}"


### PR DESCRIPTION
Bumps every workflow action to its latest major so they run on Node.js 24 ahead of GitHub's June 16th forced cutover: checkout v6, setup-java v5, upload-artifact v7, download-artifact v8, setup-node v6, action-gh-release v3, release-drafter v7.

Closes #288