### PR TITLE
refactor: extract LyricsViewModel from SpfyViewModel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,17 @@ The pre-resolved cache (`nextCdnUrl` + `nextCdnFileId` from `onNextPlaybackId`) 
 
 ## ViewModel split strategy
 
-`SpotifyViewModel` is large. The plan is to extract feature-scoped ViewModels incrementally: Search → Library → Account → Lyrics → Detail. Each extraction lands with its own tests.
+`SpotifyViewModel` is large (~3.1k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`.** Each lands with its own tests.
 
-Pattern:
-1. Move the feature's state and methods into a new `<Feature>ViewModel` class.
-2. The new ViewModel reads `Session` from `SessionHolder` and uses the same `launchWithSession` shape (or its own equivalent).
-3. The screen calls `viewModel<<Feature>ViewModel>()` instead of pulling the field off `SpotifyViewModel`.
-4. Cross-feature triggers (e.g. "library refresh after createPlaylist") go through a shared event bus or are inlined in the caller.
+Pattern (proven by `SearchViewModel`/`LyricsViewModel`):
+1. Move the feature's state + methods into a new `<Feature>ViewModel : ViewModel()`.
+2. It reads `Session` from `SessionHolder` and rolls its own small `launchWith…` helper (the ones on `SpotifyViewModel` are private; copy the shape).
+3. A screen can hold **both** ViewModels at once — obtain the feature VM in the body with `val featureVm: <Feature>ViewModel = viewModel()`. `LyricsScreen` reads playback/transport/theme from `SpotifyViewModel` and lyrics content from `LyricsViewModel` side by side. The feature VM doesn't need to own the whole screen.
+4. Pass the inputs the feature needs down from the screen (e.g. `lyricsVm.fetch(track.uri)`), rather than having the feature VM reach back into `SpotifyViewModel` state.
+
+**What makes a feature safe to extract now vs. what's blocked:**
+- Clean today = the feature only *reads* the session and *writes its own* state, and does **not** trigger navigation or a cross-feature refresh from inside its own logic. `Lyrics` qualified (it never navigates — `SpotifyViewModel.openLyrics` does that; it has no cross-writes).
+- **Blocked until there's a shared navigation channel:** `Library`, `Detail`, `Account`, `Devices`. Their screens call `openPlaylist`/`openAlbum`/`openArtist`, which go through `navigateTo` + the back stack — both owned by `SpotifyViewModel`. Extracting them today just re-couples the new VM back to `SpotifyViewModel` for navigation, which defeats the point. **Do that navigation channel first** (a process-scoped `Navigator` / shared `SharedFlow<Screen>` that `SpotifyViewModel` observes), then extract these. Same goes for cross-feature triggers like "refresh library after `createPlaylist`" — route them through that channel or inline them in the caller.
 
 Don't try to extract playback. The handler-extraction + test rig pattern (see `RemotePlayPauseHandlerTest`) is the safer route for that area.
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
@@ -38,10 +38,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.AsyncImage
 import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.*
+import ch.snepilatch.app.viewmodel.LyricsViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -50,6 +52,7 @@ import kotify.api.lyrics.SyncedLine
 
 @Composable
 fun LyricsScreen(vm: SpotifyViewModel) {
+    val lyricsVm: LyricsViewModel = viewModel()
     // Narrow projections — the lyrics scaffold must not recompose on the 2Hz position tick; position
     // is consumed only through the smoothPosition state below (mutated off the flow, not read here).
     val track by vm.currentTrack.collectAsState()
@@ -57,13 +60,13 @@ fun LyricsScreen(vm: SpotifyViewModel) {
     val isPaused by vm.isPausedFlow.collectAsState()
     val repeatMode by vm.repeatModeFlow.collectAsState()
     val theme by vm.themeColors.collectAsState()
-    val lyrics by vm.lyrics.collectAsState()
-    val isLoading by vm.isLyricsLoading.collectAsState()
+    val lyrics by lyricsVm.lyrics.collectAsState()
+    val isLoading by lyricsVm.isLoading.collectAsState()
     val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "lyricsPrimary")
     val lyricsAnimDirection by vm.lyricsAnimDirection.collectAsState()
 
     LaunchedEffect(track?.uri) {
-        if (track != null) vm.fetchLyrics()
+        track?.uri?.let { lyricsVm.fetch(it) }
     }
 
     // Smooth position interpolation:

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/LyricsViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/LyricsViewModel.kt
@@ -1,0 +1,72 @@
+package ch.snepilatch.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.util.LokiLogger
+import kotify.api.lyrics.Lyrics
+import kotify.api.lyrics.LyricsData
+import kotify.session.Session
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the lyrics overlay's content.
+ *
+ * Owns only the lyrics *data* concern (fetch + result + loading flag). The
+ * [ch.snepilatch.app.ui.screens.LyricsScreen] still reads playback state,
+ * transport controls and theme from [SpotifyViewModel]; the two ViewModels
+ * sit side by side on the screen. Navigation to the overlay stays on
+ * [SpotifyViewModel.openLyrics] — this class never navigates.
+ */
+class LyricsViewModel : ViewModel() {
+
+    private val tag = "LyricsVM"
+
+    private val _lyrics = MutableStateFlow<LyricsData?>(null)
+    val lyrics: StateFlow<LyricsData?> = _lyrics
+    val isLoading = MutableStateFlow(false)
+
+    /** The track whose lyrics we last fetched, so re-entering the screen is a no-op. */
+    private var lastTrackUri: String? = null
+
+    /**
+     * Fetch lyrics for [trackUri] (a `spotify:track:<id>` URI). De-duplicated:
+     * a repeat call for the same track that already has lyrics does nothing.
+     */
+    fun fetch(trackUri: String) {
+        if (trackUri == lastTrackUri && _lyrics.value != null) return
+        lastTrackUri = trackUri
+        launchLoading { sess ->
+            try {
+                val trackId = trackUri.removePrefix("spotify:track:")
+                _lyrics.value = Lyrics(sess).getLyrics(trackId)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Clear stale lyrics on failure, then rethrow so the helper logs it.
+                _lyrics.value = null
+                throw e
+            }
+        }
+    }
+
+    private fun launchLoading(block: suspend (Session) -> Unit): Job =
+        viewModelScope.launch(Dispatchers.IO) {
+            val sess = SessionHolder.session ?: return@launch
+            isLoading.value = true
+            try {
+                block(sess)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LokiLogger.e(tag, "fetch", e)
+            } finally {
+                isLoading.value = false
+            }
+        }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -26,8 +26,6 @@ import kotify.api.podcast.Podcast
 import kotify.api.playerstatus.DeviceInfo
 import kotify.api.playerstatus.PlayerStateData
 import kotify.api.playerstatus.PlayerTrack
-import kotify.api.lyrics.Lyrics
-import kotify.api.lyrics.LyricsData
 import kotify.api.song.Song
 import kotify.api.user.User
 import kotify.api.canvas.Canvas
@@ -319,11 +317,7 @@ class SpotifyViewModel : ViewModel() {
     val canvasUrl = MutableStateFlow<String?>(null)
     private var lastCanvasTrackUri: String? = null
 
-    // Lyrics
-    private val _lyrics = MutableStateFlow<LyricsData?>(null)
-    val lyrics: StateFlow<LyricsData?> = _lyrics
-    val isLyricsLoading = MutableStateFlow(false)
-    private var lastLyricsTrackUri: String? = null
+    // Lyrics content moved to LyricsViewModel; this VM only navigates to the overlay (openLyrics).
 
 
     // Single-flight guard for onAuthLost recovery so a run of anonymous-token blips can't spawn
@@ -1838,26 +1832,8 @@ class SpotifyViewModel : ViewModel() {
     }
 
     fun openLyrics() {
-        // The lyrics screen fetches on its own via LaunchedEffect(track?.uri); don't double-fetch here.
+        // The lyrics screen (via LyricsViewModel) fetches on its own from LaunchedEffect(track?.uri).
         navigateTo(Screen.LYRICS)
-    }
-
-    fun fetchLyrics() {
-        val trackUri = _playback.value.track?.uri ?: return
-        if (trackUri == lastLyricsTrackUri && _lyrics.value != null) return
-        lastLyricsTrackUri = trackUri
-        launchWithSessionLoading("fetchLyrics", isLyricsLoading) { sess ->
-            try {
-                val trackId = trackUri.removePrefix("spotify:track:")
-                _lyrics.value = Lyrics(sess).getLyrics(trackId)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // Clear stale lyrics on failure, then rethrow so the helper logs it.
-                _lyrics.value = null
-                throw e
-            }
-        }
     }
 
     fun refreshQueue() {

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/LyricsViewModelTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/LyricsViewModelTest.kt
@@ -1,0 +1,56 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.playback.SessionHolder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [LyricsViewModel]. Like [SearchViewModelTest], this doesn't mock
+ * the network: with no [SessionHolder.session] the fetch short-circuits, which
+ * is exactly the local-state contract we want to pin — a fetch never leaves
+ * the loading flag stuck on and never populates lyrics without a session.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LyricsViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var vm: LyricsViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        SessionHolder.session = null
+        vm = LyricsViewModel()
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test fun startsClean() {
+        assertNull(vm.lyrics.value)
+        assertFalse(vm.isLoading.value)
+    }
+
+    @Test fun fetchWithoutSessionIsSafeNoOp() {
+        vm.fetch("spotify:track:abc123")
+        // No session → the launch returns before touching the loading flag or lyrics.
+        assertNull(vm.lyrics.value)
+        assertFalse(vm.isLoading.value)
+    }
+
+    @Test fun repeatedFetchWithoutSessionStaysClean() {
+        vm.fetch("spotify:track:abc123")
+        vm.fetch("spotify:track:abc123")
+        vm.fetch("spotify:track:def456")
+        assertNull(vm.lyrics.value)
+        assertFalse(vm.isLoading.value)
+    }
+}


### PR DESCRIPTION
Continues the incremental ViewModel split (after `SearchViewModel`).

## What
- New `LyricsViewModel` owns the lyrics-content concern: `lyrics`, `isLoading`, `fetch(trackUri)` and the same-track dedup guard. Reads `Session` from `SessionHolder`, rolls its own `launchLoading` helper (mirrors `SearchViewModel`).
- `LyricsScreen` obtains it via `viewModel()` and keeps reading playback/transport/theme from `SpfyViewModel` — the two VMs sit side by side.
- `SpfyViewModel`: removed `_lyrics`/`lyrics`/`isLyricsLoading`/`lastLyricsTrackUri`/`fetchLyrics()` and the now-unused `kotify.api.lyrics.*` imports. `openLyrics()` (navigation) stays.
- `LyricsViewModelTest` added (no-session state contract, matching `SearchViewModelTest`).
- CLAUDE.md split-strategy updated with the verified finding: the remaining features (Library/Detail/Account/Devices) are blocked on a shared navigation channel and must not be extracted before it exists.

## Why
Chips away at the 3.1k-line god object along the one seam that needs no cross-VM channel (lyrics never navigates and has no cross-writes).

## Verified
- Gate green: `:app:assembleProdDebug :app:testProdDebugUnitTest detekt`.
- Compose compiler report: all touched composables remain `restartable skippable` (74/74 app-wide).
- On device (Samsung, prod-debug): instrumental → 'No lyrics available'; NMIXX 'Passionfruit' → full syllable-synced karaoke render + auto-scroll. Behavior-preserving.

Closes #438