### PR TITLE
Forward the tapped track index into skip_to

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -157,7 +157,7 @@ fun SpotifyImage(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null) {
+fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null, trackIndex: Int? = null) {
     var showMenu by remember { mutableStateOf(false) }
     val context = androidx.compose.ui.platform.LocalContext.current
     val playback by vm.playback.collectAsState()
@@ -168,7 +168,7 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)
     Row(
         Modifier
             .fillMaxWidth()
-            .clickable { vm.playTrack(track, contextUri) }
+            .clickable { vm.playTrack(track, contextUri, trackIndex) }
             .padding(horizontal = 16.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -267,7 +267,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                                 vm.togglePlayPause()
                             } else {
                                 val first = detail.tracks.firstOrNull() ?: return@clickable
-                                vm.playTrack(first, detail.uri)
+                                vm.playTrack(first, detail.uri, 0)
                             }
                         },
                     contentAlignment = Alignment.Center
@@ -302,8 +302,8 @@ fun DetailScreen(vm: SpotifyViewModel) {
             }
             when {
                 isArtist -> ArtistTrackRow(index + 1, track, vm, detail.uri, detail.topTrackPlaycounts.getOrNull(index))
-                detail.type == "album" -> AlbumTrackRow(track, vm, detail.uri)
-                else -> TrackRow(track, vm, contextUri = detail.uri)
+                detail.type == "album" -> AlbumTrackRow(track, vm, detail.uri, index)
+                else -> TrackRow(track, vm, contextUri = detail.uri, trackIndex = index)
             }
         }
 
