### PR TITLE
Don't hand free accounts a premium-format audio file id

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 39
-        versionName = "2.9.7"
+        versionCode = 40
+        versionName = "2.9.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
@@ -81,6 +81,15 @@ class SpotifyCdnResolver(
         spotifyPlayback.resolveFileIdForUri(trackUri)
 
     /**
+     * Like [fetchFileIdFromMedia] but also returns the audio's numeric storage format (10=MP4_128,
+     * 11=MP4_256, 12/13=dual). Callers use the format to avoid handing a premium-quality file id to a
+     * free account's Widevine CDM, which returns ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED. Null if
+     * the URI has no resolvable audio manifest.
+     */
+    suspend fun resolveMediaEntry(trackUri: String): Pair<String, String>? =
+        spotifyPlayback.resolveAudioEntryForUri(trackUri)
+
+    /**
      * Fetch the file id for a track via the metadata API, preferring the
      * higher-quality MP4_256 variant and falling back to MP4_128.
      */

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1299,7 +1299,7 @@ class SpotifyViewModel : ViewModel() {
         // the per-uri media self-resolve (authoritative for the failed uri) so a state-machine advance
         // can't leave us reloading the wrong file; latestFileId covers hosted episodes.
         val resolver = cdnResolver ?: return false
-        val fileId = resolver.fetchFileIdFromMedia(failedUri)
+        val fileId = safeMediaFileId(failedUri)
             ?: latestFileId
             ?: resolver.fetchFileIdFromMetadata(failedUri)
             ?: return false
@@ -1480,8 +1480,8 @@ class SpotifyViewModel : ViewModel() {
         try {
             val resolver = cdnResolver ?: return
             val trackUri = track.uri
-            val fileId = resolver.fetchFileIdFromMedia(trackUri) ?: run {
-                LokiLogger.i(TAG, "[InstantTap] no media file id for $trackUri, deferring to echo")
+            val fileId = safeMediaFileId(trackUri) ?: run {
+                LokiLogger.i(TAG, "[InstantTap] no licensable media file id for $trackUri, deferring to echo")
                 return
             }
             val stream = resolver.resolveForFileId(fileId)
@@ -2121,6 +2121,27 @@ class SpotifyViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Media-endpoint file id, gated to what the account can actually license. The media endpoint
+     * returns the highest offered quality (often MP4_256, format 11), but a FREE account can only get
+     * a Widevine license for MP4_128 (format 10) — handing its CDM a premium file id yields
+     * ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED mid-track. Return the media file id only for premium
+     * accounts or a free-safe MP4_128; otherwise null so the caller relies on the connect-state file
+     * id (the account's entitled quality). Fixes the regression from self-resolving the echo path via
+     * the media endpoint.
+     */
+    internal suspend fun safeMediaFileId(trackUri: String): String? {
+        val (fileId, format) = cdnResolver?.resolveMediaEntry(trackUri) ?: return null
+        if (_account.value.isPremium || format == "10") return fileId
+        LokiLogger.i(TAG, "Skipping media file id for $trackUri (format=$format not licensable on free tier)")
+        return null
+    }
+
+    /** Test seam: set the account's premium flag so [safeMediaFileId] can be exercised. */
+    internal fun setPremiumForTest(premium: Boolean) {
+        _account.value = _account.value.copy(isPremium = premium)
+    }
+
     private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent) {
         val resolveStart = System.currentTimeMillis()
         val current = event.current ?: return
@@ -2223,20 +2244,22 @@ class SpotifyViewModel : ViewModel() {
                     // Use file ID from cluster state or from onPlaybackId (state machine)
                     var fileId = event.currentFileId ?: latestFileId
                     if (fileId == null) {
-                        // Brief wait — onPlaybackId may fire slightly after onTrackChange
-                        LokiLogger.d(TAG, "SpotifyCDN: Waiting briefly for file ID...")
-                        for (i in 1..5) {
+                        // Wait for onPlaybackId — the state machine pushes the account's ENTITLED file id
+                        // (MP4_128 on free). Give it real time before self-resolving, because the media
+                        // endpoint below only offers premium MP4_256 on many accounts, which a free CDM
+                        // can't license. Cheap: only runs when the cluster hasn't supplied a file id yet.
+                        LokiLogger.d(TAG, "SpotifyCDN: Waiting for state-machine file ID...")
+                        for (i in 1..15) {
                             delay(100)
                             fileId = latestFileId
                             if (fileId != null) break
-                            LokiLogger.d(TAG, "SpotifyCDN: file ID still null after attempt $i")
                         }
                     }
-                    // If still null, self-resolve the file ID. Prefer track-playback/v1/media (returns
-                    // real audio ids) and fall back to metadata/4/track for parity with older accounts.
+                    // Still null: self-resolve. Use the media endpoint only when the file id is
+                    // licensable for this account (see safeMediaFileId), else metadata/4/track.
                     if (fileId == null) {
-                        LokiLogger.i(TAG, "SpotifyCDN: No file ID from state machine, self-resolving via media endpoint...")
-                        fileId = resolver.fetchFileIdFromMedia(trackUri) ?: resolver.fetchFileIdFromMetadata(trackUri)
+                        LokiLogger.i(TAG, "SpotifyCDN: No file ID from state machine, self-resolving...")
+                        fileId = safeMediaFileId(trackUri) ?: resolver.fetchFileIdFromMetadata(trackUri)
                         if (fileId != null) {
                             LokiLogger.i(TAG, "SpotifyCDN: Got file ID from self-resolve: $fileId")
                             latestFileId = fileId

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/FreeTierFormatTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/FreeTierFormatTest.kt
@@ -1,0 +1,63 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.playback.engine.SpotifyCdnResolver
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A FREE account can only get a Widevine license for MP4_128 (format 10); the media endpoint often
+ * offers MP4_256 (format 11), which fails with ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED mid-track.
+ * safeMediaFileId must reject a premium-format media file id on a free account, but accept it on
+ * premium (or when it's already the free-safe format 10). Regression guard for the 2.7.0 media-fallback
+ * change that broke free-tier playback on some tracks.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class FreeTierFormatTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before fun setUp() { rig.install() }
+
+    @After fun tearDown() {
+        SessionHolder.cdnResolver = null
+        rig.uninstall()
+    }
+
+    @Test
+    fun freeAccount_rejectsPremiumFormatMediaFileId() = runBlocking {
+        val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
+        coEvery { resolver.resolveMediaEntry("spotify:track:x") } returns ("fileMP4_256" to "11")
+        SessionHolder.cdnResolver = resolver
+        rig.vm.setPremiumForTest(false)
+
+        assertNull("free account must not use an unlicensable MP4_256 file id", rig.vm.safeMediaFileId("spotify:track:x"))
+    }
+
+    @Test
+    fun freeAccount_acceptsFreeSafeMp4128() = runBlocking {
+        val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
+        coEvery { resolver.resolveMediaEntry("spotify:track:y") } returns ("fileMP4_128" to "10")
+        SessionHolder.cdnResolver = resolver
+        rig.vm.setPremiumForTest(false)
+
+        assertEquals("fileMP4_128", rig.vm.safeMediaFileId("spotify:track:y"))
+    }
+
+    @Test
+    fun premiumAccount_acceptsPremiumFormat() = runBlocking {
+        val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
+        coEvery { resolver.resolveMediaEntry("spotify:track:z") } returns ("fileMP4_256" to "11")
+        SessionHolder.cdnResolver = resolver
+        rig.vm.setPremiumForTest(true)
+
+        assertEquals("fileMP4_256", rig.vm.safeMediaFileId("spotify:track:z"))
+    }
+}

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackErrorRecoveryTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackErrorRecoveryTest.kt
@@ -38,7 +38,7 @@ class PlaybackErrorRecoveryTest {
     @Test
     fun transientError_reResolvesAndReloadsSameTrack_notSilent() = runBlocking {
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.fetchFileIdFromMedia("spotify:track:test") } returns "fileXYZ"
+        coEvery { resolver.resolveMediaEntry("spotify:track:test") } returns ("fileXYZ" to "10")
         coEvery { resolver.resolveForFileId(eq("fileXYZ"), any()) } returns SpotifyStream(
             cdnUrl = "https://cdn.example/audio",
             licenseUrl = "https://license.example",
@@ -67,7 +67,7 @@ class PlaybackErrorRecoveryTest {
         // each recovery reload (which used to reset the retry budget), so it stayed pinned to mirror #1
         // forever — never escalating or skipping. It must now walk mirror #1 -> #2 -> #3, then skip.
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.fetchFileIdFromMedia("spotify:track:test") } returns "fileXYZ"
+        coEvery { resolver.resolveMediaEntry("spotify:track:test") } returns ("fileXYZ" to "10")
         coEvery { resolver.resolveForFileId(eq("fileXYZ"), any()) } returns SpotifyStream(
             cdnUrl = "https://cdn.example/audio",
             licenseUrl = "https://license.example",
@@ -99,7 +99,7 @@ class PlaybackErrorRecoveryTest {
     fun repeatedFailures_skipToNextTrackInsteadOfSilence() = runBlocking {
         // Resolve never yields a usable file id, so every mirror/attempt fails.
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.fetchFileIdFromMedia(any()) } returns null
+        coEvery { resolver.resolveMediaEntry(any()) } returns null
         coEvery { resolver.fetchFileIdFromMetadata(any()) } returns null
         SessionHolder.cdnResolver = resolver
         val pc = mockk<PlayerConnect>(relaxed = true)


### PR DESCRIPTION
Since 2.7.0 the echo path self-resolves file ids via track-playback/v1/media, which returns MP4_256 (format 11); a free account can't get a Widevine license for MP4_256, so those tracks failed with ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED mid-track (confirmed on SM-S938B: clean on 2.5.0/2.6.1, failures start at 2.7.0). safeMediaFileId now only uses a media file id when the account is premium or it's the free-safe MP4_128, and the echo path waits longer for the connect-state's entitled file id first. Ships 2.9.8.

Closes #355