### PR TITLE
Inject Widevine PSSH from seektable so encrypted tracks decrypt

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -572,11 +572,34 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             .build()
     }
 
+    /**
+     * Progressive media source that injects a Widevine PSSH (base64 from Spotify's seektable) into
+     * the DRM session. Needed because many Spotify files are cenc-encrypted but embed no Widevine
+     * pssh box, so ExoPlayer's default in-file DRM throws MissingSchemeDataException and plays silent.
+     */
+    @OptIn(UnstableApi::class)
+    private fun buildPsshDrmSource(url: String, licenseUrl: String, licenseHeaders: Map<String, String>, psshBase64: String): MediaSource {
+        val callback = androidx.media3.exoplayer.drm.HttpMediaDrmCallback(licenseUrl, DefaultHttpDataSource.Factory())
+        licenseHeaders.forEach { (k, v) -> callback.setKeyRequestProperty(k, v) }
+        val base = androidx.media3.exoplayer.drm.DefaultDrmSessionManager.Builder()
+            .setUuidAndExoMediaDrmProvider(C.WIDEVINE_UUID, androidx.media3.exoplayer.drm.FrameworkMediaDrm.DEFAULT_PROVIDER)
+            .setMultiSession(true)
+            .build(callback)
+        val psshBytes = android.util.Base64.decode(psshBase64, android.util.Base64.DEFAULT)
+        val injecting = ch.snepilatch.app.playback.engine.PsshInjectingDrmSessionManager(base, psshBytes)
+        return ProgressiveMediaSource.Factory(DefaultDataSource.Factory(this))
+            .setDrmSessionManagerProvider { injecting }
+            .createMediaSource(MediaItem.fromUri(url))
+    }
+
+    @OptIn(UnstableApi::class)
+    @Suppress("LongParameterList")
     fun playDrmUrl(url: String, licenseUrl: String, licenseHeaders: Map<String, String>,
                    title: String, artist: String, albumArtUrl: String?,
                    startPlaying: Boolean = true,
-                   startPositionMs: Long = 0L) {
-        LokiLogger.i(TAG, "Loading DRM: $title by $artist -> ${url.take(80)} (play=$startPlaying, pos=${startPositionMs}ms)")
+                   startPositionMs: Long = 0L,
+                   pssh: String? = null) {
+        LokiLogger.i(TAG, "Loading DRM: $title by $artist -> ${url.take(80)} (play=$startPlaying, pos=${startPositionMs}ms, pssh=${pssh != null})")
         val meta = TrackMetadata(title, artist, albumArtUrl)
         metadataQueue.clear()
         metadataQueue.add(meta)
@@ -589,7 +612,11 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             // seek, and reach STATE_READY at that exact position. No post-prepare seek
             // dance — eliminates the race where the post-ready seek fails to actually
             // produce audio (the bug in the cold-start sync).
-            player.setMediaItem(buildDrmMediaItem(url, licenseUrl, licenseHeaders), startPositionMs)
+            if (pssh != null) {
+                player.setMediaSource(buildPsshDrmSource(url, licenseUrl, licenseHeaders, pssh), startPositionMs)
+            } else {
+                player.setMediaItem(buildDrmMediaItem(url, licenseUrl, licenseHeaders), startPositionMs)
+            }
             player.playWhenReady = startPlaying
             // Register listener BEFORE prepare() so we catch STATE_READY
             player.addListener(object : Player.Listener {

--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/PsshInjectingDrmSessionManager.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/PsshInjectingDrmSessionManager.kt
@@ -1,0 +1,53 @@
+package ch.snepilatch.app.playback.engine
+
+import android.os.Looper
+import androidx.media3.common.C
+import androidx.media3.common.DrmInitData
+import androidx.media3.common.Format
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.analytics.PlayerId
+import androidx.media3.exoplayer.drm.DrmSession
+import androidx.media3.exoplayer.drm.DrmSessionEventListener
+import androidx.media3.exoplayer.drm.DrmSessionManager
+
+/**
+ * Many Spotify audio files are cenc-encrypted but carry **no Widevine `pssh`** box (their in-file
+ * pssh is for a different DRM system). ExoPlayer then throws `MissingSchemeDataException` and the
+ * track plays silent. The web player handles this by fetching the Widevine PSSH from the seektable
+ * and feeding it to EME. We do the same: this wrapper rewrites every [Format]'s [DrmInitData] to the
+ * seektable Widevine PSSH before delegating to a real [DefaultDrmSessionManager], so a license is
+ * always requested with the correct init data regardless of what the file embeds.
+ */
+@UnstableApi
+class PsshInjectingDrmSessionManager(
+    private val delegate: DrmSessionManager,
+    psshBox: ByteArray
+) : DrmSessionManager {
+
+    private val widevineInitData = DrmInitData(
+        DrmInitData.SchemeData(C.WIDEVINE_UUID, "video/mp4", psshBox)
+    )
+
+    private fun inject(format: Format): Format =
+        format.buildUpon().setDrmInitData(widevineInitData).build()
+
+    override fun setPlayer(playbackLooper: Looper, playerId: PlayerId) =
+        delegate.setPlayer(playbackLooper, playerId)
+
+    override fun prepare() = delegate.prepare()
+
+    override fun release() = delegate.release()
+
+    override fun acquireSession(
+        eventDispatcher: DrmSessionEventListener.EventDispatcher?,
+        format: Format
+    ): DrmSession? = delegate.acquireSession(eventDispatcher, inject(format))
+
+    override fun preacquireSession(
+        eventDispatcher: DrmSessionEventListener.EventDispatcher?,
+        format: Format
+    ): DrmSessionManager.DrmSessionReference =
+        delegate.preacquireSession(eventDispatcher, inject(format))
+
+    override fun getCryptoType(format: Format): Int = delegate.getCryptoType(inject(format))
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
@@ -11,7 +11,11 @@ data class SpotifyStream(
     val cdnUrl: String,
     val licenseUrl: String,
     val licenseHeaders: Map<String, String>,
-    val mirrorCount: Int
+    val mirrorCount: Int,
+    // Base64 Widevine PSSH from the seektable. Many Spotify files don't embed a Widevine pssh box, so
+    // we inject this one into ExoPlayer's DRM session (see PsshInjectingDrmSessionManager). Null if the
+    // seektable lookup failed — playback then falls back to the file's own (possibly missing) pssh.
+    val pssh: String? = null
 )
 
 /**
@@ -35,7 +39,8 @@ class SpotifyCdnResolver(
             cdnUrl = cdnUrl,
             licenseUrl = session.spclientUrl("widevine-license/v1/audio/license"),
             licenseHeaders = buildLicenseHeaders(),
-            mirrorCount = cdnUrls.size
+            mirrorCount = cdnUrls.size,
+            pssh = runCatching { spotifyPlayback.getPssh(fileId) }.getOrNull()
         )
     }
 
@@ -45,11 +50,12 @@ class SpotifyCdnResolver(
      * re-hitting getCdnUrls. Use when the caller already has a valid URL and
      * only needs fresh license headers.
      */
-    fun buildStreamForCachedUrl(cdnUrl: String): SpotifyStream = SpotifyStream(
+    suspend fun buildStreamForCachedUrl(cdnUrl: String, fileId: String?): SpotifyStream = SpotifyStream(
         cdnUrl = cdnUrl,
         licenseUrl = session.spclientUrl("widevine-license/v1/audio/license"),
         licenseHeaders = buildLicenseHeaders(),
-        mirrorCount = 1
+        mirrorCount = 1,
+        pssh = fileId?.let { id -> runCatching { spotifyPlayback.getPssh(id) }.getOrNull() }
     )
 
     /**

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1014,6 +1014,7 @@ class SpotifyViewModel : ViewModel() {
                     stream.cdnUrl, stream.licenseUrl, stream.licenseHeaders, title, artist, art,
                     startPlaying = true,
                     startPositionMs = savedPositionAtEntry,
+                    pssh = stream.pssh,
                 )
             }
             currentStreamUri = trackUri

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1839,7 +1839,7 @@ class SpotifyViewModel : ViewModel() {
                     LokiLogger.i(TAG, "SpotifyCDN: Using pre-resolved CDN URL (fileId=$currentFileId)")
                     nextCdnUrl = null
                     nextCdnFileId = null
-                    resolver.buildStreamForCachedUrl(cachedCdnUrl)
+                    resolver.buildStreamForCachedUrl(cachedCdnUrl, currentFileId)
                 } else {
                     // Use file ID from cluster state or from onPlaybackId (state machine)
                     var fileId = event.currentFileId ?: latestFileId
@@ -1891,6 +1891,7 @@ class SpotifyViewModel : ViewModel() {
                     MusicPlaybackService.instance?.playDrmUrl(
                         stream.cdnUrl, stream.licenseUrl, stream.licenseHeaders, title, artist, art,
                         startPlaying = !coldStart,
+                        pssh = stream.pssh,
                     )
                 }
                 currentStreamUri = trackUri


### PR DESCRIPTION
## Summary

Many Spfy audio files are cenc-encrypted but embed **no Widevine `pssh` box** (their in-file pssh is for a different DRM system), so ExoPlayer throws `MissingSchemeDataException` and the track plays silent with no error. The web player handles this by fetching the Widevine PSSH from Spfy's seektable and feeding it to EME. This does the same: `SpfyCdnResolver` fetches the seektable PSSH (`getPssh`) and a new `PsshInjectingDrmSessionManager` injects it into each track's DRM init data before the license request, on both the normal-resume and cold-start paths.