### PR TITLE
Ignore out-of-range remote seeks that kill the track

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -364,10 +364,20 @@ class SpotifyViewModel : ViewModel() {
     /**
      * A remote controller seeked the current track (KotifyClient surfaced the inbound `seek_to`
      * command). Seek ExoPlayer to the exact target — the web player's only seek path, replacing the
-     * old position-diffing heuristic. Only act when we're the streaming device.
+     * old position-diffing heuristic. Only act when we're the streaming device. Public for the rig.
+     *
+     * A legitimate seek is always within the current track. A stale cloud snapshot can produce a
+     * wildly out-of-range target (e.g. 23 min into a 3-min song); applying it would seek ExoPlayer
+     * past the end and instantly kill the track. The web player never hits this — the media element
+     * clamps currentTime to [0, duration] — so we ignore any target outside the known duration.
      */
-    private fun handleRemoteSeek(positionMs: Long) {
+    internal fun handleRemoteSeek(positionMs: Long) {
         if (!isStreaming.value) return
+        val duration = _playback.value.durationMs
+        if (positionMs < 0 || (duration > 0 && positionMs > duration + SEEK_BOUNDS_TOLERANCE_MS)) {
+            LokiLogger.w(TAG, "Ignoring out-of-range remote seek -> ${positionMs}ms (duration=${duration}ms)")
+            return
+        }
         LokiLogger.i(TAG, "Remote seek -> ${positionMs}ms")
         MusicPlaybackService.instance?.syncSeek(positionMs)
         _playback.value = _playback.value.copy(positionMs = positionMs)
@@ -2371,6 +2381,10 @@ class SpotifyViewModel : ViewModel() {
          *  lands within ~1.5s; 5s gives generous headroom so we don't double-skip
          *  when the natural advance arrives just past a tighter timeout. */
         private const val AUTO_ADVANCE_GRACE_MS = 5000L
+
+        // Slack allowed when bounds-checking a remote seek target against the track duration, so a
+        // seek to the very end isn't rejected on rounding/boundary jitter.
+        private const val SEEK_BOUNDS_TOLERANCE_MS = 1000L
 
         /** Page size for playlist/album detail pagination. Matches the limit
          *  passed to [kotify.api.playlist.Playlist.getPlaylist] in

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/RemoteSeekBoundsTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/RemoteSeekBoundsTest.kt
@@ -1,0 +1,60 @@
+package ch.snepilatch.app.viewmodel
+
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A stale cloud snapshot can surface a remote seek target far past the track end (the real bug:
+ * `Remote seek -> 1420411ms` on a multi-minute track instantly ended it). A legitimate seek is always
+ * within the track, so an out-of-range target must be ignored — mirroring the web player, where the
+ * media element clamps currentTime to [0, duration].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RemoteSeekBoundsTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() {
+        rig.install()
+    }
+
+    @After
+    fun tearDown() {
+        rig.uninstall()
+    }
+
+    @Test
+    fun inBoundsSeek_appliesToExoPlayer() {
+        rig.seedStreaming(positionMs = 0L, isPaused = false) // duration = 200_000
+
+        rig.vm.handleRemoteSeek(60_000L)
+
+        verify { rig.service.syncSeek(60_000L) }
+        assertEquals(60_000L, rig.vm.playback.value.positionMs)
+    }
+
+    @Test
+    fun outOfRangeSeek_isIgnored() {
+        rig.seedStreaming(positionMs = 30_000L, isPaused = false) // duration = 200_000
+
+        rig.vm.handleRemoteSeek(1_420_411L) // ~23 min, way past the end
+
+        verify(exactly = 0) { rig.service.syncSeek(any()) }
+        assertEquals("position must not move on a bogus seek", 30_000L, rig.vm.playback.value.positionMs)
+    }
+
+    @Test
+    fun negativeSeek_isIgnored() {
+        rig.seedStreaming(positionMs = 30_000L, isPaused = false)
+
+        rig.vm.handleRemoteSeek(-5_000L)
+
+        verify(exactly = 0) { rig.service.syncSeek(any()) }
+        assertEquals(30_000L, rig.vm.playback.value.positionMs)
+    }
+}


### PR DESCRIPTION
handleRemoteSeek now ignores any target below 0 or beyond the current track's duration, so a stale-snapshot seek (e.g. 23 min into a 3-min song) can't seek ExoPlayer past the end and end the track. Restores the protection the removed position-diff guard provided, the way the web player gets it from media-element clamping. Adds RemoteSeekBoundsTest.

Closes #329