### PR TITLE
Replace cold-start magic delays with a serviceReady flow

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
@@ -31,6 +31,7 @@ import ch.snepilatch.app.util.loadCookies
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -121,23 +122,19 @@ class MainActivity : ComponentActivity() {
             }
 
             // Wire service controls once initialized and service is ready
+            // Wait for the service to actually be up (instance published) rather than guessing with a
+            // fixed delay, then wire controls and — for a headphone cold-launch started by the
+            // MediaButtonReceiver with an autoplay extra — start playback. Kept as ONE effect so wiring
+            // is guaranteed to finish before autoplay reaches the cold-start onReady handoff.
             LaunchedEffect(initialized) {
                 if (initialized) {
-                    kotlinx.coroutines.delay(500)
+                    MusicPlaybackService.serviceReady.first { it }
                     vm.wireServiceControls()
-                }
-            }
-
-            // Headphone cold-launch: if MainActivity was started by the
-            // MediaButtonReceiver with an autoplay extra, fire togglePlayPause
-            // as soon as init finishes so the user hears music without having
-            // to tap the play button.
-            LaunchedEffect(initialized) {
-                if (initialized && intent.getBooleanExtra(MediaButtonReceiver.EXTRA_AUTO_PLAY, false)) {
-                    intent.removeExtra(MediaButtonReceiver.EXTRA_AUTO_PLAY)
-                    kotlinx.coroutines.delay(600) // let wireServiceControls finish
-                    if (!vm.playback.value.isPlaying) {
-                        vm.togglePlayPause()
+                    if (intent.getBooleanExtra(MediaButtonReceiver.EXTRA_AUTO_PLAY, false)) {
+                        intent.removeExtra(MediaButtonReceiver.EXTRA_AUTO_PLAY)
+                        if (!vm.playback.value.isPlaying) {
+                            vm.togglePlayPause()
+                        }
                     }
                 }
             }

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -41,6 +41,7 @@ import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
@@ -58,6 +59,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         private const val ALERT_NOTIFICATION_ID = 2
         var instance: MusicPlaybackService? = null
             private set
+
+        // True once onCreate has published `instance` (and false after teardown). Lets the Activity
+        // await genuine service readiness instead of guessing with a fixed delay before wiring controls.
+        val serviceReady: MutableStateFlow<Boolean> = MutableStateFlow(false)
     }
 
     private var mediaSession: MediaSessionCompat? = null
@@ -410,6 +415,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         sessionToken = mediaSession!!.sessionToken
 
         instance = this
+        serviceReady.value = true
 
         // Start foreground immediately with a placeholder notification
         startForeground(NOTIFICATION_ID, buildNotification())
@@ -1188,6 +1194,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         // other reasons (e.g. low memory) we want the session to stay live
         // so the next launch can resume.
         instance = null
+        serviceReady.value = false
         super.onDestroy()
     }
 }


### PR DESCRIPTION
Adds MusicPlaybackService.serviceReady (true once instance is published) and merges MainActivity's two delay-based effects into one that awaits it, wires controls, then autoplays — guaranteeing wire-before-autoplay and removing delay(500)/delay(600). Device-verified: cold launch (force-stop + relaunch) initializes, wires controls (play works), and correctly does not autoplay without the extra. Closes #434