### PR TITLE
refactor: extract DetailViewModel (consumes Navigator)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,9 @@ The pre-resolved cache (`nextCdnUrl` + `nextCdnFileId` from `onNextPlaybackId`) 
 
 ## ViewModel split strategy
 
-`SpotifyViewModel` is large (~3.1k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`.** Each lands with its own tests.
+`SpotifyViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`** (the last built on the shared `Navigator`). Each lands with its own tests.
+
+**Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `SpotifyViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly — that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `SpotifyViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
 
 Pattern (proven by `SearchViewModel`/`LyricsViewModel`):
 1. Move the feature's state + methods into a new `<Feature>ViewModel : ViewModel()`.
@@ -67,8 +69,8 @@ Pattern (proven by `SearchViewModel`/`LyricsViewModel`):
 4. Pass the inputs the feature needs down from the screen (e.g. `lyricsVm.fetch(track.uri)`), rather than having the feature VM reach back into `SpotifyViewModel` state.
 
 **What makes a feature safe to extract now vs. what's blocked:**
-- Clean today = the feature only *reads* the session and *writes its own* state, and does **not** trigger navigation or a cross-feature refresh from inside its own logic. `Lyrics` qualified (it never navigates — `SpotifyViewModel.openLyrics` does that; it has no cross-writes).
-- **Blocked until there's a shared navigation channel:** `Library`, `Detail`, `Account`, `Devices`. Their screens call `openPlaylist`/`openAlbum`/`openArtist`, which go through `navigateTo` + the back stack — both owned by `SpotifyViewModel`. Extracting them today just re-couples the new VM back to `SpotifyViewModel` for navigation, which defeats the point. **Do that navigation channel first** (a process-scoped `Navigator` / shared `SharedFlow<Screen>` that `SpotifyViewModel` observes), then extract these. Same goes for cross-feature triggers like "refresh library after `createPlaylist`" — route them through that channel or inline them in the caller.
+- Clean = the feature reads the session, writes its own state, and navigates through `Navigator`. `Lyrics` needed no navigation at all; `Detail` navigates via `Navigator` and exposes `DetailRoutes` for the `SpotifyViewModel`/non-composable callers.
+- **Still on `SpotifyViewModel`:** `Library`, `Account`, `Devices`. These are now unblocked (Navigator exists) — follow the `DetailViewModel` PR as the template. Watch for cross-feature triggers (e.g. "refresh library after `createPlaylist`"): route them through a small router object like `DetailRoutes`, or inline them in the caller. `removeFromLibrary` stayed on `SpotifyViewModel` with the other library-mutation actions.
 
 Don't try to extract playback. The handler-extraction + test rig pattern (see `RemotePlayPauseHandlerTest`) is the safer route for that area.
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -67,6 +67,8 @@ import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.util.formatTime
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import coil.compose.AsyncImage
 
@@ -188,6 +190,7 @@ fun rememberSmoothPositionMs(positionMs: Long, durationMs: Long, isPlaying: Bool
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null, trackIndex: Int? = null) {
+    val detailVm: DetailViewModel = viewModel()
     var showMenu by remember { mutableStateOf(false) }
     val context = androidx.compose.ui.platform.LocalContext.current
     // Subscribe only to the two projections that affect a row (which track is current +
@@ -280,10 +283,10 @@ fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null,
                     vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
                 },
                 Triple(Icons.Rounded.Album, visitAlbumLabel) {
-                    showMenu = false; vm.openAlbumForTrack(track.uri)
+                    showMenu = false; detailVm.openAlbumForTrack(track.uri)
                 },
                 Triple(Icons.Rounded.Person, visitArtistLabel) {
-                    showMenu = false; vm.openArtistForTrack(track.uri)
+                    showMenu = false; detailVm.openArtistForTrack(track.uri)
                 },
                 Triple(Icons.Rounded.Share, shareLabel) {
                     showMenu = false

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -42,13 +42,17 @@ import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.components.TrackRow
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.stripHtml
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.snepilatch.app.viewmodel.DetailRoutes
+import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 @Composable
 fun DetailScreen(vm: SpotifyViewModel) {
-    val detail by vm.detail.collectAsState()
-    val isLoading by vm.isLoading.collectAsState()
-    val isLoadingMore by vm.isLoadingMore.collectAsState()
+    val detailVm: DetailViewModel = viewModel()
+    val detail by detailVm.detail.collectAsState()
+    val isLoading by detailVm.isLoading.collectAsState()
+    val isLoadingMore by detailVm.isLoadingMore.collectAsState()
     val theme by vm.themeColors.collectAsState()
     val accentColor by androidx.compose.animation.animateColorAsState(theme.primary, androidx.compose.animation.core.tween(800), label = "detailAccent")
     val isArtist = detail.type == "artist"
@@ -144,7 +148,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                             fontSize = 14.sp,
                             fontWeight = FontWeight.SemiBold,
                             modifier = Modifier.clickable {
-                                detail.artistUri?.substringAfterLast(":")?.let { vm.openArtist(it) }
+                                detail.artistUri?.substringAfterLast(":")?.let { detailVm.openArtist(it) }
                             }
                         )
                     }
@@ -206,15 +210,15 @@ fun DetailScreen(vm: SpotifyViewModel) {
             ) {
                 // Save/Follow (albums & artists)
                 if (detail.type == "album" || isArtist) {
-                    val saved by vm.detailSaved.collectAsState()
+                    val saved by detailVm.detailSaved.collectAsState()
                     val detailId = detail.uri
                         .removePrefix("spotify:album:")
                         .removePrefix("spotify:artist:")
-                    LaunchedEffect(detail.uri) { vm.checkDetailSaved(detail.type, detailId) }
+                    LaunchedEffect(detail.uri) { detailVm.checkDetailSaved(detail.type, detailId) }
 
                     if (isArtist) {
                         OutlinedButton(
-                            onClick = { vm.toggleDetailSaved(detail.type, detailId) },
+                            onClick = { detailVm.toggleDetailSaved(detail.type, detailId) },
                             colors = ButtonDefaults.outlinedButtonColors(
                                 contentColor = SpotifyWhite
                             ),
@@ -231,7 +235,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                     } else {
                         IconToggleButton(
                             checked = saved,
-                            onCheckedChange = { vm.toggleDetailSaved(detail.type, detailId) },
+                            onCheckedChange = { detailVm.toggleDetailSaved(detail.type, detailId) },
                             colors = IconButtonDefaults.iconToggleButtonColors(
                                 contentColor = SpotifyWhite,
                                 checkedContentColor = accentColor,
@@ -314,7 +318,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
         // Tracks
         itemsIndexed(detail.tracks, key = { index, track -> "$index-${track.uri}" }) { index, track ->
             if (hasMore && index >= detail.tracks.size - 5) {
-                LaunchedEffect(detail.tracks.size) { vm.loadMoreDetail() }
+                LaunchedEffect(detail.tracks.size) { detailVm.loadMoreDetail() }
             }
             when {
                 isArtist -> ArtistTrackRow(index + 1, track, vm, detail.uri, detail.topTrackPlaycounts.getOrNull(index))
@@ -355,7 +359,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                                 .width(130.dp)
                                 .clickable {
                                     val id = rel.uri.substringAfterLast(":")
-                                    vm.openAlbum(id)
+                                    detailVm.openAlbum(id)
                                 }
                         ) {
                             SpotifyImage(
@@ -400,7 +404,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                                 .width(120.dp)
                                 .clickable {
                                     val id = ra.uri.substringAfterLast(":")
-                                    vm.openArtist(id)
+                                    detailVm.openArtist(id)
                                 },
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
@@ -467,7 +471,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
                                 .width(130.dp)
                                 .clickable {
                                     val id = rel.uri.substringAfterLast(":")
-                                    vm.openAlbum(id)
+                                    detailVm.openAlbum(id)
                                 }
                         ) {
                             SpotifyImage(
@@ -512,6 +516,7 @@ private fun ArtistTrackRow(
     contextUri: String,
     playcount: String? = null
 ) {
+    val detailVm: DetailViewModel = viewModel()
     val playback by vm.playback.collectAsState()
     val isPlaying = playback.track?.uri == track.uri && playback.isPlaying
     val theme by vm.themeColors.collectAsState()
@@ -611,7 +616,7 @@ private fun ArtistTrackRow(
                         vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
                     },
                     Triple(Icons.Rounded.Album, visitAlbumLabel) {
-                        showMenu = false; vm.openAlbumForTrack(track.uri)
+                        showMenu = false; detailVm.openAlbumForTrack(track.uri)
                     },
                     Triple(Icons.Rounded.Share, shareLabel) {
                         showMenu = false
@@ -651,6 +656,7 @@ private fun AlbumTrackRow(
     contextUri: String,
     trackIndex: Int? = null
 ) {
+    val detailVm: DetailViewModel = viewModel()
     val playback by vm.playback.collectAsState()
     val isPlaying = playback.track?.uri == track.uri && playback.isPlaying
     val theme by vm.themeColors.collectAsState()
@@ -736,7 +742,7 @@ private fun AlbumTrackRow(
                         vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
                     },
                     Triple(Icons.Rounded.Person, visitArtistLabel) {
-                        showMenu = false; vm.openArtistForTrack(track.uri)
+                        showMenu = false; detailVm.openArtistForTrack(track.uri)
                     },
                     Triple(Icons.Rounded.Share, shareLabel) {
                         showMenu = false
@@ -842,7 +848,7 @@ private fun DetailHeaderMenu(
                 add(Triple(Icons.Rounded.Person, visitArtistLabel) {
                     onDismiss()
                     val artistId = detail.artistUri.substringAfterLast(":")
-                    vm.openArtist(artistId)
+                    DetailRoutes.openArtist(artistId)
                 })
             }
         }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -46,6 +46,8 @@ import ch.snepilatch.app.ui.components.ShimmerBox
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.SpotifyCardBg
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 // --- Home Screen ---
@@ -114,6 +116,7 @@ fun HomeScreen(vm: SpotifyViewModel) {
 
 @Composable
 fun QuickPickGrid(items: List<kotify.api.home.HomeSectionItem>, vm: SpotifyViewModel) {
+    val detailVm: DetailViewModel = viewModel()
     Column(
         Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -131,10 +134,10 @@ fun QuickPickGrid(items: List<kotify.api.home.HomeSectionItem>, vm: SpotifyViewM
                             .clickable {
                                 val id = item.uri.split(":").lastOrNull() ?: return@clickable
                                 when (item.type) {
-                                    "playlist" -> vm.openPlaylist(id)
-                                    "album" -> vm.openAlbum(id)
-                                    "artist" -> vm.openArtist(id)
-                                    "show" -> vm.openShow(id, item.owner, item.imageUrl)
+                                    "playlist" -> detailVm.openPlaylist(id)
+                                    "album" -> detailVm.openAlbum(id)
+                                    "artist" -> detailVm.openArtist(id)
+                                    "show" -> detailVm.openShow(id, item.owner, item.imageUrl)
                                     else -> vm.playTrack(item.uri)
                                 }
                             },
@@ -214,6 +217,7 @@ fun HomeShimmer() {
 
 @Composable
 fun HomeSectionCard(item: kotify.api.home.HomeSectionItem, vm: SpotifyViewModel, modifier: Modifier = Modifier) {
+    val detailVm: DetailViewModel = viewModel()
     val isArtist = item.type == "artist"
     Column(
         modifier
@@ -221,10 +225,10 @@ fun HomeSectionCard(item: kotify.api.home.HomeSectionItem, vm: SpotifyViewModel,
             .clickable {
                 val id = item.uri.split(":").lastOrNull() ?: return@clickable
                 when (item.type) {
-                    "playlist" -> vm.openPlaylist(id)
-                    "album" -> vm.openAlbum(id)
-                    "artist" -> vm.openArtist(id)
-                    "show" -> vm.openShow(id, item.owner, item.imageUrl)
+                    "playlist" -> detailVm.openPlaylist(id)
+                    "album" -> detailVm.openAlbum(id)
+                    "artist" -> detailVm.openArtist(id)
+                    "show" -> detailVm.openShow(id, item.owner, item.imageUrl)
                     else -> vm.playTrack(item.uri)
                 }
             },

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
@@ -72,6 +72,8 @@ import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 private const val PREFS_NAME = "kotify_prefs"
@@ -294,24 +296,24 @@ fun LibraryScreen(vm: SpotifyViewModel) {
     }
 }
 
-fun libraryItemClick(item: LibraryItem, vm: SpotifyViewModel) {
+fun libraryItemClick(item: LibraryItem, detailVm: DetailViewModel) {
     when (item.type) {
-        "collection" -> vm.openLikedSongs()
+        "collection" -> detailVm.openLikedSongs()
         "playlist" -> {
             val id = item.uri.split(":").lastOrNull() ?: return
-            vm.openPlaylist(id)
+            detailVm.openPlaylist(id)
         }
         "album" -> {
             val id = item.uri.split(":").lastOrNull() ?: return
-            vm.openAlbum(id)
+            detailVm.openAlbum(id)
         }
         "artist" -> {
             val id = item.uri.split(":").lastOrNull() ?: return
-            vm.openArtist(id)
+            detailVm.openArtist(id)
         }
         "show" -> {
             val id = item.uri.split(":").lastOrNull() ?: return
-            vm.openShow(id, item.owner, item.imageUrl)
+            detailVm.openShow(id, item.owner, item.imageUrl)
         }
     }
 }
@@ -319,6 +321,7 @@ fun libraryItemClick(item: LibraryItem, vm: SpotifyViewModel) {
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LibraryGridCard(item: LibraryItem, vm: SpotifyViewModel) {
+    val detailVm: DetailViewModel = viewModel()
     val isArtist = item.type == "artist"
     var showRemove by remember { mutableStateOf(false) }
     if (showRemove && item.type != "collection") {
@@ -328,7 +331,7 @@ fun LibraryGridCard(item: LibraryItem, vm: SpotifyViewModel) {
         Modifier
             .fillMaxWidth()
             .combinedClickable(
-                onClick = { libraryItemClick(item, vm) },
+                onClick = { libraryItemClick(item, detailVm) },
                 onLongClick = { if (item.type != "collection") showRemove = true }
             ),
         horizontalAlignment = if (isArtist) Alignment.CenterHorizontally else Alignment.Start
@@ -364,6 +367,7 @@ fun LibraryGridCard(item: LibraryItem, vm: SpotifyViewModel) {
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LibraryListItem(item: LibraryItem, vm: SpotifyViewModel) {
+    val detailVm: DetailViewModel = viewModel()
     val isArtist = item.type == "artist"
     var showRemove by remember { mutableStateOf(false) }
     if (showRemove && item.type != "collection") {
@@ -373,7 +377,7 @@ fun LibraryListItem(item: LibraryItem, vm: SpotifyViewModel) {
         Modifier
             .fillMaxWidth()
             .combinedClickable(
-                onClick = { libraryItemClick(item, vm) },
+                onClick = { libraryItemClick(item, detailVm) },
                 onLongClick = { if (item.type != "collection") showRemove = true }
             )
             .padding(horizontal = 16.dp, vertical = 8.dp),

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
@@ -76,6 +76,7 @@ import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.ui.theme.SpotifyWhite
+import ch.snepilatch.app.viewmodel.DetailRoutes
 import ch.snepilatch.app.viewmodel.SearchViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import kotify.api.song.SearchAlbum
@@ -321,10 +322,10 @@ private fun SearchTrack.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedR
             vm.likeSong(uri.removePrefix("spotify:track:"))
         },
         OverflowAction(Icons.Rounded.Album, ctx.getString(R.string.visit_album)) {
-            vm.openAlbumForTrack(uri)
+            DetailRoutes.openAlbumForTrack(uri)
         },
         OverflowAction(Icons.Rounded.Person, ctx.getString(R.string.visit_artist)) {
-            vm.openArtistForTrack(uri)
+            DetailRoutes.openArtistForTrack(uri)
         },
         shareAction(ctx, uri)
     )
@@ -336,7 +337,7 @@ private fun SearchArtist.toUnified(vm: SpotifyViewModel, ctx: Context) = Unified
     subtitle = ctx.getString(R.string.search_subtitle_artist),
     imageUrl = avatarUrl,
     circular = true,
-    onClick = { vm.openArtist(idFromUri(uri)) },
+    onClick = { DetailRoutes.openArtist(idFromUri(uri)) },
     menu = listOf(
         OverflowAction(Icons.Rounded.PersonAdd, "Follow") {
             vm.followArtist(idFromUri(uri))
@@ -345,7 +346,7 @@ private fun SearchArtist.toUnified(vm: SpotifyViewModel, ctx: Context) = Unified
     )
 )
 
-private fun SearchAlbum.toUnified(vm: SpotifyViewModel, ctx: Context): UnifiedResult {
+private fun SearchAlbum.toUnified(ctx: Context): UnifiedResult {
     val typeLabel = type.lowercase().replaceFirstChar { it.uppercase() }
     val artistName = artists.firstOrNull()?.name
     return UnifiedResult(
@@ -354,7 +355,7 @@ private fun SearchAlbum.toUnified(vm: SpotifyViewModel, ctx: Context): UnifiedRe
         subtitle = listOfNotNull(typeLabel.takeIf { it.isNotBlank() }, artistName).joinToString(" · "),
         imageUrl = coverArtUrl,
         circular = false,
-        onClick = { vm.openAlbum(idFromUri(uri)) },
+        onClick = { DetailRoutes.openAlbum(idFromUri(uri)) },
         menu = listOf(shareAction(ctx, uri))
     )
 }
@@ -365,7 +366,7 @@ private fun SearchPlaylist.toUnified(vm: SpotifyViewModel, ctx: Context) = Unifi
     subtitle = listOfNotNull(ctx.getString(R.string.search_subtitle_playlist), ownerName).joinToString(" · "),
     imageUrl = coverArtUrl,
     circular = false,
-    onClick = { vm.openPlaylist(idFromUri(uri)) },
+    onClick = { DetailRoutes.openPlaylist(idFromUri(uri)) },
     menu = listOf(
         OverflowAction(Icons.Rounded.Add, "Save to Library") {
             vm.savePlaylist(idFromUri(uri))
@@ -374,14 +375,14 @@ private fun SearchPlaylist.toUnified(vm: SpotifyViewModel, ctx: Context) = Unifi
     )
 )
 
-private fun SearchPodcast.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedResult(
+private fun SearchPodcast.toUnified(ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
     subtitle = listOfNotNull(ctx.getString(R.string.search_subtitle_podcast), publisher).joinToString(" · "),
     imageUrl = coverArtUrl,
     circular = false,
     // Carry publisher + cover art into the show screen — the queryPodcastEpisodes payload lacks them.
-    onClick = { vm.openShow(idFromUri(uri), publisher, coverArtUrl) },
+    onClick = { DetailRoutes.openShow(idFromUri(uri), publisher, coverArtUrl) },
     menu = listOf(shareAction(ctx, uri))
 )
 
@@ -466,13 +467,13 @@ private fun sectionFor(
             .map { it.toUnified(vm, ctx) }
     "ALBUMS" ->
         SearchViewModel.SearchFilter.ALBUMS to results.albums.items.take(SECTION_PREVIEW)
-            .map { it.toUnified(vm, ctx) }
+            .map { it.toUnified(ctx) }
     "PLAYLISTS" ->
         SearchViewModel.SearchFilter.PLAYLISTS to results.playlists.items.take(SECTION_PREVIEW)
             .map { it.toUnified(vm, ctx) }
     "PODCASTS" ->
         SearchViewModel.SearchFilter.PODCASTS to results.podcasts.items.take(SECTION_PREVIEW)
-            .map { it.toUnified(vm, ctx) }
+            .map { it.toUnified(ctx) }
     "USERS" ->
         SearchViewModel.SearchFilter.PROFILES to results.users.items.take(SECTION_PREVIEW)
             .map { it.toUnified(ctx) }
@@ -486,10 +487,10 @@ private fun singleFilterRows(
     filter: SearchViewModel.SearchFilter
 ): List<UnifiedResult> = when (filter) {
     SearchViewModel.SearchFilter.ARTISTS -> results.artists.items.map { it.toUnified(vm, ctx) }
-    SearchViewModel.SearchFilter.ALBUMS -> results.albums.items.map { it.toUnified(vm, ctx) }
+    SearchViewModel.SearchFilter.ALBUMS -> results.albums.items.map { it.toUnified(ctx) }
     SearchViewModel.SearchFilter.SONGS -> results.tracks.items.map { it.toUnified(vm, ctx) }
     SearchViewModel.SearchFilter.PLAYLISTS -> results.playlists.items.map { it.toUnified(vm, ctx) }
-    SearchViewModel.SearchFilter.PODCASTS -> results.podcasts.items.map { it.toUnified(vm, ctx) }
+    SearchViewModel.SearchFilter.PODCASTS -> results.podcasts.items.map { it.toUnified(ctx) }
     SearchViewModel.SearchFilter.PROFILES -> results.users.items.map { it.toUnified(ctx) }
     SearchViewModel.SearchFilter.ALL -> emptyList()
 }
@@ -497,9 +498,9 @@ private fun singleFilterRows(
 private fun SearchTopResult.toUnified(vm: SpotifyViewModel, ctx: Context): UnifiedResult = when (this) {
     is SearchTopResult.Track -> track.toUnified(vm, ctx)
     is SearchTopResult.Artist -> artist.toUnified(vm, ctx)
-    is SearchTopResult.Album -> album.toUnified(vm, ctx)
+    is SearchTopResult.Album -> album.toUnified(ctx)
     is SearchTopResult.Playlist -> playlist.toUnified(vm, ctx)
-    is SearchTopResult.Podcast -> podcast.toUnified(vm, ctx)
+    is SearchTopResult.Podcast -> podcast.toUnified(ctx)
     is SearchTopResult.User -> user.toUnified(ctx)
 }
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -55,6 +55,8 @@ import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
@@ -95,6 +97,9 @@ private val MorphCardPadV = 6.dp
 
 @Composable
 fun SpotifyApp(vm: SpotifyViewModel) {
+    // Eagerly create the DetailViewModel from the post-login shell so it registers itself in
+    // DetailRoutes before any deep link or playback-context bridge tries to open a detail.
+    viewModel<DetailViewModel>()
     val screen by vm.currentScreen.collectAsState()
     // Only whether a track exists — collecting the whole PlaybackUiState here would recompose the
     // entire app root twice a second, since the interpolator rewrites positionMs at 2Hz.

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
@@ -1,0 +1,252 @@
+package ch.snepilatch.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ch.snepilatch.app.data.*
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.util.LokiLogger
+import kotify.api.album.Album
+import kotify.api.artist.Artist
+import kotify.api.playlist.Playlist
+import kotify.api.podcast.Podcast
+import kotify.api.song.Song
+import kotify.session.Session
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the shared detail screen (playlist / album / artist / show).
+ *
+ * Owns the detail data + its pagination + the follow/save toggle, and the
+ * openers that navigate to a detail and load it. Navigation goes through the
+ * process-scoped [Navigator]; the session comes from [SessionHolder]. Screens
+ * obtain this via `viewModel()` alongside [SpotifyViewModel].
+ *
+ * [SpotifyViewModel]'s deep-link handler and playback-context bridges
+ * (openAlbumFromCurrentTrack / openArtistFromCurrentTrack / navigateToContext)
+ * need PlayerConnect / playingContext, so they stay there and reach the openers
+ * through [DetailRoutes] rather than holding a reference to this ViewModel.
+ */
+class DetailViewModel : ViewModel() {
+
+    private val tag = "DetailVM"
+
+    private val _detail = MutableStateFlow(DetailData())
+    val detail: StateFlow<DetailData> = _detail
+
+    val isLoading = MutableStateFlow(false)
+
+    private val _isLoadingMore = MutableStateFlow(false)
+    val isLoadingMore: StateFlow<Boolean> = _isLoadingMore
+
+    val detailSaved = MutableStateFlow(false)
+
+    init { DetailRoutes.register(this) }
+
+    override fun onCleared() {
+        DetailRoutes.unregister(this)
+        super.onCleared()
+    }
+
+    /** Navigate to a detail screen and load it under [isLoading]; a null result leaves the previous
+     *  detail unchanged (used by openShow when the podcast has no info). */
+    private fun openDetail(screen: Screen, tag: String, load: suspend (Session) -> DetailData?) {
+        Navigator.navigateTo(screen)
+        launchLoading(tag) { sess -> load(sess)?.let { _detail.value = it } }
+    }
+
+    fun openLikedSongs() = openDetail(Screen.PLAYLIST_DETAIL, "openLikedSongs") { sess ->
+        Playlist(sess).getLikedSongs(limit = 50).toDetailData(offset = 0)
+    }
+
+    fun openPlaylist(playlistId: String) = openDetail(Screen.PLAYLIST_DETAIL, "openPlaylist") { sess ->
+        Playlist(sess).getPlaylist(playlistId, limit = 50).toDetailData(playlistId)
+    }
+
+    fun openAlbum(albumId: String) = openDetail(Screen.ALBUM_DETAIL, "openAlbum") { sess ->
+        Album(sess).getAlbum(albumId, limit = 50).toDetailData(albumId)
+    }
+
+    fun openArtist(artistId: String) = openDetail(Screen.ARTIST_DETAIL, "openArtist") { sess ->
+        Artist(sess).getArtist(artistId).toDetailData(artistId)
+    }
+
+    /**
+     * Open a podcast show. [publisher]/[imageUrl] come from the search/library item that was tapped
+     * (the `queryPodcastEpisodes` payload doesn't carry them); they fall back to the first episode's
+     * cover art. Episodes render as episode-URI [ch.snepilatch.app.data.TrackInfo]s.
+     */
+    fun openShow(showId: String, publisher: String? = null, imageUrl: String? = null) =
+        openDetail(Screen.SHOW_DETAIL, "openShow") { sess ->
+            Podcast(sess, showId).getPodcastInfo(limit = 50, offset = 0)
+                ?.toDetailData(showId, publisher, imageUrl)
+                .also { if (it == null) LokiLogger.e(tag, "openShow: no podcast info for $showId") }
+        }
+
+    fun openAlbumForTrack(trackUri: String) {
+        launchSession("openAlbumForTrack") { sess ->
+            val trackId = trackUri.removePrefix("spotify:track:")
+            val track = Song(sess).getSong(trackId) ?: return@launchSession
+            val albumUri = track.album.uri.takeIf { it.isNotBlank() } ?: return@launchSession
+            openAlbum(albumUri.substringAfterLast(":"))
+        }
+    }
+
+    fun openArtistForTrack(trackUri: String) {
+        launchSession("openArtistForTrack") { sess ->
+            val trackId = trackUri.removePrefix("spotify:track:")
+            val track = Song(sess).getSong(trackId) ?: return@launchSession
+            val artistUri = track.artists.firstOrNull()?.uri?.takeIf { it.isNotBlank() } ?: return@launchSession
+            openArtist(artistUri.substringAfterLast(":"))
+        }
+    }
+
+    fun loadMoreDetail() {
+        val current = _detail.value
+        if (_isLoadingMore.value) return
+        if (current.totalCount in 0..current.tracks.size) return
+        val uri = current.uri
+        _isLoadingMore.value = true
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val sess = SessionHolder.session ?: return@launch
+                val offset = current.tracks.size
+                if (uri == "spotify:collection:tracks") {
+                    val data = Playlist(sess).getLikedSongs(limit = 50, offset = offset)
+                    val more = data.toDetailData(offset)
+                    _detail.value = current.copy(
+                        tracks = current.tracks + more.tracks,
+                        totalCount = more.totalCount,
+                        loadedOffset = offset + more.tracks.size
+                    )
+                } else if (uri.startsWith("spotify:playlist:")) {
+                    val id = uri.removePrefix("spotify:playlist:")
+                    val info = Playlist(sess).getPlaylist(id, limit = DETAIL_PAGE_SIZE, offset = offset)
+                    val more = info.tracks.map { it.toTrackInfo() }
+                    val newSize = current.tracks.size + more.size
+                    // Server-reported totalTracks is unreliable (PlaylistMapper
+                    // returns 0 when content.totalCount is missing). Use the
+                    // page-shorter-than-limit signal as the authoritative
+                    // "we're at the end" indicator instead.
+                    val newTotalCount = when {
+                        more.size < DETAIL_PAGE_SIZE -> newSize
+                        info.totalTracks > 0 -> info.totalTracks
+                        else -> -1
+                    }
+                    _detail.value = current.copy(
+                        tracks = current.tracks + more,
+                        totalCount = newTotalCount,
+                        loadedOffset = newSize
+                    )
+                } else if (uri.startsWith("spotify:album:")) {
+                    val id = uri.removePrefix("spotify:album:")
+                    val info = Album(sess).getAlbum(id, limit = 50, offset = offset)
+                    val more = info.tracks.map { it.toTrackInfo(info.coverArtUrl) }
+                    _detail.value = current.copy(
+                        tracks = current.tracks + more,
+                        totalCount = info.totalTracks,
+                        loadedOffset = offset + more.size
+                    )
+                } else if (uri.startsWith("spotify:show:")) {
+                    val id = uri.removePrefix("spotify:show:")
+                    val info = Podcast(sess, id).getPodcastInfo(limit = DETAIL_PAGE_SIZE, offset = offset)
+                    val more = info?.episodes?.map { it.toTrackInfo(current.name) } ?: emptyList()
+                    val newSize = current.tracks.size + more.size
+                    // A short page means we've hit the end; otherwise keep the server-reported total.
+                    val newTotalCount = if (more.size < DETAIL_PAGE_SIZE) newSize else (info?.totalEpisodes ?: newSize)
+                    _detail.value = current.copy(
+                        tracks = current.tracks + more,
+                        totalCount = newTotalCount,
+                        loadedOffset = newSize
+                    )
+                }
+            } catch (e: Exception) {
+                LokiLogger.e(tag, "loadMoreDetail", e)
+            } finally {
+                _isLoadingMore.value = false
+            }
+        }
+    }
+
+    fun checkDetailSaved(type: String, id: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val sess = SessionHolder.session ?: return@launch
+                detailSaved.value = when (type) {
+                    "album" -> Album(sess).isSaved(id)
+                    "artist" -> Artist(sess).isFollowing(id)
+                    else -> false
+                }
+            } catch (_: Exception) { detailSaved.value = false }
+        }
+    }
+
+    fun toggleDetailSaved(type: String, id: String) {
+        launchSession("toggleDetailSaved") { sess ->
+            val currentlySaved = detailSaved.value
+            when (type) {
+                "album" -> if (currentlySaved) Album(sess).removeFromLibrary(id) else Album(sess).saveToLibrary(id)
+                "artist" -> if (currentlySaved) Artist(sess).unfollow(id) else Artist(sess).follow(id)
+            }
+            detailSaved.value = !currentlySaved
+        }
+    }
+
+    private fun launchSession(tag: String, block: suspend (Session) -> Unit): Job =
+        viewModelScope.launch(Dispatchers.IO) {
+            val sess = SessionHolder.session ?: return@launch
+            try {
+                block(sess)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LokiLogger.e(this@DetailViewModel.tag, tag, e)
+            }
+        }
+
+    private fun launchLoading(tag: String, block: suspend (Session) -> Unit): Job =
+        viewModelScope.launch(Dispatchers.IO) {
+            val sess = SessionHolder.session ?: return@launch
+            isLoading.value = true
+            try {
+                block(sess)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LokiLogger.e(this@DetailViewModel.tag, tag, e)
+            } finally {
+                isLoading.value = false
+            }
+        }
+
+    companion object {
+        private const val DETAIL_PAGE_SIZE = 50
+    }
+}
+
+/**
+ * Process-scoped hop so [SpotifyViewModel]'s deep-link + playback-context code can open a detail
+ * without a reference to the (screen-scoped) [DetailViewModel]. The live ViewModel registers itself
+ * on construction; calls before one exists are dropped (in practice a screen — normally Home — is
+ * always composed before a deep link is processed, so one is registered).
+ */
+object DetailRoutes {
+    @Volatile private var target: DetailViewModel? = null
+
+    fun register(vm: DetailViewModel) { target = vm }
+    fun unregister(vm: DetailViewModel) { if (target === vm) target = null }
+
+    fun openAlbum(id: String) { target?.openAlbum(id) }
+    fun openArtist(id: String) { target?.openArtist(id) }
+    fun openPlaylist(id: String) { target?.openPlaylist(id) }
+    fun openShow(id: String, publisher: String? = null, imageUrl: String? = null) {
+        target?.openShow(id, publisher, imageUrl)
+    }
+    fun openLikedSongs() { target?.openLikedSongs() }
+    fun openAlbumForTrack(trackUri: String) { target?.openAlbumForTrack(trackUri) }
+    fun openArtistForTrack(trackUri: String) { target?.openArtistForTrack(trackUri) }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -22,7 +22,6 @@ import kotify.api.home.Home
 import kotify.api.home.HomeData
 import kotify.api.playerconnect.PlayerConnect
 import kotify.api.playlist.Playlist
-import kotify.api.podcast.Podcast
 import kotify.api.playerstatus.DeviceInfo
 import kotify.api.playerstatus.PlayerStateData
 import kotify.api.playerstatus.PlayerTrack
@@ -256,9 +255,8 @@ class SpotifyViewModel : ViewModel() {
     // Next track info (always available from WebSocket state for mini player swipe)
     val nextTrackPreview = MutableStateFlow<TrackInfo?>(null)
 
-    // Detail
-    private val _detail = MutableStateFlow(DetailData())
-    val detail: StateFlow<DetailData> = _detail
+    // Detail state + openers live in DetailViewModel; SpotifyViewModel's deep-link/playback bridges
+    // reach them through DetailRoutes.
 
     // Devices
     private val _devices = MutableStateFlow<List<DeviceInfo>>(emptyList())
@@ -278,8 +276,7 @@ class SpotifyViewModel : ViewModel() {
     private var lastDeviceIndicatorKey: Pair<Boolean, Boolean>? = null
     private val playlistNameCache = mutableMapOf<String, String>()
 
-    // Loading
-    val isLoading = MutableStateFlow(false)
+    // Loading (detail loading moved to DetailViewModel.isLoading)
     val isStreamLoading = MutableStateFlow(false)
 
     // Snackbar messages
@@ -807,29 +804,6 @@ class SpotifyViewModel : ViewModel() {
             }
         }
 
-    /**
-     * Same shape as [launchWithSession] but flips [loading] true around the block and always
-     * resets it in a finally. For loaders whose only extra work is a loading-spinner flag.
-     */
-    private fun launchWithSessionLoading(
-        tag: String,
-        loading: MutableStateFlow<Boolean>,
-        block: suspend (Session) -> Unit
-    ): Job =
-        viewModelScope.launch(Dispatchers.IO) {
-            val sess = session ?: return@launch
-            loading.value = true
-            try {
-                block(sess)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                LokiLogger.e(TAG, tag, e)
-            } finally {
-                loading.value = false
-            }
-        }
-
     fun showLogin() {
         needsLogin.value = true
     }
@@ -855,9 +829,9 @@ class SpotifyViewModel : ViewModel() {
 
         when (type) {
             "track" -> playTrack("spotify:track:$id")
-            "album" -> openAlbum(id)
-            "playlist" -> openPlaylist(id)
-            "artist" -> openArtist(id)
+            "album" -> DetailRoutes.openAlbum(id)
+            "playlist" -> DetailRoutes.openPlaylist(id)
+            "artist" -> DetailRoutes.openArtist(id)
             else -> LokiLogger.i(TAG, "Unsupported deep link type: $type")
         }
     }
@@ -1874,6 +1848,8 @@ class SpotifyViewModel : ViewModel() {
         }
     }
 
+    // Playback-context bridges: these read PlayerConnect / playingContext (playback-owned), then hand
+    // off to DetailViewModel via DetailRoutes to open the resolved page.
     fun openAlbumFromCurrentTrack() {
         launchWithPlayer("openAlbumFromCurrentTrack") { pc ->
             val state = pc.getState() ?: return@launchWithPlayer
@@ -1882,7 +1858,7 @@ class SpotifyViewModel : ViewModel() {
                 ?: state.context_uri?.takeIf { it.contains(":album:") }
             if (albumUri != null) {
                 val albumId = albumUri.removePrefix("spotify:album:")
-                openAlbum(albumId)
+                DetailRoutes.openAlbum(albumId)
             } else {
                 LokiLogger.w(TAG, "No album URI on current track")
             }
@@ -1893,28 +1869,10 @@ class SpotifyViewModel : ViewModel() {
         val ctx = playingContext.value ?: return
         val uri = ctx.uri ?: return
         when {
-            uri.contains(":playlist:") -> openPlaylist(uri.substringAfter(":playlist:"))
-            uri.contains(":album:") -> openAlbum(uri.substringAfter(":album:"))
-            uri.contains(":artist:") -> openArtist(uri.substringAfter(":artist:"))
-            uri.contains(":collection:tracks") -> openLikedSongs()
-        }
-    }
-
-    fun openAlbumForTrack(trackUri: String) {
-        launchWithSession("openAlbumForTrack") { sess ->
-            val trackId = trackUri.removePrefix("spotify:track:")
-            val track = Song(sess).getSong(trackId) ?: return@launchWithSession
-            val albumUri = track.album.uri.takeIf { it.isNotBlank() } ?: return@launchWithSession
-            openAlbum(albumUri.substringAfterLast(":"))
-        }
-    }
-
-    fun openArtistForTrack(trackUri: String) {
-        launchWithSession("openArtistForTrack") { sess ->
-            val trackId = trackUri.removePrefix("spotify:track:")
-            val track = Song(sess).getSong(trackId) ?: return@launchWithSession
-            val artistUri = track.artists.firstOrNull()?.uri?.takeIf { it.isNotBlank() } ?: return@launchWithSession
-            openArtist(artistUri.substringAfterLast(":"))
+            uri.contains(":playlist:") -> DetailRoutes.openPlaylist(uri.substringAfter(":playlist:"))
+            uri.contains(":album:") -> DetailRoutes.openAlbum(uri.substringAfter(":album:"))
+            uri.contains(":artist:") -> DetailRoutes.openArtist(uri.substringAfter(":artist:"))
+            uri.contains(":collection:tracks") -> DetailRoutes.openLikedSongs()
         }
     }
 
@@ -1925,7 +1883,7 @@ class SpotifyViewModel : ViewModel() {
             val artistUri = track.artistUri?.takeIf { it.isNotBlank() }
             if (artistUri != null) {
                 val artistId = artistUri.removePrefix("spotify:artist:")
-                openArtist(artistId)
+                DetailRoutes.openArtist(artistId)
             }
         }
     }
@@ -2905,140 +2863,7 @@ class SpotifyViewModel : ViewModel() {
         }
     }
 
-
-    // --- Detail ---
-
-    private val _isLoadingMore = MutableStateFlow(false)
-    val isLoadingMore: StateFlow<Boolean> = _isLoadingMore
-
-    /** Navigate to a detail screen and load it under the shared isLoading flag; a null result leaves
-     *  the previous detail unchanged (used by openShow when the podcast has no info). */
-    private fun openDetail(screen: Screen, tag: String, load: suspend (Session) -> DetailData?) {
-        navigateTo(screen)
-        launchWithSessionLoading(tag, isLoading) { sess -> load(sess)?.let { _detail.value = it } }
-    }
-
-    fun openLikedSongs() = openDetail(Screen.PLAYLIST_DETAIL, "openLikedSongs") { sess ->
-        Playlist(sess).getLikedSongs(limit = 50).toDetailData(offset = 0)
-    }
-
-    fun loadMoreDetail() {
-        val current = _detail.value
-        if (_isLoadingMore.value) return
-        if (current.totalCount in 0..current.tracks.size) return
-        val uri = current.uri
-        _isLoadingMore.value = true
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                val sess = session ?: return@launch
-                val offset = current.tracks.size
-                if (uri == "spotify:collection:tracks") {
-                    val data = Playlist(sess).getLikedSongs(limit = 50, offset = offset)
-                    val more = data.toDetailData(offset)
-                    _detail.value = current.copy(
-                        tracks = current.tracks + more.tracks,
-                        totalCount = more.totalCount,
-                        loadedOffset = offset + more.tracks.size
-                    )
-                } else if (uri.startsWith("spotify:playlist:")) {
-                    val id = uri.removePrefix("spotify:playlist:")
-                    val info = Playlist(sess).getPlaylist(id, limit = DETAIL_PAGE_SIZE, offset = offset)
-                    val more = info.tracks.map { it.toTrackInfo() }
-                    val newSize = current.tracks.size + more.size
-                    // Server-reported totalTracks is unreliable (PlaylistMapper
-                    // returns 0 when content.totalCount is missing). Use the
-                    // page-shorter-than-limit signal as the authoritative
-                    // "we're at the end" indicator instead.
-                    val newTotalCount = when {
-                        more.size < DETAIL_PAGE_SIZE -> newSize
-                        info.totalTracks > 0 -> info.totalTracks
-                        else -> -1
-                    }
-                    _detail.value = current.copy(
-                        tracks = current.tracks + more,
-                        totalCount = newTotalCount,
-                        loadedOffset = newSize
-                    )
-                } else if (uri.startsWith("spotify:album:")) {
-                    val id = uri.removePrefix("spotify:album:")
-                    val info = Album(sess).getAlbum(id, limit = 50, offset = offset)
-                    val more = info.tracks.map { it.toTrackInfo(info.coverArtUrl) }
-                    _detail.value = current.copy(
-                        tracks = current.tracks + more,
-                        totalCount = info.totalTracks,
-                        loadedOffset = offset + more.size
-                    )
-                } else if (uri.startsWith("spotify:show:")) {
-                    val id = uri.removePrefix("spotify:show:")
-                    val info = Podcast(sess, id).getPodcastInfo(limit = DETAIL_PAGE_SIZE, offset = offset)
-                    val more = info?.episodes?.map { it.toTrackInfo(current.name) } ?: emptyList()
-                    val newSize = current.tracks.size + more.size
-                    // A short page means we've hit the end; otherwise keep the server-reported total.
-                    val newTotalCount = if (more.size < DETAIL_PAGE_SIZE) newSize else (info?.totalEpisodes ?: newSize)
-                    _detail.value = current.copy(
-                        tracks = current.tracks + more,
-                        totalCount = newTotalCount,
-                        loadedOffset = newSize
-                    )
-                }
-            } catch (e: Exception) { LokiLogger.e(TAG, "loadMoreDetail", e) }
-            finally { _isLoadingMore.value = false }
-        }
-    }
-
-
-    fun openPlaylist(playlistId: String) = openDetail(Screen.PLAYLIST_DETAIL, "openPlaylist") { sess ->
-        Playlist(sess).getPlaylist(playlistId, limit = 50).toDetailData(playlistId)
-    }
-
-    fun openAlbum(albumId: String) = openDetail(Screen.ALBUM_DETAIL, "openAlbum") { sess ->
-        Album(sess).getAlbum(albumId, limit = 50).toDetailData(albumId)
-    }
-
-    fun openArtist(artistId: String) = openDetail(Screen.ARTIST_DETAIL, "openArtist") { sess ->
-        Artist(sess).getArtist(artistId).toDetailData(artistId)
-    }
-
-    /**
-     * Open a podcast show. [publisher]/[imageUrl] come from the search/library item that was tapped
-     * (the `queryPodcastEpisodes` payload doesn't carry them); they fall back to the first episode's
-     * cover art. Episodes render as episode-URI [TrackInfo]s and play through the normal [playTrack].
-     */
-    fun openShow(showId: String, publisher: String? = null, imageUrl: String? = null) =
-        openDetail(Screen.SHOW_DETAIL, "openShow") { sess ->
-            Podcast(sess, showId).getPodcastInfo(limit = 50, offset = 0)
-                ?.toDetailData(showId, publisher, imageUrl)
-                .also { if (it == null) LokiLogger.e(TAG, "openShow: no podcast info for $showId") }
-        }
-
-
-    // --- Library actions (save/follow) ---
-
-    val detailSaved = MutableStateFlow(false)
-
-    fun checkDetailSaved(type: String, id: String) {
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                val sess = session ?: return@launch
-                detailSaved.value = when (type) {
-                    "album" -> Album(sess).isSaved(id)
-                    "artist" -> Artist(sess).isFollowing(id)
-                    else -> false
-                }
-            } catch (_: Exception) { detailSaved.value = false }
-        }
-    }
-
-    fun toggleDetailSaved(type: String, id: String) {
-        launchWithSession("toggleDetailSaved") { sess ->
-            val currentlySaved = detailSaved.value
-            when (type) {
-                "album" -> if (currentlySaved) Album(sess).removeFromLibrary(id) else Album(sess).saveToLibrary(id)
-                "artist" -> if (currentlySaved) Artist(sess).unfollow(id) else Artist(sess).follow(id)
-            }
-            detailSaved.value = !currentlySaved
-        }
-    }
+    // --- Library actions ---
 
     fun removeFromLibrary(item: ch.snepilatch.app.data.LibraryItem) {
         launchWithSession("removeFromLibrary") { sess ->
@@ -3171,12 +2996,6 @@ class SpotifyViewModel : ViewModel() {
         // Slack allowed when bounds-checking a remote seek target against the track duration, so a
         // seek to the very end isn't rejected on rounding/boundary jitter.
         private const val SEEK_BOUNDS_TOLERANCE_MS = 1000L
-
-        /** Page size for playlist/album detail pagination. Matches the limit
-         *  passed to [kotify.api.playlist.Playlist.getPlaylist] in
-         *  [loadMoreDetail]; when a page returns fewer rows than this we've
-         *  reached the end regardless of any server-reported total. */
-        private const val DETAIL_PAGE_SIZE = 50
 
         /** How many times to auto-re-resolve + reload a track (rotating CDN mirrors) after a transient
          *  ExoPlayer/DRM error before skipping to the next track. See [recoverFromPlaybackError]. */

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/DetailViewModelTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/DetailViewModelTest.kt
@@ -1,0 +1,71 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.data.Screen
+import ch.snepilatch.app.playback.SessionHolder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [DetailViewModel]. Like [SearchViewModelTest]/[LyricsViewModelTest] this doesn't mock the
+ * network: with no [SessionHolder.session] a load short-circuits, which lets us pin two contracts —
+ * (1) opening a detail navigates via [Navigator] *before* the load runs, so navigation is unaffected
+ * by session state, and (2) [DetailRoutes] routes to the constructed ViewModel.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DetailViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var vm: DetailViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        SessionHolder.session = null
+        Navigator.reset()
+        vm = DetailViewModel()
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test fun startsClean() {
+        assertEquals("", vm.detail.value.uri)
+        assertFalse(vm.isLoading.value)
+        assertFalse(vm.isLoadingMore.value)
+        assertFalse(vm.detailSaved.value)
+    }
+
+    @Test fun openAlbumNavigatesEvenWithoutSession() {
+        vm.openAlbum("abc")
+        assertEquals(Screen.ALBUM_DETAIL, Navigator.currentScreen.value)
+        // Load short-circuits (no session): loading flag settled, detail untouched.
+        assertFalse(vm.isLoading.value)
+        assertEquals("", vm.detail.value.uri)
+    }
+
+    @Test fun openPlaylistAndArtistNavigateToTheirScreens() {
+        vm.openPlaylist("p1")
+        assertEquals(Screen.PLAYLIST_DETAIL, Navigator.currentScreen.value)
+        vm.openArtist("a1")
+        assertEquals(Screen.ARTIST_DETAIL, Navigator.currentScreen.value)
+    }
+
+    @Test fun detailRoutesForwardsToTheConstructedViewModel() {
+        // SpotifyViewModel's deep-link/playback bridges reach the detail openers through this hop.
+        DetailRoutes.openArtist("a2")
+        assertEquals(Screen.ARTIST_DETAIL, Navigator.currentScreen.value)
+    }
+
+    @Test fun checkDetailSavedDefaultsFalseWithoutSession() {
+        vm.checkDetailSaved("album", "abc")
+        assertFalse(vm.detailSaved.value)
+    }
+}


### PR DESCRIPTION
Second feature-VM extraction, built on the `Navigator` from #441.

## What
- New `DetailViewModel` owns detail state (`detail`/`isLoading`/`isLoadingMore`/`detailSaved`), the openers (playlist/album/artist/show/likedSongs + `openAlbumForTrack`/`openArtistForTrack`), `loadMoreDetail`, and `checkDetailSaved`/`toggleDetailSaved`. Navigates via `Navigator`, reads `Session` from `SessionHolder`.
- Screens (Home/Library/Search/Detail/SharedComponents) obtain it via `viewModel()`. Non-composable builders (Search `toUnified`) and `SpfyViewModel`'s deep-link + playback-context bridges reach the openers through a small `DetailRoutes` registry — no cross-VM references. `SpfyApp` eagerly creates the VM so it's registered before any deep link is processed.
- `SpfyViewModel`: detail code removed; `removeFromLibrary` (a library mutation) stays; orphaned `launchWithSessionLoading` + unused `Podcast` import removed.
- Adds `DetailViewModelTest`; updates CLAUDE.md split strategy (Navigator + DetailRoutes pattern).

## Verified
- Gate green: `assembleProdDebug testProdDebugUnitTest detekt`.
- On device (Samsung, prod-debug): Home→playlist (direct `detailVm`); **player ⋮ → Visit Album → `DetailRoutes` → registered VM → album detail** (the registry path); album save toggle; Search→artist via `DetailRoutes` (with `checkDetailSaved` showing 'Following'); 50-song playlist pagination. All behavior-preserving.

Closes #442