### PR TITLE
Fix back button opening the player instead of the previous page

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
@@ -73,7 +73,7 @@ fun BottomNav(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
                 val selected = screen == nav.s
                 NavigationBarItem(
                     selected = selected,
-                    onClick = { vm.currentScreen.value = nav.s },
+                    onClick = { vm.navigateToTab(nav.s) },
                     icon = {
                         if (nav.s == Screen.ACCOUNT && account.profileImageUrl != null) {
                             Box(

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -561,8 +561,22 @@ class SpotifyViewModel : ViewModel() {
         needsLogin.value = true
     }
 
+    /** The player and lyrics are overlays, not pages — they never sit on the back stack. */
+    private fun isOverlay(s: Screen) = s == Screen.NOW_PLAYING || s == Screen.LYRICS
+
     fun navigateTo(screen: Screen) {
-        screenStack.add(currentScreen.value)
+        val current = currentScreen.value
+        if (screen == current) return
+        // Don't record an overlay we're leaving for a real page, else back re-opens the
+        // player instead of returning to the page beneath it.
+        if (!isOverlay(current) || isOverlay(screen)) screenStack.add(current)
+        currentScreen.value = screen
+    }
+
+    /** Tabs are roots: switching resets the stack so back returns to Home, not a stale page. */
+    fun navigateToTab(screen: Screen) {
+        screenStack.clear()
+        if (screen != Screen.HOME) screenStack.add(Screen.HOME)
         currentScreen.value = screen
     }
 

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/NavigationStackTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/NavigationStackTest.kt
@@ -1,0 +1,78 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.data.Screen
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+/** Regression cover for "back opens the player": overlays must not sit on the back stack. */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NavigationStackTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var vm: SpotifyViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        vm = SpotifyViewModel()
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test fun backFromPageOpenedFromPlayerReturnsToContentNotPlayer() {
+        vm.navigateTo(Screen.PLAYLIST_DETAIL) // stack=[HOME]
+        vm.navigateTo(Screen.NOW_PLAYING) // stack=[HOME, PLAYLIST_DETAIL]
+        vm.navigateTo(Screen.QUEUE) // overlay→content: stack unchanged
+        assertEquals(Screen.QUEUE, vm.currentScreen.value)
+
+        vm.goBack()
+        // The bug was this returning NOW_PLAYING; it must be the page beneath the player.
+        assertEquals(Screen.PLAYLIST_DETAIL, vm.currentScreen.value)
+    }
+
+    @Test fun backFromLyricsReturnsToPlayer() {
+        vm.navigateTo(Screen.NOW_PLAYING)
+        vm.navigateTo(Screen.LYRICS)
+        vm.goBack()
+        assertEquals(Screen.NOW_PLAYING, vm.currentScreen.value)
+    }
+
+    @Test fun backFromPlayerCollapsesToContentBeneath() {
+        vm.navigateTo(Screen.NOW_PLAYING)
+        vm.goBack()
+        assertEquals(Screen.HOME, vm.currentScreen.value)
+    }
+
+    @Test fun tabSwitchResetsStackAndBackReturnsToHome() {
+        vm.navigateTo(Screen.PLAYLIST_DETAIL)
+        vm.navigateTo(Screen.NOW_PLAYING)
+        vm.navigateToTab(Screen.SEARCH)
+        assertEquals(Screen.SEARCH, vm.currentScreen.value)
+
+        vm.goBack()
+        assertEquals(Screen.HOME, vm.currentScreen.value)
+    }
+
+    @Test fun homeTabLeavesEmptyStack() {
+        vm.navigateTo(Screen.PLAYLIST_DETAIL)
+        vm.navigateToTab(Screen.HOME)
+        assertEquals(Screen.HOME, vm.currentScreen.value)
+        assertFalse(vm.goBack())
+    }
+
+    @Test fun duplicateNavigateDoesNotStackOntoItself() {
+        vm.navigateTo(Screen.QUEUE)
+        vm.navigateTo(Screen.QUEUE)
+        vm.goBack()
+        assertEquals(Screen.HOME, vm.currentScreen.value)
+    }
+}


### PR DESCRIPTION
Closes #297.

## Problem
Opening the Queue (or a detail page) from the expanded player and pressing the top-left back arrow sometimes opened the Now Playing / player screen instead of returning to the previous page.

## Cause
The manual back-stack (`screenStack` in `SpfyViewModel`) had two issues:
1. The player/lyrics overlays were pushed onto the stack as pages, so back from a page opened *from* the player popped the player and re-expanded it.
2. The bottom-nav tabs set `currentScreen` directly, bypassing the stack — stale entries (incl. the player) lingered and a later back press surfaced them ("sometimes").

## Fix
- `navigateTo` is overlay-aware: leaving an overlay (player/lyrics) for a real page does **not** record the overlay, so back returns to the page beneath it. Player→lyrics still records, so back from lyrics returns to the player. Added a dedup guard so a double-tap can''t stack a screen onto itself.
- Added `navigateToTab` (used by the bottom nav): tabs are roots and reset the stack — back from a tab goes to Home, never a stale page.

## Behaviour now
- Queue/detail opened from the player → back returns to the previous page, not the player
- Lyrics → back → player
- Player → back → collapses to the content beneath
- Tab switch → reset stack, back → Home

## Verification
- New `NavigationStackTest` (6 cases), including the regression "back must not return the player"
- `assembleDevDebug`, `testProdDebugUnitTest`, `detekt` green; installed + tested on the dev flavor