### PR TITLE
Cut jukebox preview reanalysis cadence and hoist the Hann window

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/JukeboxController.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/JukeboxController.kt
@@ -48,7 +48,11 @@ class JukeboxController(
         const val VIZ_BUCKETS = 56 // number of pillars in the remix map
         const val VIZ_TICK_MS = 120L // how often the remix map refreshes
         const val PREVIEW_START_S = 10 // run the first similarity search ~10s in (populates the remix map)
-        const val PREVIEW_EVERY_S = 5 // refresh the preview similarities every +5s until the centre handoff
+
+        // Refresh cadence for the preview similarities until the centre handoff. Was 5s, but each refresh
+        // is a whole-buffer FFT + O(n^2) pass feeding only the cosmetic 56-bar histogram, so ~18s cuts the
+        // reanalysis count ~4x with no correctness/handoff impact.
+        const val PREVIEW_EVERY_S = 18
         const val HANDOFF_OVERLAP_MS = 180L // overlap engine + ExoPlayer briefly so the takeover has no gap
         const val LOOP_MARGIN_MS = 3000L // seek the muted keep-alive player back this far before the end
     }

--- a/src/app/src/main/java/ch/snepilatch/app/playback/WaveformAnalyzer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/WaveformAnalyzer.kt
@@ -35,6 +35,10 @@ object WaveformAnalyzer {
     private const val TIMBRE_BANDS = 8
     private const val SILENCE_GATE = 0.05 // frames below 5% of peak energy can't be jump points
 
+    // The Hann window is immutable and FFT_SIZE-sized; compute it once instead of rebuilding it on
+    // every analyze() call (which runs repeatedly over the capture half during a jukebox session).
+    private val WINDOW = DoubleArray(FFT_SIZE) { 0.5 - 0.5 * cos(2.0 * Math.PI * it / (FFT_SIZE - 1)) }
+
     /**
      * Analyse [mono] PCM at [sampleRate]. [minGapMs] keeps jumps from being trivially close; [maxDistance]
      * is the similarity cutoff (z-scored feature distance); [maxParallels] caps the returned list.
@@ -52,7 +56,7 @@ object WaveformAnalyzer {
         val dim = CHROMA_BINS + TIMBRE_BANDS
         val feats = Array(nFrames) { DoubleArray(dim) }
         val energy = DoubleArray(nFrames)
-        val window = hann(FFT_SIZE)
+        val window = WINDOW
         val re = DoubleArray(FFT_SIZE)
         val im = DoubleArray(FFT_SIZE)
         val mag = DoubleArray(FFT_SIZE / 2)
@@ -168,8 +172,6 @@ object WaveformAnalyzer {
         }
         return sqrt(s)
     }
-
-    private fun hann(n: Int): DoubleArray = DoubleArray(n) { 0.5 - 0.5 * cos(2.0 * Math.PI * it / (n - 1)) }
 
     /** In-place iterative radix-2 FFT ([re]/[im] length must be a power of two). */
     private fun fft(re: DoubleArray, im: DoubleArray) {


### PR DESCRIPTION
The jukebox preview similarities were recomputed every 5s (~19 whole-buffer FFT + O(n^2) passes over the capture half) just to feed the cosmetic 56-bar histogram; raises PREVIEW_EVERY_S to 18s (~4x fewer passes, no correctness or handoff impact). WaveformAnalyzer also rebuilt its immutable Hann window on every analyze() call — hoisted to a computed-once WINDOW (identical values). Handoff and growth reanalysis paths are unchanged.

Closes #388
