### PR TITLE
Bump version to 2.5.0

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 22
-        versionName = "2.4.3"
+        versionCode = 23
+        versionName = "2.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Release bump for the batch of fixes shipped today (ad-skip speedup, local-transport cleanup, navigation back-stack fix, bottom-sheet nav-bar fix).

- versionName 2.4.3 → 2.5.0
- versionCode 22 → 23

Prod release APK built locally (Loki endpoint baked in, verified) and distributed.