### PR TITLE
Interactive mini-player morph into full player

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
@@ -31,9 +31,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.layout.boundsInRoot
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -45,21 +44,25 @@ import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 /**
+ * Base fill colour of the mini-player card. Shared with the expanding-player morph
+ * (PlayerMorph in SpotifyApp) so the hand-off from bar to growing card has no
+ * colour seam — both must derive the fill from the same tint of the album colour.
+ */
+fun miniCardBaseColor(primary: Color): Color = lerp(SpotifyElevated, primary, 0.18f)
+
+/**
  * The compact now-playing bar — a rounded card around [MiniPlayerContent].
  * Gesture-free: the parent supplies tap/drag via [modifier] so the same bar acts
  * as the collapsed anchor of the expanding player morph (see SpotifyApp).
- * [cardCornerRadius] lets the morph un-round the card as it grows to fullscreen.
  */
 @Composable
 fun MiniPlayer(
     vm: SpotifyViewModel,
-    modifier: Modifier = Modifier,
-    cardCornerRadius: androidx.compose.ui.unit.Dp = 12.dp,
-    onArtworkBounds: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null
+    modifier: Modifier = Modifier
 ) {
     val theme by vm.themeColors.collectAsState()
     val animatedCardBg by animateColorAsState(
-        lerp(SpotifyElevated, theme.primary, 0.18f),
+        miniCardBaseColor(theme.primary),
         tween(800), label = "miniCardBg"
     )
 
@@ -70,13 +73,12 @@ fun MiniPlayer(
             .padding(horizontal = 12.dp, vertical = 6.dp)
             .shadow(
                 elevation = 12.dp,
-                shape = RoundedCornerShape(cardCornerRadius),
+                shape = RoundedCornerShape(12.dp),
                 ambientColor = animatedCardBg,
                 spotColor = animatedCardBg
             )
-            .clip(RoundedCornerShape(cardCornerRadius))
-            .background(animatedCardBg),
-        onArtworkBounds = onArtworkBounds
+            .clip(RoundedCornerShape(12.dp))
+            .background(animatedCardBg)
     )
 }
 
