### PR TITLE
Richer Android Auto browse tree: tabs, drill-in, art, and search

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -10,6 +10,7 @@ import android.graphics.BitmapFactory
 import android.media.audiofx.AudioEffect
 import android.net.ConnectivityManager
 import android.net.Network
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.support.v4.media.MediaBrowserCompat
@@ -35,7 +36,9 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import kotify.api.album.Album
 import kotify.api.playlist.Playlist
+import kotify.api.song.Song
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -52,6 +55,25 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         // Android Auto browse tree
         private const val BROWSE_ROOT = "root"
         private const val LIKED_SONGS_URI = "spotify:collection:tracks"
+
+        // Top-level category nodes — Android Auto renders root-level browsable items as tabs.
+        private const val CAT_PLAYLISTS = "cat:playlists"
+        private const val CAT_ALBUMS = "cat:albums"
+        private const val CAT_LIKED = "cat:liked"
+        private const val CAT_RECENT = "cat:recent"
+
+        // mediaId prefixes so onPlayFromMediaId knows how to act on a tapped item.
+        // PLAY_PREFIX + contextUri plays a whole context; TRACK_PREFIX + "trackUri|contextUri"
+        // plays a single track within its context so the queue continues.
+        private const val PLAY_PREFIX = "play:"
+        private const val TRACK_PREFIX = "track:"
+
+        // Android Auto content-style hints (androidx.media doesn't expose these as constants).
+        private const val CONTENT_STYLE_SUPPORTED = "android.media.browse.CONTENT_STYLE_SUPPORTED"
+        private const val CONTENT_STYLE_BROWSABLE_HINT = "android.media.browse.CONTENT_STYLE_BROWSABLE_HINT"
+        private const val CONTENT_STYLE_PLAYABLE_HINT = "android.media.browse.CONTENT_STYLE_PLAYABLE_HINT"
+        private const val CONTENT_STYLE_LIST = 1
+        private const val CONTENT_STYLE_GRID = 2
         private const val NOTIFICATION_ID = 1
         var instance: MusicPlaybackService? = null
             private set
