### PR TITLE
Fix white nav-bar backdrop behind bottom sheets

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
@@ -83,6 +83,7 @@ fun DevicesDialog(vm: SpotifyViewModel) {
             )
         }
     ) {
+        SheetNavBarFix()
         Column(
             Modifier
                 .fillMaxWidth()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -38,10 +38,14 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
+import android.os.Build
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -63,6 +67,24 @@ import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.util.formatTime
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import coil.compose.SubcomposeAsyncImage
+
+/**
+ * Match the app's transparent, edge-to-edge nav bar inside a ModalBottomSheet. The sheet
+ * has its own window that re-enables the nav-bar contrast scrim the Activity turned off,
+ * which shows as a static white backdrop behind the system buttons. Call at the top of the
+ * sheet's content.
+ */
+@Composable
+fun SheetNavBarFix() {
+    val view = LocalView.current
+    SideEffect {
+        val window = (view.parent as? DialogWindowProvider)?.window ?: return@SideEffect
+        window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
+    }
+}
 
 // --- Shimmer effect ---
 
@@ -191,6 +213,7 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
                 )
             }
         ) {
+            SheetNavBarFix()
             // Track header
             Row(
                 Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -582,7 +582,7 @@ fun AccountScreen(vm: SpotifyViewModel) {
             headlineContent = { Text("Cinnabar 🧼", color = SpotifyWhite) },
             leadingContent = {
                 AsyncImage(
-                    model = "https://cdn.discordapp.com/avatars/823656705350565898/02562d1feab0425121ca6fabc7f1d66e.webp?size=1024",
+                    model = "https://cdn.discordapp.com/avatars/823656705350565898/0167b0e2080d52dfa1f0a964a17828bb.webp?size=1024",
                     contentDescription = "Cinnabar",
                     modifier = Modifier.size(40.dp).clip(CircleShape),
                     contentScale = ContentScale.Crop

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -563,6 +563,7 @@ private fun ArtistTrackRow(
                     )
                 }
             ) {
+                ch.snepilatch.app.ui.components.SheetNavBarFix()
                 // Track header
                 Row(
                     Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
@@ -688,6 +689,7 @@ private fun AlbumTrackRow(
                     )
                 }
             ) {
+                ch.snepilatch.app.ui.components.SheetNavBarFix()
                 Row(
                     Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -773,13 +775,13 @@ private fun DetailHeaderMenu(
     val trackUris = detail.tracks.map { it.uri }; val hasTracks = trackUris.isNotEmpty(); val type = detail.type
     val isAlbum = type == "album"; val isCollection = type == "collection"; val isArtist = type == "artist"
     val shareLabel = stringResource(R.string.share); val addToQueueLabel = stringResource(R.string.add_to_queue)
-    val addToPlaylistLabel = stringResource(R.string.add_to_playlist)
-    val visitArtistLabel = stringResource(R.string.visit_artist)
+    val addToPlaylistLabel = stringResource(R.string.add_to_playlist); val visitArtistLabel = stringResource(R.string.visit_artist)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         containerColor = SpotifyElevated,
     ) {
+        ch.snepilatch.app.ui.components.SheetNavBarFix()
         Row(
             Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
+import ch.snepilatch.app.ui.components.SheetNavBarFix
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.*
@@ -1133,6 +1134,7 @@ private fun NowPlayingMenu(
                 )
             }
         ) {
+            SheetNavBarFix()
             // Track header
             track?.let { t ->
                 Row(


### PR DESCRIPTION
Closes #299.

## Problem
Since the Compose BOM bump (2024.09 → 2026.05, Material3 `1.5.0-alpha21`), every bottom drawer (`ModalBottomSheet`) paints a static **white** backdrop behind the Android navigation-bar buttons. Previously the sheet''s gray scrim animated over that area.

## Cause
`ModalBottomSheet` renders in its own window (`ModalBottomSheetDialogLayout`, which implements `DialogWindowProvider`). That window doesn''t inherit the Activity''s `enableEdgeToEdge`, so Android''s nav-bar **contrast enforcement** is re-enabled on it and draws the white scrim.

## Fix
`SheetNavBarFix()` — a small composable that reaches the sheet window via `DialogWindowProvider` and sets the nav bar transparent + `isNavigationBarContrastEnforced = false`, matching the rest of the app. Called at the top of all six sheets (Devices, track menu, now-playing menu, 3× detail menus).

Verified `ModalBottomSheetDialogLayout : AbstractComposeView, DialogWindowProvider` against the resolved Material3 `1.5.0-alpha21` artifact, so the window lookup is reliable.

## Also
Minor: updated the Cinnabar avatar URL on the Account tab (separate commit).

## Verification
`assembleDevDebug`, `testProdDebugUnitTest`, `detekt` green; installed + checked on the dev flavor — the gray animated scrim is back, no white backdrop.