### PR TITLE
Don't double-fetch lyrics from openLyrics

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -1838,8 +1838,8 @@ class SpotifyViewModel : ViewModel() {
     }
 
     fun openLyrics() {
+        // The lyrics screen fetches on its own via LaunchedEffect(track?.uri); don't double-fetch here.
         navigateTo(Screen.LYRICS)
-        fetchLyrics()
     }
 
     fun fetchLyrics() {


### PR DESCRIPTION
openLyrics navigated AND called fetchLyrics, but LyricsScreen already fetches via LaunchedEffect(track?.uri) — a redundant fetch on every open. Drops it from openLyrics; the screen owns the fetch. Device-verified: opening lyrics still fetches (shows No lyrics available for an instrumental). Closes #436