@@ -265,7 +287,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                 }
 
                 override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) {
-                    if (mediaId != null) playFromContext(mediaId)
+                    if (mediaId != null) playFromMediaId(mediaId)
                 }
 
                 override fun onSeekTo(pos: Long) {
@@ -864,71 +886,179 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     override fun onGetRoot(clientPackageName: String, clientUid: Int, rootHints: Bundle?): BrowserRoot {
         // The content is the signed-in user's own library, so we grant any caller (Android Auto,
         // Assistant, the app itself). Transport still runs through the validated MediaSession.
-        return BrowserRoot(BROWSE_ROOT, null)
+        // Advertise content-style support so Auto honours the per-node grid/list hints below.
+        val extras = Bundle().apply {
+            putBoolean(CONTENT_STYLE_SUPPORTED, true)
+            putInt(CONTENT_STYLE_BROWSABLE_HINT, CONTENT_STYLE_GRID)
+            putInt(CONTENT_STYLE_PLAYABLE_HINT, CONTENT_STYLE_LIST)
+        }
+        return BrowserRoot(BROWSE_ROOT, extras)
     }
 
     override fun onLoadChildren(parentId: String, result: Result<MutableList<MediaBrowserCompat.MediaItem>>) {
-        if (parentId != BROWSE_ROOT) {
-            result.sendResult(mutableListOf())
+        // The root tabs are static and need no network, so answer synchronously.
+        if (parentId == BROWSE_ROOT) {
+            result.sendResult(buildRootTabs())
             return
         }
-        // Library load is a network call — detach and fill asynchronously.
+        // Everything below the root is a network call — detach and fill asynchronously.
         result.detach()
         serviceScope.launch {
             val items = try {
-                withContext(Dispatchers.IO) { buildRootChildren() }
+                withContext(Dispatchers.IO) { loadCategory(parentId) }
             } catch (e: Exception) {
-                LokiLogger.e(TAG, "onLoadChildren failed", e)
+                LokiLogger.e(TAG, "onLoadChildren failed for $parentId", e)
                 mutableListOf()
             }
             result.sendResult(items)
         }
     }
 
-    /** Liked Songs + the user's playlists, each as a playable item whose mediaId is its context URI. */
-    private suspend fun buildRootChildren(): MutableList<MediaBrowserCompat.MediaItem> {
+    /** Top-level tabs shown across the Android Auto browse bar. */
+    private fun buildRootTabs(): MutableList<MediaBrowserCompat.MediaItem> = mutableListOf(
+        browsableItem(CAT_PLAYLISTS, "Playlists", null, null),
+        browsableItem(CAT_ALBUMS, "Albums", null, null),
+        browsableItem(CAT_LIKED, "Liked Songs", null, null),
+        browsableItem(CAT_RECENT, "Recently Played", null, null),
+    )
+
+    /** Resolve the children of any non-root node: a category tab, or a playlist/album to drill into. */
+    private suspend fun loadCategory(parentId: String): MutableList<MediaBrowserCompat.MediaItem> {
         val sess = SessionHolder.session ?: return mutableListOf()
-        val out = mutableListOf<MediaBrowserCompat.MediaItem>()
-        out.add(browseItem(LIKED_SONGS_URI, "Liked Songs", "Playlist"))
-        Playlist(sess).getLibrary(limit = 50, offset = 0).items
-            .filter { it.uri.contains(":playlist:") || it.uri.contains(":album:") }
-            .forEach { out.add(browseItem(it.uri, it.name, it.ownerName ?: it.type)) }
-        return out
+        return when (parentId) {
+            CAT_PLAYLISTS -> Playlist(sess).getLibrary(limit = 50).items
+                .filter { it.uri.contains(":playlist:") }
+                .map { browsableItem(it.uri, it.name, it.ownerName ?: "Playlist", it.imageUrl) }
+                .toMutableList()
+
+            CAT_ALBUMS -> Playlist(sess).getLibrary(limit = 50).items
+                .filter { it.uri.contains(":album:") }
+                .map { browsableItem(it.uri, it.name, it.ownerName ?: "Album", it.imageUrl) }
+                .toMutableList()
+
+            CAT_RECENT -> Playlist(sess).getLibrary(limit = 50).items
+                .filter { it.uri.contains(":playlist:") || it.uri.contains(":album:") }
+                .sortedByDescending { it.playedAt ?: "" }
+                .take(20)
+                .map { browsableItem(it.uri, it.name, it.ownerName ?: it.type, it.imageUrl) }
+                .toMutableList()
+
+            CAT_LIKED, LIKED_SONGS_URI -> {
+                val out = mutableListOf(playAllItem(LIKED_SONGS_URI))
+                Playlist(sess).getLikedSongs(limit = 100).items.forEach { t ->
+                    out.add(trackItem(t.uri, LIKED_SONGS_URI, t.name, t.artists.joinToString(", ") { it.name }, t.album.coverArtUrl))
+                }
+                out
+            }
+
+            else -> when {
+                parentId.contains(":playlist:") -> {
+                    val info = Playlist(sess).getPlaylist(parentId.substringAfterLast(":"), limit = 100)
+                    val out = mutableListOf(playAllItem(parentId))
+                    info.tracks.forEach { t ->
+                        out.add(trackItem(t.uri, parentId, t.name, t.artists.joinToString(", "), t.coverArtUrl))
+                    }
+                    out
+                }
+                parentId.contains(":album:") -> {
+                    val info = Album(sess).getAlbum(parentId.substringAfterLast(":"), limit = 100)
+                    val out = mutableListOf(playAllItem(parentId))
+                    info.tracks.forEach { t ->
+                        out.add(trackItem(t.uri, parentId, t.name, t.artists.joinToString(", "), info.coverArtUrl))
+                    }
+                    out
+                }
+                else -> mutableListOf()
+            }
+        }
     }
 
-    private fun browseItem(mediaId: String, title: String, subtitle: String?): MediaBrowserCompat.MediaItem {
+    override fun onSearch(query: String, extras: Bundle?, result: Result<MutableList<MediaBrowserCompat.MediaItem>>) {
+        result.detach()
+        serviceScope.launch {
+            val items = try {
+                withContext(Dispatchers.IO) {
+                    val sess = SessionHolder.session ?: return@withContext mutableListOf()
+                    Song(sess).search(query, limit = 30).tracks.items.map { t ->
+                        // Search hits have no surrounding context — play the single track.
+                        trackItem(t.uri, t.uri, t.name, t.artists.joinToString(", ") { it.name }, t.album.coverArtUrl)
+                    }.toMutableList()
+                }
+            } catch (e: Exception) {
+                LokiLogger.e(TAG, "onSearch failed for '$query'", e)
+                mutableListOf()
+            }
+            result.sendResult(items)
+        }
+    }
+
+    /** A node Auto can open to reveal its children (a category, playlist or album). */
+    private fun browsableItem(mediaId: String, title: String, subtitle: String?, imageUrl: String?): MediaBrowserCompat.MediaItem {
         val desc = MediaDescriptionCompat.Builder()
             .setMediaId(mediaId)
             .setTitle(title)
             .setSubtitle(subtitle)
+            .apply { imageUrl?.let { setIconUri(Uri.parse(it)) } }
+            .build()
+        return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_BROWSABLE)
+    }
+
+    /** "Play all" entry at the top of a context, so the whole playlist/album can play in one tap. */
+    private fun playAllItem(contextUri: String): MediaBrowserCompat.MediaItem {
+        val desc = MediaDescriptionCompat.Builder()
+            .setMediaId(PLAY_PREFIX + contextUri)
+            .setTitle("▶ Play all")
+            .build()
+        return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
+    }
+
+    /** A single playable track; tapping plays it within [contextUri] so the queue continues. */
+    private fun trackItem(trackUri: String, contextUri: String, title: String, subtitle: String?, imageUrl: String?): MediaBrowserCompat.MediaItem {
+        val desc = MediaDescriptionCompat.Builder()
+            .setMediaId("$TRACK_PREFIX$trackUri|$contextUri")
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .apply { imageUrl?.let { setIconUri(Uri.parse(it)) } }
             .build()
         return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
     }
 
     /**
-     * Play a context (playlist/album/Liked Songs) chosen from the Android Auto browse tree. Resolves
-     * the context's first track and issues the play command via PlayerConnect; the dealer then drives
-     * the rest of the pipeline (onTrackChange -> resolve -> ExoPlayer) exactly like an in-app tap.
-     * Requires a live session — if the app process is cold this is a no-op (see the Auto cold-start note).
+     * Act on a tapped Android Auto item. "play:<ctx>" plays a whole context from its first track;
+     * "track:<trackUri>|<ctx>" plays a specific track inside its context (so the queue continues);
+     * a bare context URI keeps the old whole-context behaviour. The dealer then drives the rest of
+     * the pipeline (onTrackChange -> resolve -> ExoPlayer) exactly like an in-app tap. Requires a
+     * live session — if the app process is cold this is a no-op (see the Auto cold-start note).
      */
-    private fun playFromContext(contextUri: String) {
+    private fun playFromMediaId(mediaId: String) {
         serviceScope.launch {
             try {
                 val sess = SessionHolder.session ?: return@launch
                 val player = SessionHolder.player ?: return@launch
+                if (mediaId.startsWith(TRACK_PREFIX)) {
+                    val body = mediaId.removePrefix(TRACK_PREFIX)
+                    val trackUri = body.substringBefore("|")
+                    val contextUri = body.substringAfter("|", trackUri)
+                    LokiLogger.i(TAG, "Auto: playing track $trackUri in $contextUri")
+                    withContext(Dispatchers.IO) { player.playTrack(trackUri, contextUri) }
+                    return@launch
+                }
+                val contextUri = mediaId.removePrefix(PLAY_PREFIX)
                 val firstTrack = withContext(Dispatchers.IO) {
                     when {
                         contextUri == LIKED_SONGS_URI ->
                             Playlist(sess).getLikedSongs(limit = 1).items.firstOrNull()?.uri
                         contextUri.contains(":playlist:") ->
                             Playlist(sess).getPlaylist(contextUri.substringAfterLast(":"), limit = 1).tracks.firstOrNull()?.uri
+                        contextUri.contains(":album:") ->
+                            Album(sess).getAlbum(contextUri.substringAfterLast(":"), limit = 1).tracks.firstOrNull()?.uri
                         else -> null
                     }
                 } ?: return@launch
                 LokiLogger.i(TAG, "Auto: playing $contextUri from $firstTrack")
                 withContext(Dispatchers.IO) { player.playTrack(firstTrack, contextUri) }
             } catch (e: Exception) {
-                LokiLogger.e(TAG, "Auto play failed for $contextUri", e)
+                LokiLogger.e(TAG, "Auto play failed for $mediaId", e)
             }
         }
     }

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -74,6 +74,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         private const val CONTENT_STYLE_PLAYABLE_HINT = "android.media.browse.CONTENT_STYLE_PLAYABLE_HINT"
         private const val CONTENT_STYLE_LIST = 1
         private const val CONTENT_STYLE_GRID = 2
+
+        // Tells Android Auto the browser supports search, so it shows the search button → onSearch.
+        private const val SEARCH_SUPPORTED = "android.media.browse.SEARCH_SUPPORTED"
         private const val NOTIFICATION_ID = 1
         var instance: MusicPlaybackService? = null
             private set
@@ -891,6 +894,8 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             putBoolean(CONTENT_STYLE_SUPPORTED, true)
             putInt(CONTENT_STYLE_BROWSABLE_HINT, CONTENT_STYLE_GRID)
             putInt(CONTENT_STYLE_PLAYABLE_HINT, CONTENT_STYLE_LIST)
+            // Surface Auto's search affordance (the magnifying-glass button) — routed to onSearch.
+            putBoolean(SEARCH_SUPPORTED, true)
         }
         return BrowserRoot(BROWSE_ROOT, extras)
     }
@@ -914,13 +919,16 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         }
     }
 
