### PR TITLE
Hold a wake lock during playback so the dealer and audio survive standby

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 24
-        versionName = "2.6.0"
+        versionCode = 25
+        versionName = "2.6.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/src/app/src/main/AndroidManifest.xml
+++ b/src/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -137,6 +137,11 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         player = ExoPlayer.Builder(this)
             .setAudioAttributes(audioAttributes, true)
             .setLoadControl(loadControl)
+            // Hold a partial wake + Wi-Fi lock while playing. Streaming playback needs the network
+            // alive with the screen off; without this Doze freezes the CPU/radio between tracks, the
+            // dealer keep-alive thread stalls and end-of-track advance fails. WAKE_MODE_NETWORK is
+            // released automatically when playback stops. Requires the WAKE_LOCK permission.
+            .setWakeMode(C.WAKE_MODE_NETWORK)
             .build()
 
         player.addListener(object : Player.Listener {


### PR DESCRIPTION
Sets the ExoPlayer wake mode to `WAKE_MODE_NETWORK` and adds the `WAKE_LOCK` permission, so the CPU/radio stay awake during playback with the screen off — keeping the dealer keep-alive and end-of-track advance alive instead of freezing in Doze. Builds + unit tests + detekt green; standby behavior itself needs on-device confirmation.

Closes #343