### PR TITLE
Wire transport buttons to local-device transport (uncapped skipping)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ Thumbs.db
 # AI Plans
 docs/superpowers/
 cur.png
+
+# Dev-only browser capture/analyzer userscripts (not shipped)
+/spotify-analyzer.user.js
+/spotify-dealer-ws-capture.user.js
+
+# Local agent scratch (debug logs, captures, screenshots)
+.claude/

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
@@ -97,7 +97,6 @@ fun MiniPlayerContent(
     val theme by vm.themeColors.collectAsState()
     val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "miniPrimary")
     val streamLoading by vm.isStreamLoading.collectAsState()
-    val isAdBreak by vm.isAdBreak.collectAsState()
 
     Column(modifier.fillMaxWidth()) {
         Row(
@@ -131,11 +130,11 @@ fun MiniPlayerContent(
                     )
                 }
             }
-            IconButton(onClick = { vm.skipNext() }, enabled = !isAdBreak, modifier = Modifier.size(40.dp)) {
+            IconButton(onClick = { vm.skipNext() }, modifier = Modifier.size(40.dp)) {
                 Icon(
                     Icons.Rounded.SkipNext,
                     stringResource(R.string.next),
-                    tint = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f),
+                    tint = SpotifyWhite,
                     modifier = Modifier.size(24.dp)
                 )
             }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
@@ -97,6 +97,7 @@ fun MiniPlayerContent(
     val theme by vm.themeColors.collectAsState()
     val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "miniPrimary")
     val streamLoading by vm.isStreamLoading.collectAsState()
+    val isAdBreak by vm.isAdBreak.collectAsState()
 
     Column(modifier.fillMaxWidth()) {
         Row(
@@ -130,8 +131,13 @@ fun MiniPlayerContent(
                     )
                 }
             }
-            IconButton(onClick = { vm.skipNext() }, modifier = Modifier.size(40.dp)) {
-                Icon(Icons.Rounded.SkipNext, stringResource(R.string.next), tint = SpotifyWhite, modifier = Modifier.size(24.dp))
+            IconButton(onClick = { vm.skipNext() }, enabled = !isAdBreak, modifier = Modifier.size(40.dp)) {
+                Icon(
+                    Icons.Rounded.SkipNext,
+                    stringResource(R.string.next),
+                    tint = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f),
+                    modifier = Modifier.size(24.dp)
+                )
             }
         }
         if (playback.durationMs > 0) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -224,7 +224,6 @@ fun NowPlayingScreen(
     val playback by vm.playback.collectAsState()
     val track = playback.track
     val streamLoading by vm.isStreamLoading.collectAsState()
-    val isAdBreak by vm.isAdBreak.collectAsState()
     val theme by vm.themeColors.collectAsState()
 
     val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "primary")
