### PR TITLE
Clean up build warnings (string format + deprecated APIs)

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -14,6 +14,7 @@ import android.support.v4.media.MediaMetadataCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import android.os.Bundle
+import androidx.annotation.OptIn
 import androidx.core.app.NotificationCompat
 import ch.snepilatch.app.R
 import ch.snepilatch.app.util.LokiLogger

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
@@ -31,7 +31,8 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -57,7 +58,10 @@ fun DevicesDialog(vm: SpotifyViewModel) {
     val playback by vm.playback.collectAsState()
     val theme by vm.themeColors.collectAsState()
     val accentColor by androidx.compose.animation.animateColorAsState(theme.primary, androidx.compose.animation.core.tween(800), label = "devAccent")
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    )
     val ourId = vm.ourDeviceId
 
     // Sort: active device first

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -173,7 +173,10 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
 
     // Bottom sheet menu
     if (showMenu) {
-        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
         ModalBottomSheet(
             onDismissRequest = { showMenu = false },
             sheetState = sheetState,

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -545,7 +545,10 @@ private fun ArtistTrackRow(
             Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
         if (showMenu) {
-            val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            val sheetState = rememberBottomSheetState(
+                initialValue = SheetValue.Hidden,
+                enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+            )
             ModalBottomSheet(
                 onDismissRequest = { showMenu = false },
                 sheetState = sheetState,
@@ -667,7 +670,10 @@ private fun AlbumTrackRow(
             Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpotifyLightGray, modifier = Modifier.size(20.dp))
         }
         if (showMenu) {
-            val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+            val sheetState = rememberBottomSheetState(
+                initialValue = SheetValue.Hidden,
+                enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+            )
             ModalBottomSheet(
                 onDismissRequest = { showMenu = false },
                 sheetState = sheetState,
@@ -760,13 +766,13 @@ private fun DetailHeaderMenu(
     context: android.content.Context,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val trackUris = detail.tracks.map { it.uri }
-    val type = detail.type
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    )
+    val trackUris = detail.tracks.map { it.uri }; val hasTracks = trackUris.isNotEmpty(); val type = detail.type
     val isAlbum = type == "album"; val isCollection = type == "collection"; val isArtist = type == "artist"
-    val hasTracks = trackUris.isNotEmpty()
-    val shareLabel = stringResource(R.string.share)
-    val addToQueueLabel = stringResource(R.string.add_to_queue)
+    val shareLabel = stringResource(R.string.share); val addToQueueLabel = stringResource(R.string.add_to_queue)
     val addToPlaylistLabel = stringResource(R.string.add_to_playlist)
     val visitArtistLabel = stringResource(R.string.visit_artist)
     ModalBottomSheet(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -1043,7 +1043,10 @@ private fun NowPlayingMenu(
     }
 
     if (showMore) {
-        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        val sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        )
         ModalBottomSheet(
             onDismissRequest = { onShowMore(false) },
             sheetState = sheetState,

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -49,7 +49,7 @@
     <string name="user_id">Benutzer-ID</string>
     <string name="plan">Abo</string>
     <string name="plan_free">Gratis</string>
-    <string name="followers_playlists">%d Follower · %d Playlists</string>
+    <string name="followers_playlists">%1$d Follower · %2$d Playlists</string>
     <string name="log_out">Abmelde</string>
 
     <!-- Settings -->

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -49,7 +49,7 @@
     <string name="user_id">Benutzer-ID</string>
     <string name="plan">Abo</string>
     <string name="plan_free">Kostenlos</string>
-    <string name="followers_playlists">%d Follower · %d Playlists</string>
+    <string name="followers_playlists">%1$d Follower · %2$d Playlists</string>
     <string name="log_out">Abmelden</string>
 
     <!-- Settings -->

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -49,7 +49,7 @@
     <string name="user_id">ID пользователя</string>
     <string name="plan">Подписка</string>
     <string name="plan_free">Бесплатно</string>
-    <string name="followers_playlists">%d подписчиков · %d плейлистов</string>
+    <string name="followers_playlists">%1$d подписчиков · %2$d плейлистов</string>
     <string name="log_out">Выйти</string>
 
     <!-- Settings -->

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -51,7 +51,7 @@
     <string name="user_id">User ID</string>
     <string name="plan">Plan</string>
     <string name="plan_free">Free</string>
-    <string name="followers_playlists">%d Followers · %d Playlists</string>
+    <string name="followers_playlists">%1$d Followers · %2$d Playlists</string>
     <string name="log_out">Log out</string>
 
     <!-- Settings -->


### PR DESCRIPTION
Clears the warnings flagged during the build:
- followers_playlists now uses positional %1$d/%2$d in all four locales — the two non-positional %d args were a latent crash in translated strings (values-de, values-ru, values-b+gsw).
- The two @OptIn(UnstableApi) sites in MusicPlaybackService now use androidx.annotation.OptIn (media3's UnstableApi is an AndroidX RequiresOptIn marker, so Kotlin's @OptIn had no effect).
- Migrated all six rememberModalBottomSheetState usages to rememberBottomSheetState(initialValue = SheetValue.Hidden, enabledValues = {Hidden, Expanded}).

detekt, testDevDebugUnitTest and assembleDevDebug all green.

Closes #290