### PR TITLE
Bypass the jukebox audio tap and its 63MB buffer when off

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/JukeboxAudioTap.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/JukeboxAudioTap.kt
@@ -54,10 +54,30 @@ class JukeboxAudioTap : BaseAudioProcessor() {
         return out
     }
 
+    /** Allocate the (up to ~63MB) capture buffer once the format is known. Cheap no-op if already sized. */
+    @Synchronized
+    private fun ensureBuffer() {
+        val needed = capturedRate * capturedChannels * 60 * MAX_MINUTES
+        if (pcm.size < needed && capturedRate > 0 && capturedChannels > 0) pcm = ShortArray(needed)
+    }
+
     @Synchronized
     fun resetCapture() {
+        ensureBuffer()
         len = 0
     }
+
+    /** Release the ~63MB capture buffer when analysis stops, instead of holding it for the sink lifetime. */
+    @Synchronized
+    fun releaseBuffer() {
+        pcm = ShortArray(0)
+        len = 0
+    }
+
+    // Only participate in the audio chain while analyzing: when the jukebox is off ExoPlayer bypasses
+    // this processor entirely, so there is no per-buffer queueInput copy. isActive is re-read on a
+    // pipeline flush — the enable path sets analyzing before seeking, so the seek's flush activates it.
+    override fun isActive(): Boolean = analyzing
 
     override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
         sampleRate = inputAudioFormat.sampleRate
@@ -65,8 +85,9 @@ class JukeboxAudioTap : BaseAudioProcessor() {
         pcm16 = inputAudioFormat.encoding == C.ENCODING_PCM_16BIT
         capturedRate = sampleRate
         capturedChannels = channels
-        val needed = sampleRate * channels * 60 * MAX_MINUTES
-        if (pcm.size < needed && sampleRate > 0 && channels > 0) pcm = ShortArray(needed)
+        // Allocate only if analysis is already running (e.g. capturing across a format change);
+        // otherwise stay unallocated until resetCapture() on the next enable.
+        if (analyzing) ensureBuffer()
         LokiLogger.i(TAG, "tap configured: ${sampleRate}Hz ch=$channels enc=${inputAudioFormat.encoding} pcm16=$pcm16")
         return inputAudioFormat
     }
@@ -88,12 +109,13 @@ class JukeboxAudioTap : BaseAudioProcessor() {
 
     @Synchronized
     private fun capture(buf: ByteBuffer) {
-        var i = len
-        val cap = pcm.size
-        while (buf.remaining() >= 2 && i < cap) {
-            pcm[i++] = buf.short
+        // Bulk copy instead of per-sample buf.short: asShortBuffer() inherits the duplicate's
+        // LITTLE_ENDIAN order; count is clamped to the remaining capacity to keep the overflow guard.
+        val count = minOf(buf.remaining() / 2, pcm.size - len)
+        if (count > 0) {
+            buf.asShortBuffer().get(pcm, len, count)
+            len += count
         }
-        len = i
     }
 
     private companion object {

--- a/src/app/src/main/java/ch/snepilatch/app/playback/JukeboxController.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/JukeboxController.kt
@@ -132,8 +132,10 @@ class JukeboxController(
             engine?.setPaused(p)
         }
         svc.setJukeboxRemixing(true) // hide the notification seekbar for the whole session (no auto-advance)
-        svc.jukeboxSeekToStart()
+        // Enable analysis BEFORE seeking: the tap's isActive() is re-read on the seek's pipeline flush,
+        // so analyzing must already be true for the flush to add the tap back into the audio chain.
         svc.setJukeboxAnalyzing(true)
+        svc.jukeboxSeekToStart()
         LokiLogger.i(TAG, "capture pass started for $trackId")
 
         val rate = awaitRate(svc) ?: run {

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -601,10 +601,15 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         }
     }
 
-    /** Turn the decoded-PCM waveform capture on/off; resets the buffer when turning on. */
+    /** Turn the decoded-PCM waveform capture on/off; allocates the buffer on, frees the ~63MB on off. */
     fun setJukeboxAnalyzing(enabled: Boolean) {
-        if (enabled) jukeboxTap.resetCapture()
-        jukeboxTap.analyzing = enabled
+        if (enabled) {
+            jukeboxTap.resetCapture()
+            jukeboxTap.analyzing = true
+        } else {
+            jukeboxTap.analyzing = false
+            jukeboxTap.releaseBuffer()
+        }
     }
 
     fun jukeboxSampleRate(): Int = jukeboxTap.sampleRate()


### PR DESCRIPTION
The jukebox audio tap was always active: it ran queueInput and copied every decoded PCM buffer through even with the feature off, and held a ~63MB capture buffer for the whole sink lifetime. isActive() now returns analyzing (ExoPlayer bypasses the processor when off), the buffer is allocated lazily on enable and freed on disable, and capture uses a bulk asShortBuffer().get(). The enable path sets analyzing before seeking so the seek's pipeline flush re-activates the tap. Verified on-device: enabling Eternal Jukebox still captures and builds the waveform correctly, and disabling returns cleanly with no crash.

Closes #386