-    /** Top-level tabs shown across the Android Auto browse bar. */
+    /** Top-level tabs shown across the Android Auto browse bar, each with its own glyph. */
     private fun buildRootTabs(): MutableList<MediaBrowserCompat.MediaItem> = mutableListOf(
-        browsableItem(CAT_PLAYLISTS, "Playlists", null, null),
-        browsableItem(CAT_ALBUMS, "Albums", null, null),
-        browsableItem(CAT_LIKED, "Liked Songs", null, null),
-        browsableItem(CAT_RECENT, "Recently Played", null, null),
+        browsableItem(CAT_PLAYLISTS, "Playlists", null, resourceUri(R.drawable.ic_auto_playlists)),
+        browsableItem(CAT_ALBUMS, "Albums", null, resourceUri(R.drawable.ic_auto_albums)),
+        browsableItem(CAT_LIKED, "Liked Songs", null, resourceUri(R.drawable.ic_auto_liked)),
+        browsableItem(CAT_RECENT, "Recently Played", null, resourceUri(R.drawable.ic_auto_recent)),
     )
+
+    /** A loadable URI for a bundled drawable, for use as an Android Auto item/tab icon. */
+    private fun resourceUri(resId: Int): String = "android.resource://$packageName/$resId"
 
     /** Resolve the children of any non-root node: a category tab, or a playlist/album to drill into. */
     private suspend fun loadCategory(parentId: String): MutableList<MediaBrowserCompat.MediaItem> {

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -37,6 +37,7 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import kotify.api.album.Album
+import kotify.api.home.Home
 import kotify.api.playlist.Playlist
 import kotify.api.song.Song
 import kotlinx.coroutines.CoroutineScope
@@ -57,10 +58,11 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         private const val LIKED_SONGS_URI = "spotify:collection:tracks"
 
         // Top-level category nodes — Android Auto renders root-level browsable items as tabs.
-        private const val CAT_PLAYLISTS = "cat:playlists"
-        private const val CAT_ALBUMS = "cat:albums"
-        private const val CAT_LIKED = "cat:liked"
+        // Mirrors Spotify's layout: Home (Liked Songs pinned first) / Latest / Library. Search is the
+        // toolbar button (SEARCH_SUPPORTED) rather than a tab — Auto can't host a keyboard in a tab.
+        private const val CAT_HOME = "cat:home"
         private const val CAT_RECENT = "cat:recent"
+        private const val CAT_LIBRARY = "cat:library"
 
         // mediaId prefixes so onPlayFromMediaId knows how to act on a tapped item.
         // PLAY_PREFIX + contextUri plays a whole context; TRACK_PREFIX + "trackUri|contextUri"
@@ -921,10 +923,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
     /** Top-level tabs shown across the Android Auto browse bar, each with its own glyph. */
     private fun buildRootTabs(): MutableList<MediaBrowserCompat.MediaItem> = mutableListOf(
-        browsableItem(CAT_PLAYLISTS, "Playlists", null, resourceUri(R.drawable.ic_auto_playlists)),
-        browsableItem(CAT_ALBUMS, "Albums", null, resourceUri(R.drawable.ic_auto_albums)),
-        browsableItem(CAT_LIKED, "Liked Songs", null, resourceUri(R.drawable.ic_auto_liked)),
-        browsableItem(CAT_RECENT, "Recently Played", null, resourceUri(R.drawable.ic_auto_recent)),
+        browsableItem(CAT_HOME, "Home", null, resourceUri(R.drawable.ic_auto_home)),
+        browsableItem(CAT_RECENT, "Latest", null, resourceUri(R.drawable.ic_auto_recent)),
+        browsableItem(CAT_LIBRARY, "Library", null, resourceUri(R.drawable.ic_auto_library)),
     )
 
     /** A loadable URI for a bundled drawable, for use as an Android Auto item/tab icon. */
@@ -934,16 +935,23 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     private suspend fun loadCategory(parentId: String): MutableList<MediaBrowserCompat.MediaItem> {
         val sess = SessionHolder.session ?: return mutableListOf()
         return when (parentId) {
-            CAT_PLAYLISTS -> Playlist(sess).getLibrary(limit = 50).items
-                .filter { it.uri.contains(":playlist:") }
-                .map { browsableItem(it.uri, it.name, it.ownerName ?: "Playlist", it.imageUrl) }
-                .toMutableList()
+            // Home: Liked Songs pinned first, then the user's Spotify home feed (playlists/albums).
+            CAT_HOME -> {
+                val out = mutableListOf(
+                    browsableItem(LIKED_SONGS_URI, "Liked Songs", "Playlist", resourceUri(R.drawable.ic_auto_liked))
+                )
+                Home(sess).getHomeFeed()?.sections
+                    ?.flatMap { it.items }
+                    ?.filter { it.uri.contains(":playlist:") || it.uri.contains(":album:") }
+                    ?.distinctBy { it.uri }
+                    ?.take(40)
+                    ?.forEach {
+                        out.add(browsableItem(it.uri, it.name, it.artists?.joinToString(", ") ?: it.owner ?: it.type, it.imageUrl))
+                    }
+                out
+            }
 
-            CAT_ALBUMS -> Playlist(sess).getLibrary(limit = 50).items
-                .filter { it.uri.contains(":album:") }
-                .map { browsableItem(it.uri, it.name, it.ownerName ?: "Album", it.imageUrl) }
-                .toMutableList()
-
+            // Latest: recently played items from the library, newest first.
             CAT_RECENT -> Playlist(sess).getLibrary(limit = 50).items
                 .filter { it.uri.contains(":playlist:") || it.uri.contains(":album:") }
                 .sortedByDescending { it.playedAt ?: "" }
@@ -951,7 +959,13 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                 .map { browsableItem(it.uri, it.name, it.ownerName ?: it.type, it.imageUrl) }
                 .toMutableList()
 
-            CAT_LIKED, LIKED_SONGS_URI -> {
+            // Library: the user's playlists + saved albums.
+            CAT_LIBRARY -> Playlist(sess).getLibrary(limit = 50).items
+                .filter { it.uri.contains(":playlist:") || it.uri.contains(":album:") }
+                .map { browsableItem(it.uri, it.name, it.ownerName ?: it.type, it.imageUrl) }
+                .toMutableList()
+
+            LIKED_SONGS_URI -> {
                 val out = mutableListOf(playAllItem(LIKED_SONGS_URI))
                 Playlist(sess).getLikedSongs(limit = 100).items.forEach { t ->
                     out.add(trackItem(t.uri, LIKED_SONGS_URI, t.name, t.artists.joinToString(", ") { it.name }, t.album.coverArtUrl))
@@ -1015,7 +1029,8 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     private fun playAllItem(contextUri: String): MediaBrowserCompat.MediaItem {
         val desc = MediaDescriptionCompat.Builder()
             .setMediaId(PLAY_PREFIX + contextUri)
-            .setTitle("▶ Play all")
+            .setTitle("Play all")
+            .setIconUri(Uri.parse(resourceUri(R.drawable.ic_auto_play)))
             .build()
         return MediaBrowserCompat.MediaItem(desc, MediaBrowserCompat.MediaItem.FLAG_PLAYABLE)
     }

--- a/src/app/src/main/res/drawable/ic_auto_albums.xml
+++ b/src/app/src/main/res/drawable/ic_auto_albums.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,16.5c-2.49,0 -4.5,-2.01 -4.5,-4.5S9.51,7.5 12,7.5s4.5,2.01 4.5,4.5 -2.01,4.5 -4.5,4.5zM12,11c-0.55,0 -1,0.45 -1,1s0.45,1 1,1 1,-0.45 1,-1 -0.45,-1 -1,-1z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_auto_home.xml
+++ b/src/app/src/main/res/drawable/ic_auto_home.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_auto_library.xml
+++ b/src/app/src/main/res/drawable/ic_auto_library.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M4,6H2v14c0,1.1 0.9,2 2,2h14v-2H4V6zM20,2H8C6.9,2 6,2.9 6,4v12c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V4C22,2.9 21.1,2 20,2zM18,11h-3v3.5c0,1.38 -1.12,2.5 -2.5,2.5S10,15.88 10,14.5s1.12,-2.5 2.5,-2.5c0.57,0 1.08,0.19 1.5,0.51V7h4V11z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_auto_liked.xml
+++ b/src/app/src/main/res/drawable/ic_auto_liked.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_auto_play.xml
+++ b/src/app/src/main/res/drawable/ic_auto_play.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M8,5v14l11,-7z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_auto_playlists.xml
+++ b/src/app/src/main/res/drawable/ic_auto_playlists.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M15,6H3v2h12V6zM15,10H3v2h12V10zM3,16h8v-2H3V16zM17,6v8.18C16.69,14.07 16.35,14 16,14c-1.66,0 -3,1.34 -3,3s1.34,3 3,3 3,-1.34 3,-3V8h3V6H17z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_auto_recent.xml
+++ b/src/app/src/main/res/drawable/ic_auto_recent.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M13,3c-4.97,0 -9,4.03 -9,9H1l3.89,3.89 0.07,0.14L9,12H6c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8z"/>
+</vector>


### PR DESCRIPTION
Turns the flat Android Auto list into a hierarchical browse experience within Auto's media template: root tabs (Playlists / Albums / Liked Songs / Recently Played), browsable playlists/albums that drill into individual tracks with a Play all entry, cover art + grid/list content-style hints, and onSearch for voice playback.

Closes #345