### PR TITLE
Resolve podcast episodes via soundfinder with passthrough support

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 38
-        versionName = "2.9.6"
+        versionCode = 39
+        versionName = "2.9.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
@@ -64,6 +64,14 @@ class SpotifyCdnResolver(
     )
 
     /**
+     * Resolve a podcast episode via the web player's `soundfinder/v1/unauth/episode` endpoint. The
+     * result says whether the episode is passthrough (a direct DRM-free url) or Widevine-hosted (a
+     * file id), so the caller can skip DRM entirely for passthrough episodes. Null if it doesn't resolve.
+     */
+    suspend fun resolveEpisode(episodeId: String): kotify.cdn.EpisodeResolveInfo? =
+        spotifyPlayback.resolveEpisode(episodeId)
+
+    /**
      * Fetch the audio file id for a track URI via `track-playback/v1/media` — the endpoint the web
      * player's local ListPlayer uses. This is the reliable self-resolve path: [fetchFileIdFromMetadata]
      * (`metadata/4/track`) returns only cover-art ids on many accounts. Used to start a tapped track

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -2321,6 +2321,66 @@ class SpotifyViewModel : ViewModel() {
      * onPlaybackId / onExternalUrl race onTrackChange, so we wait briefly for either to arrive. On
      * failure we stop cleanly — we do NOT fall back to the third-party music CDN (wrong for podcasts).
      */