@@ -88,8 +90,7 @@ fun MiniPlayer(
 @Composable
 fun MiniPlayerContent(
     vm: SpotifyViewModel,
-    modifier: Modifier = Modifier,
-    onArtworkBounds: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null
+    modifier: Modifier = Modifier
 ) {
     val playback by vm.playback.collectAsState()
     val track = playback.track ?: return
@@ -106,9 +107,7 @@ fun MiniPlayerContent(
         ) {
             SpotifyImage(
                 url = track.albumArt,
-                modifier = Modifier
-                    .size(44.dp)
-                    .onGloballyPositioned { onArtworkBounds?.invoke(it.boundsInRoot()) },
+                modifier = Modifier.size(44.dp),
                 shape = RoundedCornerShape(8.dp)
             )
             Spacer(Modifier.width(10.dp))

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
@@ -6,8 +6,6 @@ import ch.snepilatch.app.ui.theme.SpotifyWhite
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -34,49 +32,72 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.R
-import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
+/**
+ * The compact now-playing bar — a rounded card around [MiniPlayerContent].
+ * Gesture-free: the parent supplies tap/drag via [modifier] so the same bar acts
+ * as the collapsed anchor of the expanding player morph (see SpotifyApp).
+ * [cardCornerRadius] lets the morph un-round the card as it grows to fullscreen.
+ */
 @Composable
-fun MiniPlayer(vm: SpotifyViewModel) {
-    val playback by vm.playback.collectAsState()
-    val track = playback.track ?: return
+fun MiniPlayer(
+    vm: SpotifyViewModel,
+    modifier: Modifier = Modifier,
+    cardCornerRadius: androidx.compose.ui.unit.Dp = 12.dp,
+    onArtworkBounds: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null
+) {
     val theme by vm.themeColors.collectAsState()
-    val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "miniPrimary")
     val animatedCardBg by animateColorAsState(
         lerp(SpotifyElevated, theme.primary, 0.18f),
         tween(800), label = "miniCardBg"
     )
-    val streamLoading by vm.isStreamLoading.collectAsState()
 
-    Column(
-        modifier = Modifier
+    MiniPlayerContent(
+        vm,
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 6.dp)
             .shadow(
                 elevation = 12.dp,
-                shape = RoundedCornerShape(12.dp),
+                shape = RoundedCornerShape(cardCornerRadius),
                 ambientColor = animatedCardBg,
                 spotColor = animatedCardBg
             )
-            .clip(RoundedCornerShape(12.dp))
-            .background(animatedCardBg)
-            .pointerInput(Unit) {
-                detectVerticalDragGestures { _, dragAmount ->
-                    if (dragAmount < -30) vm.navigateTo(Screen.NOW_PLAYING)
-                }
-            }
-            .clickable { vm.navigateTo(Screen.NOW_PLAYING) }
-    ) {
+            .clip(RoundedCornerShape(cardCornerRadius))
+            .background(animatedCardBg),
+        onArtworkBounds = onArtworkBounds
+    )
+}
+
+/**
+ * The mini-player's inner content (artwork + title + transport + progress),
+ * without the card chrome — so the expanding-player morph can render it inside
+ * the growing card while it stretches to fullscreen.
+ */
+@Composable
+fun MiniPlayerContent(
+    vm: SpotifyViewModel,
+    modifier: Modifier = Modifier,
+    onArtworkBounds: ((androidx.compose.ui.geometry.Rect) -> Unit)? = null
+) {
+    val playback by vm.playback.collectAsState()
+    val track = playback.track ?: return
+    val theme by vm.themeColors.collectAsState()
+    val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "miniPrimary")
+    val streamLoading by vm.isStreamLoading.collectAsState()
+
+    Column(modifier.fillMaxWidth()) {
         Row(
             Modifier
                 .fillMaxWidth()
@@ -85,7 +106,9 @@ fun MiniPlayer(vm: SpotifyViewModel) {
         ) {
             SpotifyImage(
                 url = track.albumArt,
-                modifier = Modifier.size(44.dp),
+                modifier = Modifier
+                    .size(44.dp)
+                    .onGloballyPositioned { onArtworkBounds?.invoke(it.boundsInRoot()) },
                 shape = RoundedCornerShape(8.dp)
             )
             Spacer(Modifier.width(10.dp))

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -24,9 +24,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -48,38 +50,33 @@ import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.formatTime
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
+/**
+ * The now-playing background: Canvas video when enabled, otherwise the album's
+ * accent colour with the blurred album art over it, topped by a dark scrim.
+ * Extracted so the expanding-player morph (SpotifyApp) can render the same *live*
+ * background — video included — inside the growing card, anchored to it, instead
+ * of a still. The video transform is recomputed on view resize so it stays
+ * fit-cropped while the card grows.
+ */
 @Composable
-fun NowPlayingScreen(vm: SpotifyViewModel) {
+fun PlayerBackground(vm: SpotifyViewModel, modifier: Modifier = Modifier) {
     val playback by vm.playback.collectAsState()
     val track = playback.track
-    val streamLoading by vm.isStreamLoading.collectAsState()
     val theme by vm.themeColors.collectAsState()
-
-    val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "primary")
-    val buttonBg = Color.White.copy(alpha = 0.12f)
-
-    var showMore by remember { mutableStateOf(false) }
-    var showPlaylistPicker by remember { mutableStateOf(false) }
-    val shareContext = LocalContext.current
-    val shareTrackLabel = stringResource(R.string.share_track_chooser)
+    val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "bgPrimary")
     val canvasVideoUrl by vm.canvasUrl.collectAsState()
     val canvasOn by vm.canvasEnabled.collectAsState()
     val hasCanvas = canvasOn && canvasVideoUrl != null
-    // Brighter text in canvas mode for readability over video
-    val secondaryText = if (hasCanvas) SpotifyWhite.copy(alpha = 0.85f) else SpotifyLightGray
-    val tertiaryText = if (hasCanvas) SpotifyWhite.copy(alpha = 0.65f) else SpotifyLightGray.copy(alpha = 0.7f)
 
-    Box(Modifier.fillMaxSize()) {
-        // Background layer (hazeSource for blur panels)
-        Box(Modifier.fillMaxSize()) {
+    Box(modifier) {
         // Canvas video background (looping, muted)
         if (canvasOn && canvasVideoUrl != null) {
             val context = LocalContext.current
+            val density = LocalDensity.current
             var canvasPlayer by remember { mutableStateOf<ExoPlayer?>(null) }
-
             var textureRef by remember { mutableStateOf<TextureView?>(null) }
             var surfaceReady by remember { mutableStateOf(false) }
+            var videoSizePx by remember { mutableStateOf(0 to 0) }
 
             val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
             DisposableEffect(canvasVideoUrl, lifecycleOwner) {
@@ -90,19 +87,7 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                     playWhenReady = true
                     addListener(object : Player.Listener {
                         override fun onVideoSizeChanged(videoSize: androidx.media3.common.VideoSize) {
-                            val tv = textureRef ?: return
-                            val viewW = tv.width.toFloat()
-                            val viewH = tv.height.toFloat()
-                            val videoW = videoSize.width.toFloat()
-                            val videoH = videoSize.height.toFloat()
-                            if (viewW == 0f || viewH == 0f || videoW == 0f || videoH == 0f) return
-                            val scale = maxOf(viewW / videoW, viewH / videoH)
-                            val scaledW = videoW * scale
-                            val scaledH = videoH * scale
-                            val matrix = android.graphics.Matrix()
-                            matrix.setScale(scaledW / viewW, scaledH / viewH)
-                            matrix.postTranslate((viewW - scaledW) / 2f, (viewH - scaledH) / 2f)
-                            tv.setTransform(matrix)
+                            videoSizePx = videoSize.width to videoSize.height
                         }
                     })
                     prepare()
@@ -141,39 +126,62 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                 }
             }
 
-            AndroidView(
-                factory = { ctx ->
-                    TextureView(ctx).apply {
-                        surfaceTextureListener = object : TextureView.SurfaceTextureListener {
-                            override fun onSurfaceTextureAvailable(
-                                surface: SurfaceTexture, width: Int, height: Int
-                            ) {
-                                surfaceReady = true
-                                textureRef = this@apply
-                                canvasPlayer?.setVideoTextureView(this@apply)
+            // Size the TextureView to COVER the (growing) card at the video's aspect
+            // ratio, then centre + clip it. The view's own bounds already match the
+            // video aspect, so the raw TextureView fills them without distortion — no
+            // per-frame matrix that loses the race with layout while the card resizes.
+            BoxWithConstraints(Modifier.fillMaxSize().clipToBounds()) {
+                val (vw, vh) = videoSizePx
+                val boxW = constraints.maxWidth.toFloat()
+                val boxH = constraints.maxHeight.toFloat()
+                val coverMod = if (vw > 0 && vh > 0 && minOf(boxW, boxH) > 0f) {
+                    val scale = maxOf(boxW / vw, boxH / vh)
+                    // requiredSize, not size: the cover width can exceed the box
+                    // (1080px) and must NOT be clamped to it, or the video gets
+                    // squished horizontally. The overflow is clipped by clipToBounds.
+                    Modifier.requiredSize(
+                        with(density) { (vw * scale).toDp() },
+                        with(density) { (vh * scale).toDp() }
+                    )
+                } else {
+                    Modifier.fillMaxSize()
+                }
+                AndroidView(
+                    factory = { ctx ->
+                        TextureView(ctx).apply {
+                            surfaceTextureListener = object : TextureView.SurfaceTextureListener {
+                                override fun onSurfaceTextureAvailable(
+                                    surface: SurfaceTexture, width: Int, height: Int
+                                ) {
+                                    surfaceReady = true
+                                    textureRef = this@apply
+                                    canvasPlayer?.setVideoTextureView(this@apply)
+                                }
+                                override fun onSurfaceTextureSizeChanged(
+                                    surface: SurfaceTexture, width: Int, height: Int
+                                ) {}
+                                override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
+                                    surfaceReady = false
+                                    canvasPlayer?.clearVideoTextureView(this@apply)
+                                    return true
+                                }
+                                override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {}
                             }
-                            override fun onSurfaceTextureSizeChanged(
-                                surface: SurfaceTexture, width: Int, height: Int
-                            ) {}
-                            override fun onSurfaceTextureDestroyed(surface: SurfaceTexture): Boolean {
-                                surfaceReady = false
-                                canvasPlayer?.clearVideoTextureView(this@apply)
-                                return true
-                            }
-                            override fun onSurfaceTextureUpdated(surface: SurfaceTexture) {}
+                            textureRef = this
                         }
-                        textureRef = this
-                    }
-                },
-                update = { texture ->
-                    if (surfaceReady) {
-                        canvasPlayer?.setVideoTextureView(texture)
-                    }
-                },
-                modifier = Modifier.fillMaxSize()
-            )
+                    },
+                    update = { texture ->
+                        if (surfaceReady) {
+                            canvasPlayer?.setVideoTextureView(texture)
+                        }
+                    },
+                    modifier = coverMod.align(Alignment.Center)
+                )
+            }
         } else {
-            // Blurred album art background — animated crossfade
+            // Solid one-colour base (the album's accent) under the blurred art.
+            Box(Modifier.fillMaxSize().background(animatedPrimary))
+            // Blurred album art.
             var displayedArt by remember { mutableStateOf(track?.albumArt) }
             if (track?.albumArt != null) displayedArt = track.albumArt
             androidx.compose.animation.Crossfade(
@@ -188,8 +196,6 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                         contentScale = ContentScale.Crop,
                         modifier = Modifier.fillMaxSize().blur(80.dp)
                     )
-                } else {
-                    Box(Modifier.fillMaxSize().background(Color.Black))
                 }
             }
         }
@@ -199,7 +205,48 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                 .fillMaxSize()
                 .background(Color.Black.copy(alpha = if (hasCanvas) 0.35f else 0.45f))
         )
-        } // end hazeSource Box
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NowPlayingScreen(
+    vm: SpotifyViewModel,
+    /** When false, the screen paints no background of its own — the morphing card
+     *  in SpotifyApp supplies a card-anchored background that grows with it. */
+    drawBackground: Boolean = true,
+    /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse;
+     *  when set, replaces the standalone swipe-down-to-dismiss. */
+    onMorphDrag: ((Float) -> Unit)? = null,
+    /** Drag release with vertical velocity (px/s) so the morph can settle. */
+    onMorphDragEnd: ((Float) -> Unit)? = null
+) {
+    val playback by vm.playback.collectAsState()
+    val track = playback.track
+    val streamLoading by vm.isStreamLoading.collectAsState()
+    val theme by vm.themeColors.collectAsState()
+
+    val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "primary")
+    val buttonBg = Color.White.copy(alpha = 0.12f)
+
+    var showMore by remember { mutableStateOf(false) }
+    var showPlaylistPicker by remember { mutableStateOf(false) }
+    val shareContext = LocalContext.current
+    val shareTrackLabel = stringResource(R.string.share_track_chooser)
+    val canvasVideoUrl by vm.canvasUrl.collectAsState()
+    val canvasOn by vm.canvasEnabled.collectAsState()
+    val hasCanvas = canvasOn && canvasVideoUrl != null
+    // Brighter text in canvas mode for readability over video
+    val secondaryText = if (hasCanvas) SpotifyWhite.copy(alpha = 0.85f) else SpotifyLightGray
+    val tertiaryText = if (hasCanvas) SpotifyWhite.copy(alpha = 0.65f) else SpotifyLightGray.copy(alpha = 0.7f)
+
+    Box(Modifier.fillMaxSize()) {
+        // Background (Canvas video, or album colour + blurred art + scrim). Skipped
+        // during the morph, where the growing card renders the same PlayerBackground
+        // card-anchored so the live background grows with the card.
+        if (drawBackground) {
+            PlayerBackground(vm, Modifier.fillMaxSize())
+        }
 
         BoxWithConstraints(Modifier.fillMaxSize()) {
             val isLandscape = maxWidth > maxHeight
@@ -559,15 +606,28 @@ fun NowPlayingScreen(vm: SpotifyViewModel) {
                 Column(
                     Modifier
                         .fillMaxSize()
-                        .pointerInput(Unit) {
-                            var totalDrag = 0f
-                            var handled = false
-                            detectVerticalDragGestures(
-                                onDragStart = { totalDrag = 0f; handled = false },
-                                onDragEnd = { if (totalDrag > 80 && !handled) { handled = true; vm.goBack() } },
-                                onDragCancel = { totalDrag = 0f; handled = false }
-                            ) { _, dragAmount ->
-                                totalDrag += dragAmount
+                        .pointerInput(onMorphDrag) {
+                            if (onMorphDrag != null) {
+                                // Finger-tracked collapse driven by the parent morph.
+                                val tracker = androidx.compose.ui.input.pointer.util.VelocityTracker()
+                                detectVerticalDragGestures(
+                                    onDragStart = { tracker.resetTracking() },
+                                    onDragEnd = { onMorphDragEnd?.invoke(tracker.calculateVelocity().y) },
+                                    onDragCancel = { onMorphDragEnd?.invoke(0f) }
+                                ) { change, dragAmount ->
+                                    tracker.addPosition(change.uptimeMillis, change.position)
+                                    onMorphDrag(dragAmount)
+                                }
+                            } else {
+                                var totalDrag = 0f
+                                var handled = false
+                                detectVerticalDragGestures(
+                                    onDragStart = { totalDrag = 0f; handled = false },
+                                    onDragEnd = { if (totalDrag > 80 && !handled) { handled = true; vm.goBack() } },
+                                    onDragCancel = { totalDrag = 0f; handled = false }
+                                ) { _, dragAmount ->
+                                    totalDrag += dragAmount
+                                }
                             }
                         }
                         .navigationBarsPadding()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -3,7 +3,10 @@ package ch.snepilatch.app.ui.screens
 import ch.snepilatch.app.ui.theme.SpotifyWhite
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.ui.draw.shadow
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -47,7 +50,9 @@ import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.components.BottomNav
 import ch.snepilatch.app.ui.components.DevicesDialog
 import ch.snepilatch.app.ui.components.MiniPlayer
+import ch.snepilatch.app.ui.components.MiniPlayerContent
 import ch.snepilatch.app.ui.components.SpotifyImage
+import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
@@ -57,6 +62,23 @@ import dev.chrisbanes.haze.hazeSource
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.util.lerp
+import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 /** Dp height of the bottom overlay (MiniPlayer + BottomNav). Screens use this for bottom padding. */
 val LocalBottomOverlayHeight = compositionLocalOf { mutableStateOf(0.dp) }
@@ -72,6 +94,29 @@ fun SpotifyApp(vm: SpotifyViewModel) {
     val snackbarHostState = remember { SnackbarHostState() }
     val bottomOverlayHeight = remember { mutableStateOf(0.dp) }
     val density = LocalDensity.current
+    val scope = rememberCoroutineScope()
+
+    val hasTrack = playback.track != null
+    // 0f = mini bar, 1f = full player. Single source of truth for the morph.
+    val expand = remember { Animatable(0f) }
+    // The full player counts as "open" for NOW_PLAYING and for LYRICS (which
+    // overlays it), so toggling lyrics doesn't collapse + re-expand it behind.
+    val expandedTarget = hasTrack && (screen == Screen.NOW_PLAYING || screen == Screen.LYRICS)
+    // Settle the spring whenever the committed screen changes (tap, back, queue,
+    // lyrics). Interactive drags snapTo directly, then commit a screen change so
+    // this effect finishes to the same target.
+    LaunchedEffect(expandedTarget) {
+        expand.animateTo(
+            if (expandedTarget) 1f else 0f,
+            animationSpec = spring(dampingRatio = 0.9f, stiffness = 380f)
+        )
+    }
+    // Keep a real content screen rendered behind the player, so collapsing reveals
+    // it instead of a blank. NOW_PLAYING/LYRICS are overlays, not content screens.
+    var contentScreen by remember { mutableStateOf(Screen.HOME) }
+    LaunchedEffect(screen) {
+        if (screen != Screen.NOW_PLAYING && screen != Screen.LYRICS) contentScreen = screen
+    }
 
     LaunchedEffect(Unit) {
         vm.snackbarMessage.collect { message ->
@@ -82,26 +127,17 @@ fun SpotifyApp(vm: SpotifyViewModel) {
     BackHandler(screen != Screen.HOME) { vm.goBack() }
 
     CompositionLocalProvider(LocalBottomOverlayHeight provides bottomOverlayHeight) {
-    Box(Modifier.fillMaxSize()) {
-        // Main content — fills entire screen, hazeSource for blur
-        Box(
-            Modifier
-                .fillMaxSize()
-                .statusBarsPadding()
-                .hazeSource(hazeState)
-        ) {
-            when (screen) {
-                Screen.HOME -> HomeScreen(vm)
-                Screen.SEARCH -> SearchScreen(vm)
-                Screen.LIBRARY -> { LaunchedEffect(Unit) { vm.loadLibrary() }; LibraryScreen(vm) }
-                Screen.ACCOUNT -> AccountScreen(vm)
-                Screen.QUEUE -> QueueScreen(vm)
-                Screen.PLAYLIST_DETAIL, Screen.ALBUM_DETAIL, Screen.ARTIST_DETAIL -> DetailScreen(vm)
-                Screen.NOW_PLAYING, Screen.LYRICS, Screen.LOGIN -> {}
-            }
-        }
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val fullWidthPx = constraints.maxWidth
+        val fullHeightPx = constraints.maxHeight
 
-        // Bottom overlay: MiniPlayer + BottomNav float over content
+        // Main content — always a real screen, even while the player is open, so
+        // the morph reveals it underneath rather than a blank.
+        MainContent(contentScreen, vm, hazeState)
+
+        // Mini bar + BottomNav. The bar's bounds anchor the growing card, and the
+        // bar hands off to the card the instant a drag starts.
+        var miniBounds by remember { mutableStateOf<Rect?>(null) }
         Column(
             Modifier
                 .align(Alignment.BottomCenter)
@@ -111,17 +147,67 @@ fun SpotifyApp(vm: SpotifyViewModel) {
                     }
                 }
         ) {
-            AnimatedVisibility(
-                visible = playback.track != null && screen != Screen.NOW_PLAYING,
-                enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
-                exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
-            ) {
-                MiniPlayer(vm)
+            if (hasTrack) {
+                MiniPlayer(
+                    vm,
+                    modifier = Modifier
+                        .onGloballyPositioned { miniBounds = it.boundsInRoot() }
+                        // Hand off to the growing card the instant a drag starts;
+                        // the card renders the same bar content, so the cut is unseen.
+                        .graphicsLayer { alpha = if (expand.value < 0.002f) 1f else 0f }
+                        .pointerInput(Unit) {
+                            detectTapGestures { vm.navigateTo(Screen.NOW_PLAYING) }
+                        }
+                        .pointerInput(fullHeightPx) {
+                            var opened = false
+                            // Rolling ~60ms window of (time, y) samples → an honest release
+                            // velocity that's robust to 120Hz batching (a single-sample
+                            // velocity inflates on near-zero dt and falsely "flings" a slow
+                            // drag). We always scrub during the drag and only decide on
+                            // release, so a slow drag tracks the finger and a flick opens.
+                            val times = ArrayDeque<Long>()
+                            val ys = ArrayDeque<Float>()
+                            detectVerticalDragGestures(
+                                onDragStart = { opened = false; times.clear(); ys.clear() },
+                                onDragEnd = {
+                                    if (!opened) {
+                                        val vel = if (times.size >= 2 && times.last() > times.first()) {
+                                            (ys.last() - ys.first()) / (times.last() - times.first())
+                                        } else {
+                                            0f
+                                        }
+                                        // Flick up (≥ ~700 px/s) or dragged past ~14% opens;
+                                        // else spring back.
+                                        if (vel < -0.7f || expand.value > 0.14f) {
+                                            opened = true
+                                            vm.navigateTo(Screen.NOW_PLAYING)
+                                        } else {
+                                            scope.launch { expand.animateTo(0f, spring(stiffness = 380f)) }
+                                        }
+                                    }
+                                }
+                            ) { change, dragAmount ->
+                                val t = change.uptimeMillis
+                                times.addLast(t)
+                                ys.addLast(change.position.y)
+                                while (times.size > 1 && t - times.first() > 60L) {
+                                    times.removeFirst()
+                                    ys.removeFirst()
+                                }
+                                // Always track the finger; the open decision is on release.
+                                val span = (miniBounds?.top ?: fullHeightPx.toFloat()) +
+                                    with(density) { 6.dp.toPx() }
+                                val next = (expand.value - dragAmount / span).coerceIn(0f, 1f)
+                                scope.launch { expand.snapTo(next) }
+                            }
+                        }
+                )
             }
-            AnimatedVisibility(
-                visible = screen != Screen.NOW_PLAYING && screen != Screen.LYRICS,
-                enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
-                exit = slideOutVertically(targetOffsetY = { it }) + fadeOut()
+            Box(
+                Modifier.graphicsLayer {
+                    alpha = (1f - expand.value * 1.5f).coerceIn(0f, 1f)
+                    translationY = expand.value * size.height
+                }
             ) {
                 BottomNav(screen, vm, hazeState)
             }
@@ -140,21 +226,32 @@ fun SpotifyApp(vm: SpotifyViewModel) {
             )
         }
 
-        // NowPlaying slides up as overlay
-        AnimatedVisibility(
-            visible = screen == Screen.NOW_PLAYING,
-            enter = slideInVertically(
-                initialOffsetY = { it },
-                animationSpec = tween(200)
-            ) + fadeIn(tween(150)),
-            exit = slideOutVertically(
-                targetOffsetY = { it },
-                animationSpec = tween(180)
-            ) + fadeOut(tween(120))
-        ) {
-            NowPlayingScreen(vm)
+        // Expanding player: lerps from the mini bar's bounds to fullscreen,
+        // crossfading the full NowPlaying content in (replaces the old slide-up).
+        if (hasTrack) {
+            miniBounds?.let { mb ->
+            PlayerMorph(
+                vm, expand, mb, IntSize(fullWidthPx, fullHeightPx),
+                onCollapseDrag = { delta ->
+                    // Same 1:1 mapping as the open drag: the card's top travels from
+                    // the bar to the screen top, so divide by that span, not the screen.
+                    val span = mb.top + with(density) { 6.dp.toPx() }
+                    scope.launch {
+                        expand.snapTo((expand.value - delta / span).coerceIn(0f, 1f))
+                    }
+                },
+                onCollapseEnd = { vy ->
+                    // Fling down (or dragged past a third closed) collapses; else springs open.
+                    val close = vy > 700f || (vy >= -700f && expand.value < 0.6f)
+                    if (close) {
+                        vm.goBack()
+                    } else {
+                        scope.launch { expand.animateTo(1f, spring(stiffness = 380f)) }
+                    }
+                }
+            )
+            }
         }
-
         // Lyrics slides up as overlay
         AnimatedVisibility(
             visible = screen == Screen.LYRICS,
@@ -221,6 +318,131 @@ fun SpotifyApp(vm: SpotifyViewModel) {
         }
     }
     } // CompositionLocalProvider
+}
+
+@Composable
+private fun MainContent(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .hazeSource(hazeState)
+    ) {
+        when (screen) {
+            Screen.HOME -> HomeScreen(vm)
+            Screen.SEARCH -> SearchScreen(vm)
+            Screen.LIBRARY -> { LaunchedEffect(Unit) { vm.loadLibrary() }; LibraryScreen(vm) }
+            Screen.ACCOUNT -> AccountScreen(vm)
+            Screen.QUEUE -> QueueScreen(vm)
+            Screen.PLAYLIST_DETAIL, Screen.ALBUM_DETAIL, Screen.ARTIST_DETAIL -> DetailScreen(vm)
+            Screen.NOW_PLAYING, Screen.LYRICS, Screen.LOGIN -> {}
+        }
+    }
+}
+
+/**
+ * The expanding player: a card that grows from the mini bar ([miniBounds]) to the
+ * full screen, with the full [NowPlayingScreen] fading in inside it as it grows.
+ * Reads [expand] internally so only this subtree recomposes per frame.
+ */
+@Composable
+private fun PlayerMorph(
+    vm: SpotifyViewModel,
+    expand: Animatable<Float, *>,
+    miniBounds: Rect,
+    fullSize: IntSize,
+    onCollapseDrag: (Float) -> Unit,
+    onCollapseEnd: (Float) -> Unit,
+) {
+    val f = expand.value
+    if (f <= 0.001f) return
+    val density = LocalDensity.current
+    val theme by vm.themeColors.collectAsState()
+    val cardBg by animateColorAsState(
+        androidx.compose.ui.graphics.lerp(SpotifyElevated, theme.primary, 0.18f),
+        tween(800), label = "morphCardBg"
+    )
+    // The card's fill crossfades from the solid mini-card colour into the live
+    // player background (Canvas video or blurred art) as the card grows — so the
+    // bar's background "becomes" the player's background in place, anchored to the
+    // card (never the screen).
+    val bgFade = (f / 0.7f).coerceIn(0f, 1f)
+
+    // Start from the *visible* mini card (miniBounds is the padded outer node, so
+    // inset by the 12dp/6dp card padding) and grow that rect to the full screen.
+    val padH = with(density) { 12.dp.toPx() }
+    val padV = with(density) { 6.dp.toPx() }
+    val startW = (miniBounds.width - padH * 2).coerceAtLeast(1f)
+    val startH = (miniBounds.height - padV * 2).coerceAtLeast(1f)
+    val x = lerp(miniBounds.left + padH, 0f, f)
+    val y = lerp(miniBounds.top + padV, 0f, f)
+    val w = lerp(startW, fullSize.width.toFloat(), f)
+    val h = lerp(startH, fullSize.height.toFloat(), f)
+    // Keep the card fully rounded for the first part of the swipe, then sharpen
+    // only over the last stretch — otherwise the corners go square too early.
+    val cornerFrac = ((f - 0.6f) / 0.4f).coerceIn(0f, 1f)
+    val corner = androidx.compose.ui.unit.lerp(12.dp, 0.dp, cornerFrac)
+    val elevation = androidx.compose.ui.unit.lerp(12.dp, 0.dp, f)
+    val fullAlpha = ((f - 0.1f) / 0.45f).coerceIn(0f, 1f)
+    val miniAlpha = (1f - f * 3f).coerceIn(0f, 1f)
+
+    // The card itself — grows from the bar to fullscreen keeping its background,
+    // shadow and rounded corners, so the whole card visibly enlarges.
+    Box(
+        Modifier
+            .offset { IntOffset(x.roundToInt(), y.roundToInt()) }
+            .size(with(density) { w.toDp() }, with(density) { h.toDp() })
+            .shadow(elevation, RoundedCornerShape(corner), ambientColor = cardBg, spotColor = cardBg)
+            .clip(RoundedCornerShape(corner))
+            .background(cardBg)
+    ) {
+        // Background at a STATIC full-screen size, anchored to the card's own
+        // top-left (no screen offset) so it travels WITH the card/mini-bar as it
+        // grows, and clipped by the card. Because its size never changes, the
+        // Canvas video never resizes — it can't stretch and needs no per-frame
+        // sizing. It just crossfades in over the solid cardBg as the card grows.
+        if (bgFade > 0.001f) {
+            Box(
+                Modifier
+                    .requiredSize(
+                        with(density) { fullSize.width.toDp() },
+                        with(density) { fullSize.height.toDp() }
+                    )
+                    .graphicsLayer { alpha = bgFade }
+            ) {
+                PlayerBackground(vm, Modifier.fillMaxSize())
+            }
+        }
+        // Full player pinned to the real screen rect, clipped by the growing card;
+        // fades in as the card grows. It draws no background of its own — the
+        // card-anchored PlayerBackground above is the only background.
+        Box(
+            Modifier
+                .requiredSize(
+                    with(density) { fullSize.width.toDp() },
+                    with(density) { fullSize.height.toDp() }
+                )
+                .offset { IntOffset(-x.roundToInt(), -y.roundToInt()) }
+                .graphicsLayer { alpha = fullAlpha }
+        ) {
+            NowPlayingScreen(
+                vm,
+                drawBackground = false,
+                onMorphDrag = onCollapseDrag,
+                onMorphDragEnd = onCollapseEnd
+            )
+        }
+        // The bar content at the card's top, fading as the card grows.
+        if (miniAlpha > 0.001f) {
+            MiniPlayerContent(
+                vm,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .width(with(density) { startW.toDp() })
+                    .graphicsLayer { alpha = miniAlpha }
+            )
+        }
+    }
 }
 
 // --- Loading Screen ---

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -51,8 +51,8 @@ import ch.snepilatch.app.ui.components.BottomNav
 import ch.snepilatch.app.ui.components.DevicesDialog
 import ch.snepilatch.app.ui.components.MiniPlayer
 import ch.snepilatch.app.ui.components.MiniPlayerContent
+import ch.snepilatch.app.ui.components.miniCardBaseColor
 import ch.snepilatch.app.ui.components.SpotifyImage
-import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
@@ -82,6 +82,15 @@ import kotlin.math.roundToInt
 
 /** Dp height of the bottom overlay (MiniPlayer + BottomNav). Screens use this for bottom padding. */
 val LocalBottomOverlayHeight = compositionLocalOf { mutableStateOf(0.dp) }
+
+/**
+ * The mini-player card's padding — must mirror MiniPlayer's
+ * `padding(horizontal = 12.dp, vertical = 6.dp)`. The morph insets the bar bounds
+ * by this to find the visible card rect, and the drag maps finger travel to the
+ * card's top (`miniBounds.top + [MorphCardPadV]`), so all three uses must agree.
+ */
+private val MorphCardPadH = 12.dp
+private val MorphCardPadV = 6.dp
 
 // --- App Shell ---
 
@@ -158,7 +167,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
                         .pointerInput(Unit) {
                             detectTapGestures { vm.navigateTo(Screen.NOW_PLAYING) }
                         }
-                        .pointerInput(fullHeightPx) {
+                        .pointerInput(Unit) {
                             var opened = false
                             // Rolling ~60ms window of (time, y) samples → an honest release
                             // velocity that's robust to 120Hz batching (a single-sample
@@ -196,7 +205,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
                                 }
                                 // Always track the finger; the open decision is on release.
                                 val span = (miniBounds?.top ?: fullHeightPx.toFloat()) +
-                                    with(density) { 6.dp.toPx() }
+                                    with(density) { MorphCardPadV.toPx() }
                                 val next = (expand.value - dragAmount / span).coerceIn(0f, 1f)
                                 scope.launch { expand.snapTo(next) }
                             }
@@ -235,7 +244,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
                 onCollapseDrag = { delta ->
                     // Same 1:1 mapping as the open drag: the card's top travels from
                     // the bar to the screen top, so divide by that span, not the screen.
-                    val span = mb.top + with(density) { 6.dp.toPx() }
+                    val span = mb.top + with(density) { MorphCardPadV.toPx() }
                     scope.launch {
                         expand.snapTo((expand.value - delta / span).coerceIn(0f, 1f))
                     }
@@ -359,7 +368,7 @@ private fun PlayerMorph(
     val density = LocalDensity.current
     val theme by vm.themeColors.collectAsState()
     val cardBg by animateColorAsState(
-        androidx.compose.ui.graphics.lerp(SpotifyElevated, theme.primary, 0.18f),
+        miniCardBaseColor(theme.primary),
         tween(800), label = "morphCardBg"
     )
     // The card's fill crossfades from the solid mini-card colour into the live
@@ -369,9 +378,11 @@ private fun PlayerMorph(
     val bgFade = (f / 0.7f).coerceIn(0f, 1f)
 
     // Start from the *visible* mini card (miniBounds is the padded outer node, so
-    // inset by the 12dp/6dp card padding) and grow that rect to the full screen.
-    val padH = with(density) { 12.dp.toPx() }
-    val padV = with(density) { 6.dp.toPx() }
+    // inset by the card padding) and grow that rect to the full screen.
+    val padH = with(density) { MorphCardPadH.toPx() }
+    val padV = with(density) { MorphCardPadV.toPx() }
+    val fullW = with(density) { fullSize.width.toDp() }
+    val fullH = with(density) { fullSize.height.toDp() }
     val startW = (miniBounds.width - padH * 2).coerceAtLeast(1f)
     val startH = (miniBounds.height - padV * 2).coerceAtLeast(1f)
     val x = lerp(miniBounds.left + padH, 0f, f)
@@ -404,10 +415,7 @@ private fun PlayerMorph(
         if (bgFade > 0.001f) {
             Box(
                 Modifier
-                    .requiredSize(
-                        with(density) { fullSize.width.toDp() },
-                        with(density) { fullSize.height.toDp() }
-                    )
+                    .requiredSize(fullW, fullH)
                     .graphicsLayer { alpha = bgFade }
             ) {
                 PlayerBackground(vm, Modifier.fillMaxSize())
@@ -418,10 +426,7 @@ private fun PlayerMorph(
         // card-anchored PlayerBackground above is the only background.
         Box(
             Modifier
-                .requiredSize(
-                    with(density) { fullSize.width.toDp() },
-                    with(density) { fullSize.height.toDp() }
-                )
+                .requiredSize(fullW, fullH)
                 .offset { IntOffset(-x.roundToInt(), -y.roundToInt()) }
                 .graphicsLayer { alpha = fullAlpha }
         ) {

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -5,13 +5,13 @@
     <ID>AnnotationOnSeparateLine:MediaButtonReceiver.kt$MediaButtonReceiver$@Suppress("DEPRECATION") intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT)</ID>
     <ID>BlockCommentInitialStarAlignment:Theme.kt$/* Other default colors to override background = Color(0xFFFFFBFE), surface = Color(0xFFFFFBFE), onPrimary = Color.White, onSecondary = Color.White, onTertiary = Color.White, onBackground = Color(0xFF1C1B1F), onSurface = Color(0xFF1C1B1F), */</ID>
     <ID>BlockCommentInitialStarAlignment:Type.kt$/* Other default text styles to override titleLarge = TextStyle( fontFamily = FontFamily.Default, fontWeight = FontWeight.Normal, fontSize = 22.sp, lineHeight = 28.sp, letterSpacing = 0.sp ), labelSmall = TextStyle( fontFamily = FontFamily.Default, fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 16.sp, letterSpacing = 0.5.sp ) */</ID>
-    <ID>ComplexCondition:NowPlayingScreen.kt$&lt;no name provided&gt;$viewW == 0f || viewH == 0f || videoW == 0f || videoH == 0f</ID>
     <ID>ComplexCondition:SpotifyViewModel.kt$SpotifyViewModel$isStreaming.value &amp;&amp; !isSeekGuarded &amp;&amp; !isStreamLoading.value &amp;&amp; !isTrackMismatch &amp;&amp; !isStaleSnapshot</ID>
     <ID>CyclomaticComplexMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:LibraryScreen.kt$@Composable fun LibraryScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
-    <ID>CyclomaticComplexMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen(vm: SpotifyViewModel)</ID>
+    <ID>CyclomaticComplexMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: SpotifyViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:SpotifyApp.kt$@Composable fun SpotifyApp(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
     <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun updatePlaybackFromState(state: PlayerStateData)</ID>
     <ID>Filename:AudioOutputDetector.kt$ch.snepilatch.app.util.AudioOutputDetector.kt</ID>
@@ -25,7 +25,6 @@
     <ID>Indentation:MediaButtonReceiver.kt$MediaButtonReceiver$ </ID>
     <ID>Indentation:MusicPlaybackService.kt$MusicPlaybackService$ </ID>
     <ID>Indentation:NowPlayingScreen.kt$ </ID>
-    <ID>Indentation:NowPlayingScreen.kt$&lt;no name provided&gt;$ </ID>
     <ID>Indentation:SpotifyApp.kt$ </ID>
     <ID>LongMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: SpotifyViewModel)</ID>
     <ID>LongMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: SpotifyViewModel)</ID>
@@ -35,7 +34,8 @@
     <ID>LongMethod:LibraryScreen.kt$@Composable fun LibraryScreen(vm: SpotifyViewModel)</ID>
     <ID>LongMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
     <ID>LongMethod:MainActivity.kt$MainActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen(vm: SpotifyViewModel)</ID>
+    <ID>LongMethod:NowPlayingScreen.kt$@Composable fun PlayerBackground(vm: SpotifyViewModel, modifier: Modifier = Modifier)</ID>
+    <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: SpotifyViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
     <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun NowPlayingMenu( showMore: Boolean, onShowMore: (Boolean) -&gt; Unit, onShowPlaylistPicker: () -&gt; Unit, vm: SpotifyViewModel, track: ch.snepilatch.app.data.TrackInfo?, shareContext: android.content.Context, buttonBg: Color )</ID>
     <ID>LongMethod:SearchScreen.kt$@Composable fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel())</ID>
     <ID>LongMethod:SharedComponents.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)</ID>
@@ -56,15 +56,11 @@
     <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$?:</ID>
     <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$LokiLogger.i(TAG, "[Timing] WS onTrackChange arrived (${delta}ms after CMD '$lastCommandName') -&gt; ${event.current?.uri} fileId=${event.currentFileId}")</ID>
     <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$LokiLogger.i(TAG, "[Timing] resolveAndPlay DRM loaded in ${System.currentTimeMillis() - resolveStart}ms (${System.currentTimeMillis() - lastCommandTs}ms total from CMD)")</ID>
-    <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$val result = cdn.resolveStreamUrl(nextId, region = contentRegion.value, youtubeSearchQuery = searchQuery, preferredSource = preferredAudioSource.value)</ID>
-    <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$val result = cdn.resolveStreamUrl(trackId, region = contentRegion.value, youtubeSearchQuery = searchQuery, preferredSource = preferredAudioSource.value)</ID>
     <ID>MaximumLineLength:DetailScreen.kt$ </ID>
     <ID>MaximumLineLength:MusicPlaybackService.kt$MusicPlaybackService.&lt;no name provided&gt;$ </ID>
     <ID>MaximumLineLength:NowPlayingScreen.kt$ </ID>
     <ID>MaximumLineLength:QueueScreen.kt$ </ID>
     <ID>MaximumLineLength:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
-    <ID>MultiLineIfElse:AccountScreen.kt$stringResource(R.string.qobuz_desc)</ID>
-    <ID>MultiLineIfElse:AccountScreen.kt$stringResource(R.string.tidal_desc)</ID>
     <ID>MultiLineIfElse:BottomNav.kt$Modifier</ID>
     <ID>MultiLineIfElse:BottomNav.kt$Modifier.border(2.dp, SpotifyWhite, CircleShape)</ID>
     <ID>MultiLineIfElse:DetailScreen.kt$String.format("%,d", detail.followers)</ID>
@@ -76,8 +72,6 @@
     <ID>MultiLineIfElse:LyricsScreen.kt$PaddingValues(top = 40.dp, bottom = 80.dp)</ID>
     <ID>MultiLineIfElse:LyricsScreen.kt$PaddingValues(top = 80.dp, bottom = 300.dp)</ID>
     <ID>MultiLineIfElse:LyricsScreen.kt$remember(posMs / 100) { lines.indexOfLast { posMs &gt;= it.startTimeMs }.coerceAtLeast(0) }</ID>
-    <ID>MultiLineIfElse:MusicPlaybackService.kt$MusicPlaybackService$android.R.drawable.ic_media_pause</ID>
-    <ID>MultiLineIfElse:MusicPlaybackService.kt$MusicPlaybackService$android.R.drawable.ic_media_play</ID>
     <ID>MultiLineIfElse:MusicPlaybackService.kt$MusicPlaybackService$url</ID>
     <ID>MultiLineIfElse:NowPlayingScreen.kt$seekDragValue</ID>
     <ID>MultiLineIfElse:ReleaseNotesScreen.kt$MaterialTheme.colorScheme.primary</ID>
@@ -95,7 +89,6 @@
     <ID>NoMultipleSpaces:MusicPlaybackService.kt$MusicPlaybackService$ </ID>
     <ID>NoMultipleSpaces:ReleaseNotesScreen.kt$ </ID>
     <ID>NoMultipleSpaces:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
-    <ID>PropertyWrapping:AccountScreen.kt$val losslessOnText = stringResource(R.string.lossless_on, if (audioSource == "tidal") tidalLabel else qobuzLabel)</ID>
     <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$catch</ID>
     <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$finally</ID>
     <ID>SpacingBetweenDeclarationsWithAnnotations:SessionHolder.kt$SessionHolder$@Volatile var cdnResolver: SpotifyCdnResolver? = null</ID>
@@ -109,7 +102,6 @@
     <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"</ID>
     <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Next track info (always available from WebSocket state for mini player swipe)</ID>
     <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Notification button preferences: "like", "shuffle", "repeat"</ID>
-    <ID>StringTemplate:DetailScreen.kt$${totalMin}</ID>
     <ID>ThrowsCount:SpotifyViewModel.kt$SpotifyViewModel$fun togglePlayPause()</ID>
     <ID>TooGenericExceptionThrown:ReleaseNotesScreen.kt$throw Exception("HTTP ${response.code}")</ID>
     <ID>UseCheckOrError:SpotifyCdnResolver.kt$SpotifyCdnResolver$throw IllegalStateException("No CDN mirrors for fileId=$fileId")</ID>
@@ -119,9 +111,7 @@
     <ID>VariableNaming:SpotifyViewModel.kt$SpotifyViewModel$private val TAG = "SpotifyVM"</ID>
     <ID>Wrapping:AccountScreen.kt$(</ID>
     <ID>Wrapping:AccountScreen.kt$;</ID>
-    <ID>Wrapping:AccountScreen.kt$Text( if (audioSource == "tidal") stringResource(R.string.tidal_desc) else stringResource(R.string.qobuz_desc), color = SpotifyLightGray )</ID>
     <ID>Wrapping:AccountScreen.kt$Text( if (canvasOn) stringResource(R.string.canvas_on) else stringResource(R.string.canvas_off), color = SpotifyLightGray )</ID>
-    <ID>Wrapping:AccountScreen.kt$Text( if (isLossless) losslessOnText else losslessOffText, color = SpotifyLightGray )</ID>
     <ID>Wrapping:AccountScreen.kt$Text( when { isChecking -&gt; stringResource(R.string.checking) upToDate -&gt; stringResource(R.string.up_to_date) else -&gt; stringResource(R.string.tap_to_check) }, color = if (upToDate) animatedPrimary else SpotifyLightGray )</ID>
     <ID>Wrapping:AccountScreen.kt$Text(stringResource(R.string.cancel), color = SpotifyLightGray)</ID>
     <ID>Wrapping:AccountScreen.kt$TextButton(onClick = { showLanguagePicker = false }) { Text(stringResource(R.string.cancel), color = SpotifyLightGray) }</ID>
@@ -132,7 +122,6 @@
     <ID>Wrapping:AccountScreen.kt$showRightPicker = false</ID>
     <ID>Wrapping:DetailScreen.kt$(</ID>
     <ID>Wrapping:DetailScreen.kt$;</ID>
-    <ID>Wrapping:DetailScreen.kt$showMenu = false; vm.showPlaylistPickerForTrack(track.uri)</ID>
     <ID>Wrapping:DetailScreen.kt$stripHtml(it)</ID>
     <ID>Wrapping:LibraryScreen.kt$(</ID>
     <ID>Wrapping:LibraryScreen.kt$;</ID>
@@ -144,16 +133,12 @@
     <ID>Wrapping:MainActivity.kt$MainActivity$(</ID>
     <ID>Wrapping:MiniPlayer.kt$(</ID>
     <ID>Wrapping:MusicPlaybackService.kt$MusicPlaybackService$(</ID>
-    <ID>Wrapping:NowPlayingScreen.kt$(</ID>
     <ID>Wrapping:NowPlayingScreen.kt$;</ID>
     <ID>Wrapping:NowPlayingScreen.kt$&lt;no name provided&gt;${ vm.updateAudioOutput(audioCtx) }</ID>
     <ID>Wrapping:NowPlayingScreen.kt$&lt;no name provided&gt;${ vm.updateAudioOutput(audioCtx2) }</ID>
-    <ID>Wrapping:NowPlayingScreen.kt$track?.uri?.let { vm.addToQueue(it) }; onShowMore(false)</ID>
-    <ID>Wrapping:NowPlayingScreen.kt$vm.addToQueue(it)</ID>
     <ID>Wrapping:ReleaseNotesScreen.kt$(</ID>
     <ID>Wrapping:SharedComponents.kt$(</ID>
     <ID>Wrapping:SharedComponents.kt$;</ID>
-    <ID>Wrapping:SharedComponents.kt$showMenu = false; vm.showPlaylistPickerForTrack(track.uri)</ID>
     <ID>Wrapping:SpotifyApp.kt$;</ID>
     <ID>Wrapping:SpotifyViewModel.kt$SpotifyViewModel$(</ID>
     <ID>Wrapping:SpotifyViewModel.kt$SpotifyViewModel$;</ID>


### PR DESCRIPTION
Closes #287.

The mini-player now interactively transforms into the full NowPlaying screen: hold and drag it up and it stretches into the full player, tracking your finger 1:1. A flick opens it; a flick or drag down collapses it.

## What changed
- **`SpfyApp`** — an `expand` Animatable drives a growing card (`PlayerMorph`) that lerps from the mini-bar bounds to fullscreen. Dragging scrubs the morph; the open/close decision happens on release using a **windowed (60 ms) velocity**, so 120 Hz touch batching can't misread a slow drag as a fling. Corner radius stays round through most of the swipe and sharpens only near the end.
- **Background** — rendered at a **static full-screen size**, anchored to the card and clipped by it, crossfading in over the card colour. The Canvas video keeps its true aspect ratio (no stretch/squish) and grows with the card. Extracted as a reusable **`PlayerBackground`**; the `TextureView` is sized to cover-crop dimensions rather than relying on a per-frame resize matrix.
- **`MiniPlayer`** — split into card chrome + `MiniPlayerContent` so the morph can render the same bar content inside the growing card.

## Verification
- `./gradlew :app:assembleDebug` ✅
- `./gradlew :app:testProdDebugUnitTest` ✅
- `./gradlew detekt` ✅
- Manually tested on device (Canvas-video and album-art tracks): morph, flick-to-open, slow-scrub, drag-to-collapse, video aspect.