### PR TITLE
Pick the free-safe MP4_128 from the media manifest instead of deferring

### DIFF
--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -38,8 +38,8 @@ android {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 40
-        versionName = "2.9.8"
+        versionCode = 41
+        versionName = "2.9.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
@@ -81,13 +81,13 @@ class SpotifyCdnResolver(
         spotifyPlayback.resolveFileIdForUri(trackUri)
 
     /**
-     * Like [fetchFileIdFromMedia] but also returns the audio's numeric storage format (10=MP4_128,
-     * 11=MP4_256, 12/13=dual). Callers use the format to avoid handing a premium-quality file id to a
-     * free account's Widevine CDM, which returns ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED. Null if
-     * the URI has no resolvable audio manifest.
+     * All mp4 audio (file id, numeric format) entries the media endpoint offers for a track — usually
+     * both a premium MP4_256 (format 11) and a free-safe MP4_128 (format 10). Callers pick the quality
+     * the account can license: a free account can only get a Widevine license for MP4_128, so handing
+     * its CDM the 256 file id yields ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED. Empty if unresolvable.
      */
-    suspend fun resolveMediaEntry(trackUri: String): Pair<String, String>? =
-        spotifyPlayback.resolveAudioEntryForUri(trackUri)
+    suspend fun resolveMediaEntries(trackUri: String): List<Pair<String, String>> =
+        spotifyPlayback.resolveAudioEntriesForUri(trackUri)
 
     /**
      * Fetch the file id for a track via the metadata API, preferring the

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -2131,10 +2131,17 @@ class SpotifyViewModel : ViewModel() {
      * the media endpoint.
      */
     internal suspend fun safeMediaFileId(trackUri: String): String? {
-        val (fileId, format) = cdnResolver?.resolveMediaEntry(trackUri) ?: return null
-        if (_account.value.isPremium || format == "10") return fileId
-        LokiLogger.i(TAG, "Skipping media file id for $trackUri (format=$format not licensable on free tier)")
-        return null
+        val entries = cdnResolver?.resolveMediaEntries(trackUri).orEmpty()
+        if (entries.isEmpty()) return null
+        // Premium: take the highest quality the manifest offers (first entry). Free: the CDM can only
+        // license MP4_128, so pick the free-safe format-10 (or 12=128-dual) entry the manifest also
+        // carries; if it offers only premium formats, return null so we rely on the connect-state id.
+        if (_account.value.isPremium) return entries.first().first
+        val free = entries.firstOrNull { it.second == "10" || it.second == "12" }
+        if (free == null) {
+            LokiLogger.i(TAG, "No free-tier (MP4_128) media file id for $trackUri; deferring to connect-state")
+        }
+        return free?.first
     }
 
     /** Test seam: set the account's premium flag so [safeMediaFileId] can be exercised. */

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/FreeTierFormatTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/FreeTierFormatTest.kt
@@ -32,29 +32,33 @@ class FreeTierFormatTest {
     }
 
     @Test
-    fun freeAccount_rejectsPremiumFormatMediaFileId() = runBlocking {
+    fun freeAccount_picksMp4128WhenBothOffered() = runBlocking {
+        // The real regression case: the manifest offers BOTH 256 and 128 — a free account must pick
+        // the licensable 128, not the (default first) 256.
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.resolveMediaEntry("spotify:track:x") } returns ("fileMP4_256" to "11")
+        coEvery { resolver.resolveMediaEntries("spotify:track:x") } returns
+            listOf("fileMP4_256" to "11", "fileMP4_128" to "10", "fileDual256" to "13", "fileDual128" to "12")
         SessionHolder.cdnResolver = resolver
         rig.vm.setPremiumForTest(false)
 
-        assertNull("free account must not use an unlicensable MP4_256 file id", rig.vm.safeMediaFileId("spotify:track:x"))
+        assertEquals("fileMP4_128", rig.vm.safeMediaFileId("spotify:track:x"))
     }
 
     @Test
-    fun freeAccount_acceptsFreeSafeMp4128() = runBlocking {
+    fun freeAccount_returnsNullWhenOnlyPremiumOffered() = runBlocking {
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.resolveMediaEntry("spotify:track:y") } returns ("fileMP4_128" to "10")
+        coEvery { resolver.resolveMediaEntries("spotify:track:y") } returns listOf("fileMP4_256" to "11")
         SessionHolder.cdnResolver = resolver
         rig.vm.setPremiumForTest(false)
 
-        assertEquals("fileMP4_128", rig.vm.safeMediaFileId("spotify:track:y"))
+        assertNull("free account can't license MP4_256; must defer", rig.vm.safeMediaFileId("spotify:track:y"))
     }
 
     @Test
-    fun premiumAccount_acceptsPremiumFormat() = runBlocking {
+    fun premiumAccount_takesHighestQuality() = runBlocking {
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.resolveMediaEntry("spotify:track:z") } returns ("fileMP4_256" to "11")
+        coEvery { resolver.resolveMediaEntries("spotify:track:z") } returns
+            listOf("fileMP4_256" to "11", "fileMP4_128" to "10")
         SessionHolder.cdnResolver = resolver
         rig.vm.setPremiumForTest(true)
 

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackErrorRecoveryTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackErrorRecoveryTest.kt
@@ -38,7 +38,7 @@ class PlaybackErrorRecoveryTest {
     @Test
     fun transientError_reResolvesAndReloadsSameTrack_notSilent() = runBlocking {
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.resolveMediaEntry("spotify:track:test") } returns ("fileXYZ" to "10")
+        coEvery { resolver.resolveMediaEntries("spotify:track:test") } returns listOf("fileXYZ" to "10")
         coEvery { resolver.resolveForFileId(eq("fileXYZ"), any()) } returns SpotifyStream(
             cdnUrl = "https://cdn.example/audio",
             licenseUrl = "https://license.example",
@@ -67,7 +67,7 @@ class PlaybackErrorRecoveryTest {
         // each recovery reload (which used to reset the retry budget), so it stayed pinned to mirror #1
         // forever — never escalating or skipping. It must now walk mirror #1 -> #2 -> #3, then skip.
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.resolveMediaEntry("spotify:track:test") } returns ("fileXYZ" to "10")
+        coEvery { resolver.resolveMediaEntries("spotify:track:test") } returns listOf("fileXYZ" to "10")
         coEvery { resolver.resolveForFileId(eq("fileXYZ"), any()) } returns SpotifyStream(
             cdnUrl = "https://cdn.example/audio",
             licenseUrl = "https://license.example",
@@ -99,7 +99,7 @@ class PlaybackErrorRecoveryTest {
     fun repeatedFailures_skipToNextTrackInsteadOfSilence() = runBlocking {
         // Resolve never yields a usable file id, so every mirror/attempt fails.
         val resolver = mockk<SpotifyCdnResolver>(relaxed = true)
-        coEvery { resolver.resolveMediaEntry(any()) } returns null
+        coEvery { resolver.resolveMediaEntries(any()) } returns emptyList()
         coEvery { resolver.fetchFileIdFromMetadata(any()) } returns null
         SessionHolder.cdnResolver = resolver
         val pc = mockk<PlayerConnect>(relaxed = true)


### PR DESCRIPTION
The media manifest carries both MP4_256 (format 11) and MP4_128 (format 10); a free account now picks the licensable 128 directly (via KotifyClient's resolveAudioEntries) rather than rejecting the 256 and waiting for the connect-state file id. Premium still takes the highest quality. More reliable free-tier playback than 2.9.8. Ships 2.9.9.

Refs #355