### PR TITLE
Enable Canvas videos by default

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1502,7 +1502,7 @@ class SpotifyViewModel : ViewModel() {
             @Suppress("DEPRECATION")
             context.resources.updateConfiguration(config, context.resources.displayMetrics)
         }
-        canvasEnabled.value = prefs.getBoolean("canvas_enabled", false)
+        canvasEnabled.value = prefs.getBoolean("canvas_enabled", true)
         contentRegion.value = prefs.getString("content_region", "nearest") ?: "nearest"
         notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"
         notificationRightButton.value = prefs.getString("notification_right_button", "like") ?: "like"


### PR DESCRIPTION
Closes #307.

Flips the `canvas_enabled` preference default from `false` to `true` (`SpfyViewModel.loadPreferences`).

Canvas is a popular, discoverable feature; off-by-default effectively hides it from users who never open settings. It stays a toggle, so it''s optional.

Semantics preserved: `setCanvasEnabled` persists explicit choices (true **or** false), so anyone who already turned Canvas off keeps it off — only fresh/never-touched installs default to on.

Verified: `assembleDevDebug`, `testProdDebugUnitTest`, `detekt` green.