### PR TITLE
Android Auto: queue button, full library parity, and white like icon

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -37,9 +37,9 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import kotify.api.album.Album
+import ch.snepilatch.app.data.TrackInfo
 import kotify.api.artist.Artist
 import kotify.api.home.Home
-import kotify.api.playerstatus.QueueTrack
 import kotify.api.playlist.Playlist
 import kotify.api.song.Song
 import kotlinx.coroutines.CoroutineScope
@@ -95,7 +95,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     private val mainHandler = Handler(Looper.getMainLooper())
 
     /** The upcoming queue last published to the media session, indexed by queue-item id. */
-    private var currentQueue: List<QueueTrack> = emptyList()
+    private var currentQueue: List<TrackInfo> = emptyList()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     /** Loopback proxy that decrypts Blowfish-encrypted Deezer streams on the fly. */
@@ -944,9 +944,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     /**
      * Publish the upcoming tracks to the media session so Android Auto (and the system UI) show a
      * queue button on the now-playing screen. Each item's id is its index, used by onSkipToQueueItem.
-     * Called from the ViewModel on every state update.
+     * Fed from the ViewModel's _queue (a fresh getState() fetch) — the pushed cluster state truncates
+     * next_tracks to a couple of entries, so we use the full queue the app already resolves.
      */