@@ -503,7 +503,7 @@ private fun ArtistTrackRow(
     Row(
         Modifier
             .fillMaxWidth()
-            .clickable { vm.playTrack(track, contextUri) }
+            .clickable { vm.playTrack(track, contextUri, number - 1) }
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
@@ -633,7 +633,8 @@ private fun ArtistTrackRow(
 private fun AlbumTrackRow(
     track: ch.snepilatch.app.data.TrackInfo,
     vm: SpotifyViewModel,
-    contextUri: String
+    contextUri: String,
+    trackIndex: Int? = null
 ) {
     val playback by vm.playback.collectAsState()
     val isPlaying = playback.track?.uri == track.uri && playback.isPlaying
@@ -643,7 +644,7 @@ private fun AlbumTrackRow(
     Row(
         Modifier
             .fillMaxWidth()
-            .clickable { vm.playTrack(track, contextUri) }
+            .clickable { vm.playTrack(track, contextUri, trackIndex) }
             .padding(horizontal = 16.dp, vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1290,15 +1290,15 @@ class SpotifyViewModel : ViewModel() {
     /**
      * Play a tapped track. Local-first like the web player: resolve + load it on ExoPlayer immediately,
      * in parallel with the Spotify Connect "play" command, instead of waiting for the WS onTrackChange
-     * echo. The track's uid (carried by playlist rows) is forwarded so a context with the same track more
-     * than once starts on the exact tapped occurrence, matching the JS skip_to.
+     * echo. The track's uid + index (carried by playlist/album rows) are forwarded so a context with the
+     * same track more than once starts on the exact tapped occurrence, matching the JS skip_to.
      */
-    fun playTrack(track: TrackInfo, contextUri: String? = null) {
+    fun playTrack(track: TrackInfo, contextUri: String? = null, trackIndex: Int? = null) {
         userPlayJob?.cancel()
-        userPlayJob = viewModelScope.launch(Dispatchers.IO) { startUserPlayback(track, contextUri) }
+        userPlayJob = viewModelScope.launch(Dispatchers.IO) { startUserPlayback(track, contextUri, trackIndex) }
     }
 
-    internal suspend fun startUserPlayback(track: TrackInfo, contextUri: String?) = coroutineScope {
+    internal suspend fun startUserPlayback(track: TrackInfo, contextUri: String?, trackIndex: Int? = null) = coroutineScope {
         // Honor the resulting onTrackChange even if we're starting from idle (no local audio yet).
         pendingUserPlay = true
         val pc = player ?: return@coroutineScope
@@ -1328,13 +1328,13 @@ class SpotifyViewModel : ViewModel() {
         }
         try {
             try {
-                pc.playTrack(track.uri, contextUri, track.uid)
+                pc.playTrack(track.uri, contextUri, track.uid, trackIndex)
             } catch (e: Exception) {
                 if (e.message?.contains("PLAYER_COMMAND_REJECTED") == true) {
                     LokiLogger.i(TAG, "Command rejected, transferring playback here and retrying")
                     pc.transferPlaybackHere()
                     delay(500)
-                    pc.playTrack(track.uri, contextUri, track.uid)
+                    pc.playTrack(track.uri, contextUri, track.uid, trackIndex)
                 } else throw e
             }
             delay(500)

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/LocalFirstPlayTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/LocalFirstPlayTest.kt
@@ -42,9 +42,9 @@ class LocalFirstPlayTest {
             uri = "spotify:track:abc", name = "Song", artist = "Artist", albumArt = null, uid = "uid-42",
         )
 
-        runBlocking { rig.vm.startUserPlayback(track, "spotify:playlist:p1") }
+        runBlocking { rig.vm.startUserPlayback(track, "spotify:playlist:p1", trackIndex = 7) }
 
-        coVerify(exactly = 1) { pc.playTrack("spotify:track:abc", "spotify:playlist:p1", "uid-42") }
+        coVerify(exactly = 1) { pc.playTrack("spotify:track:abc", "spotify:playlist:p1", "uid-42", 7) }
     }
 
     @Test
@@ -56,6 +56,6 @@ class LocalFirstPlayTest {
             rig.vm.startUserPlayback(TrackInfo(uri = "spotify:track:xyz", name = "", artist = "", albumArt = null), null)
         }
 
-        coVerify(exactly = 1) { pc.playTrack("spotify:track:xyz", null, null) }
+        coVerify(exactly = 1) { pc.playTrack("spotify:track:xyz", null, null, null) }
     }
 }

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -27,7 +27,7 @@
     <ID>Indentation:SpotifyApp.kt$ </ID>
     <ID>LongMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: SpotifyViewModel)</ID>
     <ID>LongMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: SpotifyViewModel)</ID>
-    <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun AlbumTrackRow( track: ch.snepilatch.app.data.TrackInfo, vm: SpotifyViewModel, contextUri: String )</ID>
+    <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun AlbumTrackRow( track: ch.snepilatch.app.data.TrackInfo, vm: SpotifyViewModel, contextUri: String, trackIndex: Int? = null )</ID>
     <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun ArtistTrackRow( number: Int, track: ch.snepilatch.app.data.TrackInfo, vm: SpotifyViewModel, contextUri: String, playcount: String? = null )</ID>
     <ID>LongMethod:DevicesDialog.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun DevicesDialog(vm: SpotifyViewModel)</ID>
     <ID>LongMethod:LibraryScreen.kt$@Composable fun LibraryScreen(vm: SpotifyViewModel)</ID>
@@ -37,7 +37,7 @@
     <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: SpotifyViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
     <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun NowPlayingMenu( showMore: Boolean, onShowMore: (Boolean) -&gt; Unit, onShowPlaylistPicker: () -&gt; Unit, vm: SpotifyViewModel, track: ch.snepilatch.app.data.TrackInfo?, shareContext: android.content.Context, buttonBg: Color )</ID>
     <ID>LongMethod:SearchScreen.kt$@Composable fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel())</ID>
-    <ID>LongMethod:SharedComponents.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null)</ID>
+    <ID>LongMethod:SharedComponents.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null, trackIndex: Int? = null)</ID>
     <ID>LongMethod:SpotifyApp.kt$@Composable fun SpotifyApp(vm: SpotifyViewModel)</ID>
     <ID>LongMethod:SpotifyViewModel.kt$SpotifyViewModel$fun initialize(cookies: Map&lt;String, String&gt;)</ID>
     <ID>LongMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun coldStartPlay()</ID>


### PR DESCRIPTION
Threads the tapped track's index from the playlist/album/track rows through playTrack into skip_to.track_index, matching the web client's play command alongside the track_uid added earlier.

Closes #339