+    /**
+     * Resolve + play an episode via soundfinder (`soundfinder/v1/unauth/episode`), the web player's
+     * episode path. Passthrough episodes stream their direct DRM-free url (no Widevine); hosted
+     * episodes resolve the Widevine file id with the corrected v2 seektable PSSH. Returns true if
+     * playback started; false (after logging) to fall back to the state-machine path.
+     */
+    internal suspend fun resolveEpisodeViaSoundfinder(
+        trackUri: String, title: String, artist: String, art: String?, resolveStart: Long
+    ): Boolean {
+        val resolver = cdnResolver ?: return false
+        val episodeId = trackUri.removePrefix("spotify:episode:")
+        return try {
+            val ep = resolver.resolveEpisode(episodeId)
+            val coldStart = coldStartPending
+            val passthroughUrl = ep?.passthroughUrl?.takeIf { ep.isPassthrough }
+            val fileId = ep?.fileId
+            when {
+                // Passthrough: the show's original DRM-free url, streamed as-is.
+                passthroughUrl != null -> {
+                    withContext(Dispatchers.Main) { MusicPlaybackService.instance?.stop() }
+                    playUrlAt = System.currentTimeMillis()
+                    withContext(Dispatchers.Main) {
+                        MusicPlaybackService.instance?.playUrl(passthroughUrl, title, artist, art, startPlaying = !coldStart, headers = emptyMap())
+                    }
+                    commitEpisodeStream(trackUri, "Podcast")
+                    LokiLogger.i(TAG, "[Episode] passthrough (direct, no DRM) for $trackUri in ${System.currentTimeMillis() - resolveStart}ms")
+                    true
+                }
+                // Hosted: Widevine file id -> CDN + v2 PSSH + license, played like a track.
+                fileId != null -> {
+                    latestFileId = fileId
+                    val stream = resolver.resolveForFileId(fileId)
+                    withContext(Dispatchers.Main) { MusicPlaybackService.instance?.stop() }
+                    playUrlAt = System.currentTimeMillis()
+                    withContext(Dispatchers.Main) {
+                        MusicPlaybackService.instance?.playDrmUrl(
+                            stream.cdnUrl, stream.licenseUrl, stream.licenseHeaders, title, artist, art,
+                            startPlaying = !coldStart, pssh = stream.pssh,
+                        )
+                    }
+                    commitEpisodeStream(trackUri, "Spotify CDN")
+                    LokiLogger.i(TAG, "[Episode] soundfinder hosted DRM loaded in ${System.currentTimeMillis() - resolveStart}ms")
+                    true
+                }
+                else -> false
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LokiLogger.e(TAG, "[Episode] soundfinder path failed for $trackUri, falling back", e)
+            false
+        }
+    }
+
+    private fun commitEpisodeStream(trackUri: String, provider: String) {
+        currentStreamUri = trackUri
+        isStreaming.value = true
+        streamProvider.value = provider
+    }
+
     private suspend fun resolveAndPlayEpisode(
         trackUri: String,
         event: kotify.api.playerstatus.TrackChangeEvent,
@@ -2330,6 +2390,12 @@ class SpotifyViewModel : ViewModel() {
         resolveStart: Long
     ) {
         try {
+            // Primary path: resolve the episode directly via soundfinder (what the web player does).
+            // Passthrough episodes hand back a direct DRM-free url (skip Widevine entirely); hosted
+            // episodes carry a Widevine file id we resolve with the corrected v2 seektable PSSH. This
+            // avoids racing the state machine and fixes DRM_LICENSE_ACQUISITION_FAILED on podcasts.
+            if (resolveEpisodeViaSoundfinder(trackUri, title, artist, art, resolveStart)) return
+
             var fileId = event.currentFileId ?: latestFileId
             var externalUrl = externalUrlByUri[trackUri]
             if (fileId == null && externalUrl == null) {

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/EpisodePassthroughTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/EpisodePassthroughTest.kt
@@ -1,0 +1,77 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.playback.engine.SpotifyCdnResolver
+import ch.snepilatch.app.playback.engine.SpotifyStream
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import kotify.cdn.EpisodeResolveInfo
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A passthrough episode (the show's original DRM-free url) must be streamed directly via playUrl —
+ * never forced through Widevine/playDrmUrl. A hosted episode (no passthrough) must go through
+ * playDrmUrl with the resolved PSSH. Guards the podcast DRM_LICENSE_ACQUISITION_FAILED fix.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class EpisodePassthroughTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before fun setUp() { rig.install() }
+
+    @After fun tearDown() {
+        SessionHolder.cdnResolver = null
+        rig.uninstall()
+    }
+
+    @Test
+    fun passthroughEpisode_streamsDirectUrl_notDrm() = runBlocking {
+        val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
+        coEvery { resolver.resolveEpisode("EP1") } returns EpisodeResolveInfo(
+            fileId = "hostedFileId",
+            format = "MP4_128",
+            cdnUrls = listOf("https://cdn/enc"),
+            passthrough = "ALLOWED",
+            passthroughUrl = "https://mcdn.podbean.com/show/ep1.mp3",
+        )
+        SessionHolder.cdnResolver = resolver
+
+        val handled = rig.vm.resolveEpisodeViaSoundfinder("spotify:episode:EP1", "Ep One", "Some Show", null, 0L)
+
+        assert(handled)
+        verify {
+            rig.service.playUrl("https://mcdn.podbean.com/show/ep1.mp3", "Ep One", "Some Show", null, startPlaying = any(), headers = emptyMap())
+        }
+        verify(exactly = 0) { rig.service.playDrmUrl(any(), any(), any(), any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun hostedEpisode_goesThroughDrm() = runBlocking {
+        val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
+        coEvery { resolver.resolveEpisode("EP2") } returns EpisodeResolveInfo(
+            fileId = "wideFileId",
+            format = "MP4_128",
+            cdnUrls = listOf("https://cdn/enc"),
+            passthrough = "NONE",
+            passthroughUrl = null,
+        )
+        coEvery { resolver.resolveForFileId(eq("wideFileId"), any()) } returns SpotifyStream(
+            cdnUrl = "https://cdn/enc", licenseUrl = "https://lic", licenseHeaders = emptyMap(),
+            mirrorCount = 1, pssh = "PSSHBYTES",
+        )
+        SessionHolder.cdnResolver = resolver
+
+        val handled = rig.vm.resolveEpisodeViaSoundfinder("spotify:episode:EP2", "Ep Two", "Show", null, 0L)
+
+        assert(handled)
+        verify {
+            rig.service.playDrmUrl("https://cdn/enc", "https://lic", emptyMap(), any(), any(), any(), any(), any(), pssh = "PSSHBYTES")
+        }
+    }
+}


### PR DESCRIPTION
Episodes now resolve through `soundfinder/v1/unauth/episode` first (the web player's path): passthrough episodes stream their direct DRM-free url and hosted episodes use the Widevine file id with the corrected v2 seektable PSSH, falling back to the state-machine path on any failure. Fixes ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED on podcasts and pulls in the KotifyClient seektable/format/passthrough fixes. Ships 2.9.7.