-    fun updateQueue(tracks: List<QueueTrack>) {
+    fun updateQueue(tracks: List<TrackInfo>) {
         val capped = tracks.take(50)
         currentQueue = capped
         mainHandler.post {
@@ -957,9 +958,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             val items = capped.mapIndexed { index, t ->
                 val desc = MediaDescriptionCompat.Builder()
                     .setMediaId(t.uri)
-                    .setTitle(t.name ?: "")
-                    .setSubtitle(t.artistName)
-                    .apply { t.imageUrl?.let { setIconUri(Uri.parse(it)) } }
+                    .setTitle(t.name)
+                    .setSubtitle(t.artist)
+                    .apply { t.albumArt?.let { setIconUri(Uri.parse(it)) } }
                     .build()
                 MediaSessionCompat.QueueItem(desc, index.toLong())
             }

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -37,7 +37,9 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import kotify.api.album.Album
+import kotify.api.artist.Artist
 import kotify.api.home.Home
+import kotify.api.playerstatus.QueueTrack
 import kotify.api.playlist.Playlist
 import kotify.api.song.Song
 import kotlinx.coroutines.CoroutineScope
@@ -91,6 +93,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
     private var mediaSession: MediaSessionCompat? = null
     private val mainHandler = Handler(Looper.getMainLooper())
+
+    /** The upcoming queue last published to the media session, indexed by queue-item id. */
+    private var currentQueue: List<QueueTrack> = emptyList()
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     /** Loopback proxy that decrypts Blowfish-encrypted Deezer streams on the fly. */
@@ -303,6 +308,19 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
                 override fun onPlayFromMediaId(mediaId: String?, extras: Bundle?) {
                     if (mediaId != null) playFromMediaId(mediaId)
+                }
+
+                override fun onSkipToQueueItem(id: Long) {
+                    val track = currentQueue.getOrNull(id.toInt()) ?: return
+                    serviceScope.launch {
+                        try {
+                            withContext(Dispatchers.IO) {
+                                SessionHolder.player?.skipToTrack(track.uri, track.uid ?: "")
+                            }
+                        } catch (e: Exception) {
+                            LokiLogger.e(TAG, "Auto: skipToQueueItem failed for ${track.uri}", e)
+                        }
+                    }
                 }
 
                 override fun onSeekTo(pos: Long) {
@@ -740,6 +758,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                 PlaybackStateCompat.ACTION_PLAY_PAUSE or
                 PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
                 PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
+                PlaybackStateCompat.ACTION_SKIP_TO_QUEUE_ITEM or
                 PlaybackStateCompat.ACTION_SEEK_TO or
                 PlaybackStateCompat.ACTION_STOP
             )
@@ -749,7 +768,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         fun addButtonAction(type: String, actionName: String) {
             when (type) {
                 "like" -> {
-                    val icon = if (isLiked) R.drawable.ic_heart_filled else R.drawable.ic_heart_outline
+                    // White/tintable icons — Android Auto can't tint the green ic_heart_* vectors and
+                    // falls back to the app icon for the custom action.
+                    val icon = if (isLiked) R.drawable.ic_auto_like_on else R.drawable.ic_auto_like_off
                     builder.addCustomAction(actionName, if (isLiked) "Unlike" else "Like", icon)
                 }
                 "shuffle" -> {
@@ -920,6 +941,33 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         }
     }
 
+    /**
+     * Publish the upcoming tracks to the media session so Android Auto (and the system UI) show a
+     * queue button on the now-playing screen. Each item's id is its index, used by onSkipToQueueItem.
+     * Called from the ViewModel on every state update.
+     */
+    fun updateQueue(tracks: List<QueueTrack>) {
+        val capped = tracks.take(50)
+        currentQueue = capped
+        mainHandler.post {
+            if (capped.isEmpty()) {
+                mediaSession?.setQueue(null)
+                return@post
+            }
+            val items = capped.mapIndexed { index, t ->
+                val desc = MediaDescriptionCompat.Builder()
+                    .setMediaId(t.uri)
+                    .setTitle(t.name ?: "")
+                    .setSubtitle(t.artistName)
+                    .apply { t.imageUrl?.let { setIconUri(Uri.parse(it)) } }
+                    .build()
+                MediaSessionCompat.QueueItem(desc, index.toLong())
+            }
+            mediaSession?.setQueue(items)
+            mediaSession?.setQueueTitle("Up next")
+        }
+    }
+
     private suspend fun loadBitmap(url: String): Bitmap? = withContext(Dispatchers.IO) {
         try {
             // Spotify's cluster API returns art as `spotify:image:<id>` URIs.
@@ -1024,10 +1072,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                 .map { browsableItem(it.uri, it.name, it.ownerName ?: it.type, it.imageUrl) }
                 .toMutableList()
 
-            // Library: the user's playlists + saved albums.
+            // Library: the user's full library — playlists, albums and artists — matching the
+            // in-app Library tab (default order), not just playlists and albums.
             CAT_LIBRARY -> Playlist(sess).getLibrary(limit = 50).items
-                .filter { it.uri.contains(":playlist:") || it.uri.contains(":album:") }
-                .map { browsableItem(it.uri, it.name, it.ownerName ?: it.type, it.imageUrl) }
+                .map { browsableItem(it.uri, it.name, it.ownerName ?: it.type.replaceFirstChar { c -> c.uppercase() }, it.imageUrl) }
                 .toMutableList()
 
             LIKED_SONGS_URI -> {
@@ -1054,6 +1102,12 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                         out.add(trackItem(t.uri, parentId, t.name, t.artists.joinToString(", "), info.coverArtUrl))
                     }
                     out
+                }
+                parentId.contains(":artist:") -> {
+                    val info = Artist(sess).getArtist(parentId.substringAfterLast(":"))
+                    info.topTracks.map { t ->
+                        trackItem(t.uri, parentId, t.name, info.name, t.coverArtUrl)
+                    }.toMutableList()
                 }
                 else -> mutableListOf()
             }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -456,8 +456,6 @@ class SpotifyViewModel : ViewModel() {
         pc.onState { state ->
             val delta = if (lastCommandTs > 0) System.currentTimeMillis() - lastCommandTs else -1
             LokiLogger.i(TAG, "[Timing] WS onState arrived (${delta}ms after CMD '$lastCommandName')")
-            // Feed the upcoming queue to the media session so Android Auto shows the queue button.
-            MusicPlaybackService.instance?.updateQueue(state.next_tracks)
             viewModelScope.launch { updatePlaybackFromState(state) }
         }
 
@@ -482,7 +480,10 @@ class SpotifyViewModel : ViewModel() {
             resolveJob?.cancel()
             resolveJob = viewModelScope.launch(Dispatchers.IO) {
                 resolveAndPlay(event)
-                if (currentScreen.value == Screen.QUEUE) refreshQueue()
+                // Refresh on every track change (not just when the queue screen is open) so the
+                // Android Auto queue stays current — refreshQueue uses a fresh getState() whose
+                // next_tracks isn't truncated like the pushed cluster state.
+                refreshQueue()
             }
         }
 
@@ -1380,6 +1381,7 @@ class SpotifyViewModel : ViewModel() {
 
                 // Show immediately with what we have
                 _queue.value = parsed.map { it.info }
+                MusicPlaybackService.instance?.updateQueue(_queue.value)
 
                 // Fetch missing metadata concurrently
                 val needFetch = parsed.filter { it.needsFetch }
@@ -1406,6 +1408,7 @@ class SpotifyViewModel : ViewModel() {
                             f.copy(uid = pt.info.uid ?: f.uid)
                         } else pt.info
                     }
+                    MusicPlaybackService.instance?.updateQueue(_queue.value)
                 }
             } catch (e: Exception) { LokiLogger.e(TAG, "refreshQueue", e) }
         }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -456,6 +456,8 @@ class SpotifyViewModel : ViewModel() {
         pc.onState { state ->
             val delta = if (lastCommandTs > 0) System.currentTimeMillis() - lastCommandTs else -1
             LokiLogger.i(TAG, "[Timing] WS onState arrived (${delta}ms after CMD '$lastCommandName')")
+            // Feed the upcoming queue to the media session so Android Auto shows the queue button.
+            MusicPlaybackService.instance?.updateQueue(state.next_tracks)
             viewModelScope.launch { updatePlaybackFromState(state) }
         }
 

--- a/src/app/src/main/res/drawable/ic_auto_like_off.xml
+++ b/src/app/src/main/res/drawable/ic_auto_like_off.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12.1,18.55l-0.1,0.1 -0.1,-0.1C7.14,14.24 4,11.39 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,0.99 3.57,2.36h1.87C13.46,5.99 14.96,5 16.5,5c2,0 3.5,1.5 3.5,3.5 0,2.89 -3.14,5.74 -7.9,10.05z"/>
+</vector>

--- a/src/app/src/main/res/drawable/ic_auto_like_on.xml
+++ b/src/app/src/main/res/drawable/ic_auto_like_on.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path android:fillColor="#FFFFFF"
+        android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+</vector>


### PR DESCRIPTION
Three Android Auto follow-ups: publishes the player's next_tracks to the media session (setQueue + skip-to-queue-item action) so Auto shows the queue button, wired to skipToTrack; makes the Library tab list the whole in-app library including artists, with artist drill-in to top tracks; and gives the like custom action a white tintable icon so Auto stops falling back to the app icon.

Closes #349