### PR TITLE
Single shared shimmer transition read in the draw phase

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -4,10 +4,6 @@ package ch.snepilatch.app.ui.components
 
 import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyWhite
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -55,6 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -93,25 +90,27 @@ fun SheetNavBarFix() {
 
 // --- Shimmer effect ---
 
+/**
+ * A shimmer placeholder driven by a shared [phase] transition (see HomeShimmer). Reading phase.value
+ * inside onDrawBehind registers a DRAW-phase snapshot read, so animation frames invalidate only the
+ * draw, not composition — the box never recomposes as the sweep animates.
+ */
 @Composable
-fun shimmerBrush(): Brush {
-    val transition = rememberInfiniteTransition(label = "shimmer")
-    val translateAnim by transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 1000f,
-        animationSpec = infiniteRepeatable(tween(1200, easing = LinearEasing)),
-        label = "shimmer"
+fun ShimmerBox(phase: State<Float>, modifier: Modifier) {
+    Box(
+        modifier.drawWithCache {
+            onDrawBehind {
+                val x = phase.value
+                drawRect(
+                    Brush.linearGradient(
+                        colors = listOf(SpotifyGray, SpotifyElevated, SpotifyGray),
+                        start = Offset(x - 500f, 0f),
+                        end = Offset(x, 0f)
+                    )
+                )
+            }
+        }
     )
-    return Brush.linearGradient(
-        colors = listOf(SpotifyGray, SpotifyElevated, SpotifyGray),
-        start = Offset(translateAnim - 500f, 0f),
-        end = Offset(translateAnim, 0f)
-    )
-}
-
-@Composable
-fun ShimmerBox(modifier: Modifier) {
-    Box(modifier.background(shimmerBrush()))
 }
 
 // --- Image with placeholder ---

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -3,6 +3,11 @@ package ch.snepilatch.app.ui.screens
 import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyWhite
 import androidx.compose.foundation.clickable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -162,17 +167,27 @@ fun QuickPickGrid(items: List<kotify.api.home.HomeSectionItem>, vm: SpotifyViewM
 
 @Composable
 fun HomeShimmer() {
+    // One shared transition drives every placeholder; ShimmerBox reads phase in the draw phase, so the
+    // sweep animates without recomposing any box. Keep `phase` as State<Float> (no `by`, never read
+    // .value here) so this composable is not invalidated each frame.
+    val phase = rememberInfiniteTransition(label = "shimmer").animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(tween(1200, easing = LinearEasing)),
+        label = "shimmer"
+    )
     Column(
         Modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
-        ShimmerBox(Modifier.width(180.dp).height(28.dp).clip(RoundedCornerShape(4.dp)))
+        ShimmerBox(phase, Modifier.width(180.dp).height(28.dp).clip(RoundedCornerShape(4.dp)))
         Spacer(Modifier.height(16.dp))
         repeat(3) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 repeat(2) {
                     ShimmerBox(
+                        phase,
                         Modifier
                             .weight(1f)
                             .height(56.dp)
@@ -183,14 +198,14 @@ fun HomeShimmer() {
             Spacer(Modifier.height(8.dp))
         }
         Spacer(Modifier.height(24.dp))
-        ShimmerBox(Modifier.width(150.dp).height(22.dp).clip(RoundedCornerShape(4.dp)))
+        ShimmerBox(phase, Modifier.width(150.dp).height(22.dp).clip(RoundedCornerShape(4.dp)))
         Spacer(Modifier.height(12.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             repeat(3) {
                 Column {
-                    ShimmerBox(Modifier.size(140.dp).clip(RoundedCornerShape(8.dp)))
+                    ShimmerBox(phase, Modifier.size(140.dp).clip(RoundedCornerShape(8.dp)))
                     Spacer(Modifier.height(8.dp))
-                    ShimmerBox(Modifier.width(100.dp).height(14.dp).clip(RoundedCornerShape(4.dp)))
+                    ShimmerBox(phase, Modifier.width(100.dp).height(14.dp).clip(RoundedCornerShape(4.dp)))
                 }
             }
         }


### PR DESCRIPTION
HomeShimmer built one infinite transition per ShimmerBox and read the phase during composition (every box recomposed each frame while loading). Drives all boxes from one shared State<Float> transition and reads phase.value inside drawWithCache/onDrawBehind so frames invalidate only draw. Deletes the unused shimmerBrush. Visual output identical (each box sweeps in its own 0..1000px space as before). Closes #410