### PR TITLE
Drop !! in formatReleaseDate via takeIf range fold

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
@@ -38,19 +38,19 @@ private fun formatReleaseDate(raw: String): String {
     return when (parts.size) {
         3 -> {
             val year = parts[0].toIntOrNull()
-            val month = parts[1].toIntOrNull()
+            val month = parts[1].toIntOrNull()?.takeIf { it in 1..12 }
             val day = parts[2].toIntOrNull()
-            if (year != null && month in 1..12 && day != null) {
-                "${MONTHS[month!! - 1]} $day, $year"
+            if (year != null && month != null && day != null) {
+                "${MONTHS[month - 1]} $day, $year"
             } else {
                 raw
             }
         }
         2 -> {
             val year = parts[0].toIntOrNull()
-            val month = parts[1].toIntOrNull()
-            if (year != null && month in 1..12) {
-                "${MONTHS[month!! - 1]} $year"
+            val month = parts[1].toIntOrNull()?.takeIf { it in 1..12 }
+            if (year != null && month != null) {
+                "${MONTHS[month - 1]} $year"
             } else {
                 raw
             }


### PR DESCRIPTION
month relied on `!!` because Kotlin can't smart-cast through `in`. Folds the 1..12 range check into the value with takeIf so month is non-null only when valid; both branches drop the range check and the `!!`. Byte-identical output. Closes #394