### PR TITLE
Allow Google login by stripping WebView user-agent marker

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
@@ -32,7 +33,7 @@ import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 @Composable
 fun SpotifyLoginScreen(vm: SpotifyViewModel) {
-    Column(Modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxSize().statusBarsPadding()) {
         Row(
             Modifier
                 .fillMaxWidth()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
@@ -51,6 +51,10 @@ fun SpotifyLoginScreen(vm: SpotifyViewModel) {
                 WebView(context).apply {
                     settings.javaScriptEnabled = true
                     settings.domStorageEnabled = true
+                    // Google's OAuth refuses embedded WebViews ("disallowed_useragent",
+                    // error 403) — it detects the "; wv" token Android appends to the
+                    // WebView UA. Strip it so "Continue with Google" is allowed through.
+                    settings.userAgentString = settings.userAgentString.replace("; wv", "")
                     CookieManager.getInstance().apply {
                         setAcceptCookie(true)
                         removeAllCookies(null)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
@@ -1,10 +1,12 @@
 package ch.snepilatch.app.ui.screens
 
 import ch.snepilatch.app.R
+import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyWhite
 import android.webkit.CookieManager
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -33,7 +35,12 @@ import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 @Composable
 fun SpotifyLoginScreen(vm: SpotifyViewModel) {
-    Column(Modifier.fillMaxSize().statusBarsPadding()) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(SpotifyBlack)
+            .statusBarsPadding()
+    ) {
         Row(
             Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
## What

Fixes the `403: disallowed_useragent` error when tapping **Continue with Google** on the login WebView (#293).

Google blocks OAuth sign-in inside embedded Android WebViews, identifying them by the `; wv` token in the default User-Agent. This strips that token so Google treats the WebView as a normal browser and lets the OAuth flow through. The `sp_dc` cookie capture in `onPageFinished` is untouched.

## Why this approach

The Google-recommended alternative (Custom Tabs) is not viable here — it would break reading the `sp_dc` cookie out of the WebView, which the whole session bootstrap depends on. Stripping `; wv` is the community-standard workaround for the Spfy-in-WebView case and keeps the real device UA otherwise intact.

## Testing

- `:app:assembleDevDebug` ✅
- `detekt` ✅
- Installed on device with cleared data to verify the Google login page loads instead of the 403.

Closes #293