@@ -406,7 +405,6 @@ fun NowPlayingScreen(
                         else if (playback.durationMs > 0) (playback.positionMs.toFloat() / playback.durationMs) else 0f
                         Slider(
                             value = sliderValue,
-                            enabled = !isAdBreak,
                             onValueChange = { seekDragging = true; seekDragValue = it },
                             onValueChangeFinished = {
                                 vm.seekTo((seekDragValue * playback.durationMs).toLong())
@@ -416,7 +414,7 @@ fun NowPlayingScreen(
                                 Box(
                                     Modifier
                                         .size(width = 6.dp, height = 30.dp)
-                                        .background(animatedPrimary.copy(alpha = if (isAdBreak) 0.3f else 1f), RoundedCornerShape(3.dp))
+                                        .background(animatedPrimary, RoundedCornerShape(3.dp))
                                 )
                             },
                             colors = SliderDefaults.colors(
@@ -454,10 +452,9 @@ fun NowPlayingScreen(
                             }
                             FilledTonalIconButton(
                                 onClick = { vm.skipPrevious() },
-                                enabled = !isAdBreak,
-                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    colors = IconButtonDefaults.filledTonalIconButtonColors(
                                     containerColor = buttonBg,
-                                    contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                                    contentColor = SpotifyWhite
                                 ),
                                 modifier = Modifier.size(48.dp),
                             ) {
@@ -485,10 +482,9 @@ fun NowPlayingScreen(
                             val nextLoading = !nextReady && isCurrentlyStreaming
                             FilledTonalIconButton(
                                 onClick = { vm.skipNext() },
-                                enabled = !isAdBreak,
-                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    colors = IconButtonDefaults.filledTonalIconButtonColors(
                                     containerColor = buttonBg,
-                                    contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                                    contentColor = SpotifyWhite
                                 ),
                                 modifier = Modifier.size(48.dp),
                             ) {
@@ -799,7 +795,6 @@ fun NowPlayingScreen(
                         else if (playback.durationMs > 0) (playback.positionMs.toFloat() / playback.durationMs) else 0f
                     Slider(
                         value = sliderValue,
-                        enabled = !isAdBreak,
                         onValueChange = { seekDragging = true; seekDragValue = it },
                         onValueChangeFinished = {
                             vm.seekTo((seekDragValue * playback.durationMs).toLong())
@@ -809,7 +804,7 @@ fun NowPlayingScreen(
                             Box(
                                 Modifier
                                     .size(width = 6.dp, height = 30.dp)
-                                    .background(animatedPrimary.copy(alpha = if (isAdBreak) 0.3f else 1f), RoundedCornerShape(3.dp))
+                                    .background(animatedPrimary, RoundedCornerShape(3.dp))
                             )
                         },
                         colors = SliderDefaults.colors(
@@ -849,10 +844,9 @@ fun NowPlayingScreen(
                         // Previous
                         FilledTonalIconButton(
                             onClick = { vm.skipPrevious() },
-                            enabled = !isAdBreak,
                             colors = IconButtonDefaults.filledTonalIconButtonColors(
                                 containerColor = buttonBg,
-                                contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                                contentColor = SpotifyWhite
                             ),
                             modifier = Modifier.size(56.dp),
                         ) {
@@ -885,10 +879,9 @@ fun NowPlayingScreen(
                         val nextLoading = !nextReady && isCurrentlyStreaming
                         FilledTonalIconButton(
                             onClick = { vm.skipNext() },
-                            enabled = !isAdBreak,
                             colors = IconButtonDefaults.filledTonalIconButtonColors(
                                 containerColor = buttonBg,
-                                contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                                contentColor = SpotifyWhite
                             ),
                             modifier = Modifier.size(56.dp),
                         ) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -224,6 +224,7 @@ fun NowPlayingScreen(
     val playback by vm.playback.collectAsState()
     val track = playback.track
     val streamLoading by vm.isStreamLoading.collectAsState()
+    val isAdBreak by vm.isAdBreak.collectAsState()
     val theme by vm.themeColors.collectAsState()
 
     val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "primary")
@@ -405,6 +406,7 @@ fun NowPlayingScreen(
                         else if (playback.durationMs > 0) (playback.positionMs.toFloat() / playback.durationMs) else 0f
                         Slider(
                             value = sliderValue,
+                            enabled = !isAdBreak,
                             onValueChange = { seekDragging = true; seekDragValue = it },
                             onValueChangeFinished = {
                                 vm.seekTo((seekDragValue * playback.durationMs).toLong())
@@ -414,7 +416,7 @@ fun NowPlayingScreen(
                                 Box(
                                     Modifier
                                         .size(width = 6.dp, height = 30.dp)
-                                        .background(animatedPrimary, RoundedCornerShape(3.dp))
+                                        .background(animatedPrimary.copy(alpha = if (isAdBreak) 0.3f else 1f), RoundedCornerShape(3.dp))
                                 )
                             },
                             colors = SliderDefaults.colors(
@@ -452,7 +454,11 @@ fun NowPlayingScreen(
                             }
                             FilledTonalIconButton(
                                 onClick = { vm.skipPrevious() },
-                                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = buttonBg, contentColor = SpotifyWhite),
+                                enabled = !isAdBreak,
+                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    containerColor = buttonBg,
+                                    contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                                ),
                                 modifier = Modifier.size(48.dp),
                             ) {
                                 Icon(Icons.Rounded.SkipPrevious, stringResource(R.string.previous), modifier = Modifier.size(28.dp))
@@ -479,7 +485,11 @@ fun NowPlayingScreen(
                             val nextLoading = !nextReady && isCurrentlyStreaming
                             FilledTonalIconButton(
                                 onClick = { vm.skipNext() },
-                                colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = buttonBg, contentColor = SpotifyWhite),
+                                enabled = !isAdBreak,
+                                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                    containerColor = buttonBg,
+                                    contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                                ),
                                 modifier = Modifier.size(48.dp),
                             ) {
                                 if (nextLoading) {
@@ -789,6 +799,7 @@ fun NowPlayingScreen(
                         else if (playback.durationMs > 0) (playback.positionMs.toFloat() / playback.durationMs) else 0f
                     Slider(
                         value = sliderValue,
+                        enabled = !isAdBreak,
                         onValueChange = { seekDragging = true; seekDragValue = it },
                         onValueChangeFinished = {
                             vm.seekTo((seekDragValue * playback.durationMs).toLong())
@@ -798,7 +809,7 @@ fun NowPlayingScreen(
                             Box(
                                 Modifier
                                     .size(width = 6.dp, height = 30.dp)
-                                    .background(animatedPrimary, RoundedCornerShape(3.dp))
+                                    .background(animatedPrimary.copy(alpha = if (isAdBreak) 0.3f else 1f), RoundedCornerShape(3.dp))
                             )
                         },
                         colors = SliderDefaults.colors(
@@ -838,7 +849,11 @@ fun NowPlayingScreen(
                         // Previous
                         FilledTonalIconButton(
                             onClick = { vm.skipPrevious() },
-                            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = buttonBg, contentColor = SpotifyWhite),
+                            enabled = !isAdBreak,
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                containerColor = buttonBg,
+                                contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                            ),
                             modifier = Modifier.size(56.dp),
                         ) {
                             Icon(Icons.Rounded.SkipPrevious, stringResource(R.string.previous), modifier = Modifier.size(32.dp))
@@ -870,7 +885,11 @@ fun NowPlayingScreen(
                         val nextLoading = !nextReady && isCurrentlyStreaming
                         FilledTonalIconButton(
                             onClick = { vm.skipNext() },
-                            colors = IconButtonDefaults.filledTonalIconButtonColors(containerColor = buttonBg, contentColor = SpotifyWhite),
+                            enabled = !isAdBreak,
+                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                containerColor = buttonBg,
+                                contentColor = SpotifyWhite.copy(alpha = if (isAdBreak) 0.3f else 1f)
+                            ),
                             modifier = Modifier.size(56.dp),
                         ) {
                             if (nextLoading) {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -849,15 +849,8 @@ class SpotifyViewModel : ViewModel() {
                         _playback.value = _playback.value.copy(isPlaying = true, isPaused = false)
                         startPositionTicker()
                         withContext(Dispatchers.Main) { MusicPlaybackService.instance?.syncPlay(_playback.value.positionMs) }
-                        try {
-                            p.localResume(_playback.value.positionMs)
-                        } catch (e: CancellationException) { throw e }
-                        catch (e: Exception) {
-                            LokiLogger.w(TAG, "resume failed, transferring playback and retrying: ${e.message}")
-                            p.transferPlaybackHere()
-                            delay(500)
-                            p.localResume(_playback.value.positionMs)
-                        }
+                        // Local state report — never fails the way a command can, so no transfer/retry needed.
+                        p.localResume(_playback.value.positionMs)
                     } else {
                         // Cold start: nothing loaded in ExoPlayer yet. Mirror the Spotify
                         // web player's protocol — fetch track metadata directly (no WS,
@@ -872,15 +865,8 @@ class SpotifyViewModel : ViewModel() {
                     if (isStreaming.value) {
                         withContext(Dispatchers.Main) { MusicPlaybackService.instance?.syncPause() }
                     }
-                    try {
-                        p.localPause(_playback.value.positionMs)
-                    } catch (e: CancellationException) { throw e }
-                    catch (e: Exception) {
-                        LokiLogger.w(TAG, "pause failed, transferring playback and retrying: ${e.message}")
-                        p.transferPlaybackHere()
-                        delay(500)
-                        p.localPause(_playback.value.positionMs)
-                    }
+                    // Local state report — never fails the way a command can, so no transfer/retry needed.
+                    p.localPause(_playback.value.positionMs)
                 }
                 LokiLogger.i(TAG, "[Timing] CMD $action API done in ${System.currentTimeMillis() - t0}ms")
             } catch (e: CancellationException) { throw e }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -111,6 +111,11 @@ class SpotifyViewModel : ViewModel() {
     val isStreaming = MutableStateFlow(false)
     val streamProvider = MutableStateFlow<String?>(null)
     val isNextReady = MutableStateFlow(false)
+
+    // Ad break: KotifyClient owns ad lifecycle/audio suppression; the app just
+    // reflects the window in UI and locks transport. Set via onAdBreakStart/End.
+    private val _isAdBreak = MutableStateFlow(false)
+    val isAdBreak: StateFlow<Boolean> = _isAdBreak
     private var suppressRemotePause = false
     private var resolveJob: Job? = null  // Cancel in-flight resolveAndPlay when a new track arrives
 
@@ -128,7 +133,7 @@ class SpotifyViewModel : ViewModel() {
         playback = _playback,
         isStreaming = isStreaming,
         getExoPositionMs = { MusicPlaybackService.instance?.getCurrentPosition() },
-        reportPosition = { pos -> player?.reportPosition(pos, false) ?: Unit }
+        reportPosition = { pos -> player?.reportPosition(pos, _playback.value.isPaused) ?: Unit }
     )
     private var commandJob: Job? = null
     private var seekGuardUntil: Long = 0  // suppress remote position updates briefly after local seek
@@ -418,6 +423,16 @@ class SpotifyViewModel : ViewModel() {
                     LokiLogger.d(TAG, "Pre-resolve next CDN failed: ${e.message}")
                 }
             }
+        }
+
+        pc.onAdBreakStart { durationMs ->
+            _isAdBreak.value = true
+            LokiLogger.i(TAG, "[Ad] break start (~${durationMs}ms) — locking transport, no ad audio")
+        }
+
+        pc.onAdBreakEnd {
+            _isAdBreak.value = false
+            LokiLogger.i(TAG, "[Ad] break end — resuming normal playback")
         }
 
         pc.onState { state ->
@@ -835,13 +850,13 @@ class SpotifyViewModel : ViewModel() {
                         startPositionTicker()
                         withContext(Dispatchers.Main) { MusicPlaybackService.instance?.syncPlay(_playback.value.positionMs) }
                         try {
-                            p.resume()
+                            p.localResume(_playback.value.positionMs)
                         } catch (e: CancellationException) { throw e }
                         catch (e: Exception) {
                             LokiLogger.w(TAG, "resume failed, transferring playback and retrying: ${e.message}")
                             p.transferPlaybackHere()
                             delay(500)
-                            p.resume()
+                            p.localResume(_playback.value.positionMs)
                         }
                     } else {
                         // Cold start: nothing loaded in ExoPlayer yet. Mirror the Spotify
@@ -858,13 +873,13 @@ class SpotifyViewModel : ViewModel() {
                         withContext(Dispatchers.Main) { MusicPlaybackService.instance?.syncPause() }
                     }
                     try {
-                        p.pause()
+                        p.localPause(_playback.value.positionMs)
                     } catch (e: CancellationException) { throw e }
                     catch (e: Exception) {
                         LokiLogger.w(TAG, "pause failed, transferring playback and retrying: ${e.message}")
                         p.transferPlaybackHere()
                         delay(500)
-                        p.pause()
+                        p.localPause(_playback.value.positionMs)
                     }
                 }
                 LokiLogger.i(TAG, "[Timing] CMD $action API done in ${System.currentTimeMillis() - t0}ms")
@@ -1055,7 +1070,8 @@ class SpotifyViewModel : ViewModel() {
         commandJob = viewModelScope.launch(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
-                player?.skipNext()
+                // Local advance (state report, never skip-capped) — the new track loads via onPlaybackId.
+                player?.localNext()
                 LokiLogger.i(TAG, "[Timing] CMD skipNext API done in ${System.currentTimeMillis() - t0}ms")
             }
             catch (e: CancellationException) { throw e }
@@ -1065,10 +1081,12 @@ class SpotifyViewModel : ViewModel() {
 
     fun skipPrevious() {
         // If we're more than 3s into the track, restart it instead of going to previous.
+        // (Same threshold KotifyClient's localPrevious uses; restarting also seeks ExoPlayer.)
         if (_playback.value.positionMs > PREV_RESTART_THRESHOLD_MS) {
             seekTo(0)
             return
         }
+        val pos = _playback.value.positionMs
         commandJob?.cancel()
         lastCommandTs = System.currentTimeMillis()
         lastCommandName = "skipPrevious"
@@ -1076,7 +1094,8 @@ class SpotifyViewModel : ViewModel() {
         commandJob = viewModelScope.launch(Dispatchers.IO) {
             try {
                 val t0 = System.currentTimeMillis()
-                player?.skipPrevious()
+                // Local go-to-previous (state report, never skip-capped) — prev track loads via onPlaybackId.
+                player?.localPrevious(pos)
                 LokiLogger.i(TAG, "[Timing] CMD skipPrevious API done in ${System.currentTimeMillis() - t0}ms")
             }
             catch (e: CancellationException) { throw e }
@@ -1092,8 +1111,8 @@ class SpotifyViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.Main) {
             MusicPlaybackService.instance?.syncSeek(positionMs)
         }
-        // Seek Spotify in background
-        launchWithPlayer("seek") { it.seek(positionMs.toInt()) }
+        // Report the seek to Spotify locally (state report, not a seek command)
+        launchWithPlayer("seek") { it.localSeek(positionMs) }
     }
 
     fun toggleShuffle() {
@@ -1201,8 +1220,8 @@ class SpotifyViewModel : ViewModel() {
                     LokiLogger.i(TAG, "QUEUE SKIP: index=$index, name=${track.name}, uri=${track.uri}, uid=$uid")
                     p.skipToTrack(track.uri, uid, ctxUri)
                 } else {
-                    LokiLogger.w(TAG, "No UID for queue track, falling back to skip_next")
-                    repeat(index + 1) { p.skipNext(); delay(300) }
+                    LokiLogger.w(TAG, "No UID for queue track, falling back to local advance")
+                    repeat(index + 1) { p.localNext(); delay(300) }
                 }
             } catch (e: Exception) { LokiLogger.e(TAG, "skipToQueueIndex", e) }
         }
@@ -1577,13 +1596,13 @@ class SpotifyViewModel : ViewModel() {
         wirePlaybackLifecycleCallbacks(svc)
     }
 
-    /** Play / pause / skip / seek — simple commands forwarded to Spotify Connect. */
+    /** Play / pause / skip / seek — forwarded through KotifyClient's local-device transport (uncapped). */
     private fun wireTransportCallbacks(svc: MusicPlaybackService) {
         svc.onPlay = { togglePlayPause() }
         svc.onPause = { togglePlayPause() }
         svc.onSkipNext = {
             viewModelScope.launch(Dispatchers.IO) {
-                try { player?.skipNext() }
+                try { player?.localNext() }
                 catch (e: CancellationException) { throw e }
                 catch (e: Exception) { LokiLogger.e(TAG, "svc next", e) }
             }
@@ -1591,7 +1610,7 @@ class SpotifyViewModel : ViewModel() {
         svc.onSkipPrevious = { skipPrevious() }
         svc.onSeek = { posMs ->
             viewModelScope.launch(Dispatchers.IO) {
-                try { player?.seek(posMs.toInt()) }
+                try { player?.localSeek(posMs) }
                 catch (e: CancellationException) { throw e }
                 catch (e: Exception) { LokiLogger.e(TAG, "svc seek", e) }
             }
@@ -1678,9 +1697,17 @@ class SpotifyViewModel : ViewModel() {
                     }
                     if (newTrackLoaded || exoPlaying) {
                         LokiLogger.d(TAG, "Auto-advance fired naturally (newTrackLoaded=$newTrackLoaded, exoPlaying=$exoPlaying)")
+                    } else if (_isAdBreak.value) {
+                        // During an ad break the silent slot is expected — the
+                        // app plays nothing and KotifyClient drives the timeline.
+                        // Forcing skipNext here would fight the ad lifecycle.
+                        LokiLogger.i(TAG, "Auto-advance watchdog suppressed during ad break (still on $endedUri)")
                     } else {
-                        LokiLogger.w(TAG, "Auto-advance didn't fire (still on $endedUri), forcing skipNext")
-                        player?.skipNext()
+                        // Advance LOCALLY (no skip command) — a slightly-late auto-advance (e.g. the
+                        // post-ad track) gets resolved without spending a Free skip. skipNext here
+                        // would burn a skip and hit Spotify's Free skip cap.
+                        LokiLogger.w(TAG, "Auto-advance didn't fire (still on $endedUri), forcing local advance")
+                        player?.forceAdvance()
                     }
                 } catch (e: CancellationException) { throw e }
                 catch (e: Exception) {
@@ -1754,14 +1781,9 @@ class SpotifyViewModel : ViewModel() {
         val trackUri = current.uri
         LokiLogger.i(TAG, "[Timing] resolveAndPlay start for $trackUri (${resolveStart - lastCommandTs}ms after CMD)")
         if (trackUri.startsWith("spotify:ad:")) {
-            LokiLogger.i(TAG, "[AdSkip] Ad detected: $trackUri — skipping to next track")
-            // Don't stop ExoPlayer — let current song keep playing while ad is skipped
-            viewModelScope.launch(Dispatchers.IO) {
-                try {
-                    delay(1000) // Brief delay so Spotify processes the ad
-                    player?.skipNext()
-                } catch (_: Exception) {}
-            }
+            // KotifyClient owns ad handling (lifecycle reporting + audio
+            // suppression). The app must not skip or play ads — just ignore.
+            LokiLogger.i(TAG, "[Ad] ignoring ad track in resolveAndPlay: $trackUri")
             return
         }
         if (trackUri == currentStreamUri) {
@@ -2011,7 +2033,8 @@ class SpotifyViewModel : ViewModel() {
             val nextTrack = state.next_tracks.firstOrNull() ?: return
             val nextUri = nextTrack.uri
             if (nextUri.startsWith("spotify:ad:")) {
-                LokiLogger.i(TAG, "[AdSkip] Skipping ad URI in preResolveNextTrack: $nextUri")
+                // Don't pre-resolve ads — KotifyClient handles them.
+                LokiLogger.i(TAG, "[Ad] not pre-resolving ad URI in preResolveNextTrack: $nextUri")
                 return
             }
             val nextId = nextUri.removePrefix("spotify:track:")

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -112,10 +112,6 @@ class SpotifyViewModel : ViewModel() {
     val streamProvider = MutableStateFlow<String?>(null)
     val isNextReady = MutableStateFlow(false)
 
-    // Ad break: KotifyClient owns ad lifecycle/audio suppression; the app just
-    // reflects the window in UI and locks transport. Set via onAdBreakStart/End.
-    private val _isAdBreak = MutableStateFlow(false)
-    val isAdBreak: StateFlow<Boolean> = _isAdBreak
     private var suppressRemotePause = false
     private var resolveJob: Job? = null  // Cancel in-flight resolveAndPlay when a new track arrives
 
@@ -425,16 +421,6 @@ class SpotifyViewModel : ViewModel() {
             }
         }
 
-        pc.onAdBreakStart { durationMs ->
-            _isAdBreak.value = true
-            LokiLogger.i(TAG, "[Ad] break start (~${durationMs}ms) — locking transport, no ad audio")
-        }
-
-        pc.onAdBreakEnd {
-            _isAdBreak.value = false
-            LokiLogger.i(TAG, "[Ad] break end — resuming normal playback")
-        }
-
         pc.onState { state ->
             val delta = if (lastCommandTs > 0) System.currentTimeMillis() - lastCommandTs else -1
             LokiLogger.i(TAG, "[Timing] WS onState arrived (${delta}ms after CMD '$lastCommandName')")
@@ -480,9 +466,7 @@ class SpotifyViewModel : ViewModel() {
                 try {
                     pc.getState()?.let { updatePlaybackFromState(it) }
                     loadDevices()
-                    if (wasPlaying) {
-                        try { pc.resume() } catch (_: Exception) {}
-                    }
+                    if (wasPlaying) fallbackResume()
                 } catch (e: Exception) {
                     LokiLogger.e(TAG, "Failed to re-sync after reconnect", e)
                 } finally {
@@ -894,14 +878,14 @@ class SpotifyViewModel : ViewModel() {
      *      Local audio and remote state start together — no ghost playback on
      *      any other device.
      *
-     * On any failure we reset state and fall back to the legacy path (p.resume()),
-     * so the user still gets audio just slower.
+     * On any failure we reset state and fall back to a plain resume, so the user
+     * still gets audio, just slower.
      */
     private suspend fun coldStartPlay() {
         val p = player ?: return
         if (cdnResolver == null) {
-            LokiLogger.w(TAG, "[ColdStart] CdnResolver not initialized, falling back to legacy resume")
-            try { p.resume() } catch (_: Exception) {}
+            LokiLogger.w(TAG, "[ColdStart] CdnResolver not initialized, falling back to resume")
+            fallbackResume()
             return
         }
 
@@ -927,18 +911,12 @@ class SpotifyViewModel : ViewModel() {
         try {
             p.transferPlaybackHere(restorePaused = true)
         } catch (e: CancellationException) {
-            coldStartPending = false
-            coldStartFileId = null
-            isStreamLoading.value = false
-            seekGuardUntil = 0L
+            resetColdStart()
             throw e
         } catch (e: Exception) {
             LokiLogger.e(TAG, "[ColdStart] transferPlaybackHere failed, falling back", e)
-            coldStartPending = false
-            coldStartFileId = null
-            isStreamLoading.value = false
-            seekGuardUntil = 0L
-            try { p.resume() } catch (_: Exception) {}
+            resetColdStart()
+            fallbackResume()
             return
         }
 
@@ -949,11 +927,9 @@ class SpotifyViewModel : ViewModel() {
         val fileId = kotlinx.coroutines.withTimeoutOrNull(5_000L) { fileIdDeferred.await() }
         coldStartFileId = null
         if (fileId == null) {
-            LokiLogger.w(TAG, "[ColdStart] timed out waiting for file id, falling back to legacy resume")
-            coldStartPending = false
-            isStreamLoading.value = false
-            seekGuardUntil = 0L
-            try { p.resume() } catch (_: Exception) {}
+            LokiLogger.w(TAG, "[ColdStart] timed out waiting for file id, falling back to resume")
+            resetColdStart()
+            fallbackResume()
             return
         }
 
@@ -963,10 +939,8 @@ class SpotifyViewModel : ViewModel() {
         val track = _playback.value.track
         if (track == null || track.uri.isBlank()) {
             LokiLogger.w(TAG, "[ColdStart] no track in playback state after transfer, falling back")
-            coldStartPending = false
-            isStreamLoading.value = false
-            seekGuardUntil = 0L
-            try { p.resume() } catch (_: Exception) {}
+            resetColdStart()
+            fallbackResume()
             return
         }
         val trackUri = track.uri
@@ -1038,14 +1012,25 @@ class SpotifyViewModel : ViewModel() {
             streamProvider.value = "Spotify CDN"
             LokiLogger.i(TAG, "[ColdStart] ExoPlayer loading at ${savedPositionAtEntry}ms, will start on STATE_READY")
         } catch (e: Exception) {
-            LokiLogger.e(TAG, "[ColdStart] CDN/playDrmUrl failed, falling back to legacy resume", e)
-            coldStartPending = false
+            LokiLogger.e(TAG, "[ColdStart] CDN/playDrmUrl failed, falling back to resume", e)
+            resetColdStart()
             currentStreamUri = null
             isStreaming.value = false
-            isStreamLoading.value = false
-            seekGuardUntil = 0L
-            try { p.resume() } catch (_: Exception) {}
+            fallbackResume()
         }
+    }
+
+    /** Reset the transient cold-start handoff flags. Variant fields (file id, stream state) stay inline. */
+    private fun resetColdStart() {
+        coldStartPending = false
+        coldStartFileId = null
+        isStreamLoading.value = false
+        seekGuardUntil = 0L
+    }
+
+    /** Hand control back to Spotify Connect (resume) — a state report that can't meaningfully fail. */
+    private suspend fun fallbackResume() {
+        try { player?.resume() } catch (_: Exception) {}
     }
 
     fun skipNext() {
@@ -1656,9 +1641,7 @@ class SpotifyViewModel : ViewModel() {
             isStreaming.value = false
             streamProvider.value = null
             currentStreamUri = null
-            viewModelScope.launch(Dispatchers.IO) {
-                try { player?.resume() } catch (_: Exception) {}
-            }
+            viewModelScope.launch(Dispatchers.IO) { fallbackResume() }
         }
         svc.onPlaybackEnded = {
             // Snapshot the URI that JUST ended. If a new track gets loaded
@@ -1683,15 +1666,9 @@ class SpotifyViewModel : ViewModel() {
                     }
                     if (newTrackLoaded || exoPlaying) {
                         LokiLogger.d(TAG, "Auto-advance fired naturally (newTrackLoaded=$newTrackLoaded, exoPlaying=$exoPlaying)")
-                    } else if (_isAdBreak.value) {
-                        // During an ad break the silent slot is expected — the
-                        // app plays nothing and KotifyClient drives the timeline.
-                        // Forcing skipNext here would fight the ad lifecycle.
-                        LokiLogger.i(TAG, "Auto-advance watchdog suppressed during ad break (still on $endedUri)")
                     } else {
-                        // Advance LOCALLY (no skip command) — a slightly-late auto-advance (e.g. the
-                        // post-ad track) gets resolved without spending a Free skip. skipNext here
-                        // would burn a skip and hit Spotify's Free skip cap.
+                        // Advance locally (no skip command) so a slightly-late auto-advance (e.g. the
+                        // post-ad track) resolves without burning a Free skip and hitting the cap.
                         LokiLogger.w(TAG, "Auto-advance didn't fire (still on $endedUri), forcing local advance")
                         player?.forceAdvance()
                     }
@@ -1734,7 +1711,7 @@ class SpotifyViewModel : ViewModel() {
                 // wash out without blocking legitimate user seeks for long.
                 viewModelScope.launch(Dispatchers.IO) {
                     try {
-                        try { player?.resume() } catch (_: Exception) {}
+                        fallbackResume()
                         seekGuardUntil = System.currentTimeMillis() + 15_000L
                     } finally {
                         isStreamLoading.value = false


### PR DESCRIPTION
Wires the transport controls to KotifyClient's local-device transport (uncapped, web-player-style) instead of the skip-capped connect-state command path, and cleans up the surrounding code.

### Button wiring
- skipNext → `localNext()`, skipPrevious → `localPrevious(pos)`, seekTo → `localSeek(to)`, togglePlayPause → `localResume(pos)`/`localPause(pos)`
- Service notification controls + the end-of-track watchdog use `localNext()`/`forceAdvance()`
- `reportPosition` wired so KotifyClient's position estimate stays honest

### Cleanup (this pass)
- **Removed the inert ad-break UI lockout.** `isAdBreak` was driven by KotifyClient's `onAdBreakStart/End` callbacks, which never fired — so the flag was always false and the "disable/dim transport during ad" UI (NowPlayingScreen, MiniPlayer) plus the auto-advance watchdog branch were dead code.
- **Extracted helpers:** the 8× `try { resume } catch` fallbacks → `fallbackResume()`; the repeated cold-start flag reset → `resetColdStart()`.
- Gitignored the dev-only browser capture userscripts and the `.claude` scratch dir.

## Verification
- `assembleDevDebug` + `assembleProdDebug` build clean against the rebuilt jar
- `testProdDebugUnitTest` + `detekt` green
- Installed on device (dev flavor)

Requires KotifyClient PR #211 (removes the `onAdBreak*` API this PR stops consuming).