### PR TITLE
refactor: introduce Navigator as a shared navigation channel

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/Navigator.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/Navigator.kt
@@ -1,0 +1,57 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.data.Screen
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Single source of truth for which [Screen] is showing, plus the back stack.
+ *
+ * Process-scoped (like [ch.snepilatch.app.playback.SessionHolder]) so feature
+ * ViewModels can drive navigation without routing through [SpotifyViewModel].
+ * [SpotifyViewModel] delegates its nav methods here and calls [reset] on
+ * construction — a freshly constructed ViewModel means a fresh app entry
+ * (Activity finished + recreated, or cold process), which mirrors the old
+ * behaviour where `currentScreen` lived on the ViewModel and reset to HOME.
+ * Config changes retain the ViewModel, so navigation survives rotation.
+ */
+object Navigator {
+
+    private val _currentScreen = MutableStateFlow(Screen.HOME)
+    val currentScreen: StateFlow<Screen> = _currentScreen
+
+    private var screenStack = mutableListOf<Screen>()
+
+    /** The player and lyrics are overlays, not pages — they never sit on the back stack. */
+    private fun isOverlay(s: Screen) = s == Screen.NOW_PLAYING || s == Screen.LYRICS
+
+    fun navigateTo(screen: Screen) {
+        val current = _currentScreen.value
+        if (screen == current) return
+        // Don't record an overlay we're leaving for a real page, else back re-opens the
+        // player instead of returning to the page beneath it.
+        if (!isOverlay(current) || isOverlay(screen)) screenStack.add(current)
+        _currentScreen.value = screen
+    }
+
+    /** Tabs are roots: switching resets the stack so back returns to Home, not a stale page. */
+    fun navigateToTab(screen: Screen) {
+        screenStack.clear()
+        if (screen != Screen.HOME) screenStack.add(Screen.HOME)
+        _currentScreen.value = screen
+    }
+
+    fun goBack(): Boolean {
+        if (screenStack.isNotEmpty()) {
+            _currentScreen.value = screenStack.removeAt(screenStack.lastIndex)
+            return true
+        }
+        return false
+    }
+
+    /** Return to the HOME root with an empty stack — called when a fresh ViewModel is created. */
+    fun reset() {
+        screenStack.clear()
+        _currentScreen.value = Screen.HOME
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -55,9 +55,11 @@ class SpotifyViewModel : ViewModel() {
 
     private val TAG = "SpotifyVM"
 
-    // Navigation
-    val currentScreen = MutableStateFlow(Screen.HOME)
-    private var screenStack = mutableListOf<Screen>()
+    // Navigation lives in the process-scoped Navigator; the ViewModel delegates (see navigateTo/goBack
+    // below). Reset on construction so a fresh ViewModel (cold process / recreated Activity) starts at
+    // HOME — config changes retain the ViewModel, so rotation keeps the current screen.
+    init { Navigator.reset() }
+    val currentScreen: StateFlow<Screen> get() = Navigator.currentScreen
     val needsLogin = MutableStateFlow(false)
 
     // Session state — ownership lives in SessionHolder (process-scoped).
@@ -832,32 +834,11 @@ class SpotifyViewModel : ViewModel() {
         needsLogin.value = true
     }
 
-    /** The player and lyrics are overlays, not pages — they never sit on the back stack. */
-    private fun isOverlay(s: Screen) = s == Screen.NOW_PLAYING || s == Screen.LYRICS
+    fun navigateTo(screen: Screen) = Navigator.navigateTo(screen)
 
-    fun navigateTo(screen: Screen) {
-        val current = currentScreen.value
-        if (screen == current) return
-        // Don't record an overlay we're leaving for a real page, else back re-opens the
-        // player instead of returning to the page beneath it.
-        if (!isOverlay(current) || isOverlay(screen)) screenStack.add(current)
-        currentScreen.value = screen
-    }
+    fun navigateToTab(screen: Screen) = Navigator.navigateToTab(screen)
 
-    /** Tabs are roots: switching resets the stack so back returns to Home, not a stale page. */
-    fun navigateToTab(screen: Screen) {
-        screenStack.clear()
-        if (screen != Screen.HOME) screenStack.add(Screen.HOME)
-        currentScreen.value = screen
-    }
-
-    fun goBack(): Boolean {
-        if (screenStack.isNotEmpty()) {
-            currentScreen.value = screenStack.removeAt(screenStack.lastIndex)
-            return true
-        }
-        return false
-    }
+    fun goBack(): Boolean = Navigator.goBack()
 
     /**
      * Handle a deep link URI from open.spotify.com.


### PR DESCRIPTION
Prerequisite for extracting the remaining feature ViewModels (Detail next).

## What
- New process-scoped `Navigator` object (mirrors `SessionHolder`) owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack` (and the `isOverlay` back-stack rule).
- `SpfyViewModel` now delegates those methods to `Navigator` and `reset()`s it on construction — so 'fresh ViewModel == fresh nav' (and unit-test isolation) is preserved, while config-change ViewModel retention keeps the screen across rotation.

## Why
Feature ViewModels can now drive navigation without a reference to `SpfyViewModel`. This unblocks the Detail/Library/Account/Devices extractions the CLAUDE.md split-strategy flagged as blocked.

## Verified
- Pure indirection: no screen call site changed; `NavigationStackTest` passes unchanged.
- Gate green: `assembleProdDebug testProdDebugUnitTest detekt`.
- On device (Samsung, prod-debug): tab→home, open playlist detail, back→home, open player overlay, back→collapses to content beneath. All correct.

Closes #440