### PR TITLE
refactor: extract LibraryViewModel (library browsing)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ The pre-resolved cache (`nextCdnUrl` + `nextCdnFileId` from `onNextPlaybackId`) 
 
 ## ViewModel split strategy
 
-`SpotifyViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`** (the last built on the shared `Navigator`). Each lands with its own tests.
+`SpotifyViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`, `LibraryViewModel`** (the last two built on the shared `Navigator`). Each lands with its own tests.
 
 **Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `SpotifyViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly — that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `SpotifyViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
 
@@ -70,7 +70,8 @@ Pattern (proven by `SearchViewModel`/`LyricsViewModel`):
 
 **What makes a feature safe to extract now vs. what's blocked:**
 - Clean = the feature reads the session, writes its own state, and navigates through `Navigator`. `Lyrics` needed no navigation at all; `Detail` navigates via `Navigator` and exposes `DetailRoutes` for the `SpotifyViewModel`/non-composable callers.
-- **Still on `SpotifyViewModel`:** `Library`, `Account`, `Devices`. These are now unblocked (Navigator exists) — follow the `DetailViewModel` PR as the template. Watch for cross-feature triggers (e.g. "refresh library after `createPlaylist`"): route them through a small router object like `DetailRoutes`, or inline them in the caller. `removeFromLibrary` stayed on `SpotifyViewModel` with the other library-mutation actions.
+- **`Account` and `Devices` are NOT clean extractions — leave them on `SpotifyViewModel`.** They're playback-coupled: `AccountInfo.isPremium` gates audio-source logic inside the VM, and `activeDeviceName` is written from the playback state handler (`updatePlaybackFromState`) while `loadDevices`/`transferPlayback` need `PlayerConnect`. Extracting them would drag playback state across a VM boundary — the same reason we don't extract playback itself.
+- **`LibraryViewModel`** took the clean part: the library list + pagination + `createPlaylist`/`removeFromLibrary`. It loads in `init` (the old eager load lived in `SpotifyViewModel.initialize`, which runs before any composable exists) and reads `username` from `SessionHolder`. The snackbar-emitting `followArtist`/`savePlaylist` and the add-to-playlist picker stayed on `SpotifyViewModel` (they'd have needed the snackbar channel + a router for non-composable callers) — "add external content to the library" is a separable concern from browsing it.
 
 Don't try to extract playback. The handler-extraction + test rig pattern (see `RemotePlayPauseHandlerTest`) is the safer route for that area.
 

--- a/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
@@ -26,6 +26,10 @@ object SessionHolder {
     @Volatile var spotifyPlayback: SpotifyPlayback? = null
     @Volatile var cdnResolver: SpotifyCdnResolver? = null
 
+    /** The signed-in user's Spotify username. Set during initialize once the profile loads; read by
+     *  library mutations (create/delete/save playlist) that need it. */
+    @Volatile var username: String = ""
+
     /** True if the holder has a ready-to-use session + player + resolver. */
     val isReady: Boolean
         get() = session != null && player != null && cdnResolver != null
@@ -49,5 +53,6 @@ object SessionHolder {
         player = null
         spotifyPlayback = null
         cdnResolver = null
+        username = ""
     }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LibraryScreen.kt
@@ -74,7 +74,7 @@ import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.LibraryViewModel
 
 private const val PREFS_NAME = "kotify_prefs"
 private const val LIKED_SONGS_IMAGE = "https://image-cdn-ak.spotifycdn.com/image/ab67706c0000da84587ecba4a27774b2f6f07174"
@@ -82,9 +82,10 @@ private const val LIKED_SONGS_IMAGE = "https://image-cdn-ak.spotifycdn.com/image
 // --- Library Screen ---
 
 @Composable
-fun LibraryScreen(vm: SpotifyViewModel) {
-    val library by vm.library.collectAsState()
-    val libraryTotal by vm.libraryTotal.collectAsState()
+fun LibraryScreen() {
+    val libraryVm: LibraryViewModel = viewModel()
+    val library by libraryVm.library.collectAsState()
+    val libraryTotal by libraryVm.libraryTotal.collectAsState()
     val libraryHasMore = libraryTotal < 0 || library.size < libraryTotal
     var showCreateDialog by remember { mutableStateOf(false) }
     val context = androidx.compose.ui.platform.LocalContext.current
@@ -262,12 +263,12 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 itemsIndexed(sortedLibrary, key = { _, item -> item.uri }) { index, item ->
-                    LibraryGridCard(item, vm)
+                    LibraryGridCard(item)
                     // Key the near-end trigger on the VISIBLE (filtered/searched) list, not the raw
                     // library — otherwise a filter that shrinks the list below library.size - 10 never
                     // reaches the threshold and pagination silently stops.
                     if (libraryHasMore && index >= sortedLibrary.size - 10) {
-                        LaunchedEffect(sortedLibrary.size) { vm.loadMoreLibrary() }
+                        LaunchedEffect(sortedLibrary.size) { libraryVm.loadMoreLibrary() }
                     }
                 }
             }
@@ -277,11 +278,11 @@ fun LibraryScreen(vm: SpotifyViewModel) {
                 verticalArrangement = Arrangement.spacedBy(0.dp)
             ) {
                 itemsIndexed(sortedLibrary, key = { _, item -> item.uri }) { index, item ->
-                    LibraryListItem(item, vm)
+                    LibraryListItem(item)
                     // See the grid branch: trigger on the visible list size, not the raw library, so
                     // pagination still fires when a filter/search shrinks the list.
                     if (libraryHasMore && index >= sortedLibrary.size - 10) {
-                        LaunchedEffect(sortedLibrary.size) { vm.loadMoreLibrary() }
+                        LaunchedEffect(sortedLibrary.size) { libraryVm.loadMoreLibrary() }
                     }
                 }
             }
@@ -291,7 +292,7 @@ fun LibraryScreen(vm: SpotifyViewModel) {
     if (showCreateDialog) {
         CreatePlaylistDialog(
             onDismiss = { showCreateDialog = false },
-            onCreate = { vm.createPlaylist(it); showCreateDialog = false }
+            onCreate = { libraryVm.createPlaylist(it); showCreateDialog = false }
         )
     }
 }
@@ -320,12 +321,12 @@ fun libraryItemClick(item: LibraryItem, detailVm: DetailViewModel) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun LibraryGridCard(item: LibraryItem, vm: SpotifyViewModel) {
+fun LibraryGridCard(item: LibraryItem) {
     val detailVm: DetailViewModel = viewModel()
     val isArtist = item.type == "artist"
     var showRemove by remember { mutableStateOf(false) }
     if (showRemove && item.type != "collection") {
-        LibraryRemoveDialog(item, vm, onDismiss = { showRemove = false })
+        LibraryRemoveDialog(item, onDismiss = { showRemove = false })
     }
     Column(
         Modifier
@@ -366,12 +367,12 @@ fun LibraryGridCard(item: LibraryItem, vm: SpotifyViewModel) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun LibraryListItem(item: LibraryItem, vm: SpotifyViewModel) {
+fun LibraryListItem(item: LibraryItem) {
     val detailVm: DetailViewModel = viewModel()
     val isArtist = item.type == "artist"
     var showRemove by remember { mutableStateOf(false) }
     if (showRemove && item.type != "collection") {
-        LibraryRemoveDialog(item, vm, onDismiss = { showRemove = false })
+        LibraryRemoveDialog(item, onDismiss = { showRemove = false })
     }
     Row(
         Modifier
@@ -453,7 +454,8 @@ fun CreatePlaylistDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
 }
 
 @Composable
-private fun LibraryRemoveDialog(item: LibraryItem, vm: SpotifyViewModel, onDismiss: () -> Unit) {
+private fun LibraryRemoveDialog(item: LibraryItem, onDismiss: () -> Unit) {
+    val libraryVm: LibraryViewModel = viewModel()
     TightAlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.library_remove_title), color = SpotifyWhite) },
@@ -461,7 +463,7 @@ private fun LibraryRemoveDialog(item: LibraryItem, vm: SpotifyViewModel, onDismi
         containerColor = SpotifyGray,
         confirmButton = {
             TextButton(onClick = {
-                vm.removeFromLibrary(item)
+                libraryVm.removeFromLibrary(item)
                 onDismiss()
             }) {
                 Text(stringResource(R.string.library_remove_button), color = Color.Red)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -49,6 +49,8 @@ import ch.snepilatch.app.ui.components.JukeboxTimeline
 import ch.snepilatch.app.ui.components.rememberSmoothPositionMs
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.formatTime
+import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.snepilatch.app.viewmodel.LibraryViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 /**
@@ -359,6 +361,7 @@ fun NowPlayingScreen(
     /** Drag release with vertical velocity (px/s) so the morph can settle. */
     onMorphDragEnd: ((Float) -> Unit)? = null
 ) {
+    val libraryVm: LibraryViewModel = viewModel()
     // Narrow projections only — positionMs (the 2Hz field) is read exclusively inside PlaybackProgress,
     // so the ~400-line orientation Columns below never recompose on position ticks.
     val track by vm.currentTrack.collectAsState()
@@ -796,7 +799,7 @@ fun NowPlayingScreen(
 
     // Playlist picker dialog
     if (showPlaylistPicker) {
-        val libraryItems by vm.library.collectAsState()
+        val libraryItems by libraryVm.library.collectAsState()
         val playlists = libraryItems.filter { it.type == "playlist" }
         TightAlertDialog(
             onDismissRequest = { showPlaylistPicker = false },

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -57,6 +57,7 @@ import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailViewModel
+import ch.snepilatch.app.viewmodel.LibraryViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
@@ -100,6 +101,9 @@ fun SpotifyApp(vm: SpotifyViewModel) {
     // Eagerly create the DetailViewModel from the post-login shell so it registers itself in
     // DetailRoutes before any deep link or playback-context bridge tries to open a detail.
     viewModel<DetailViewModel>()
+    // LibraryViewModel loads the library in its init; creating it here preloads it for the
+    // playlist picker (openable from any screen's track menu), and backs the picker's list below.
+    val libraryVm: LibraryViewModel = viewModel()
     val screen by vm.currentScreen.collectAsState()
     // Only whether a track exists — collecting the whole PlaybackUiState here would recompose the
     // entire app root twice a second, since the interpolator rewrites positionMs at 2Hz.
@@ -287,7 +291,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
         // Global playlist picker (triggered from TrackRow menu)
         val showPicker by vm.showPlaylistPicker.collectAsState()
         if (showPicker) {
-            val library by vm.library.collectAsState()
+            val library by libraryVm.library.collectAsState()
             val playlists = library.filter { it.type == "playlist" }
             TightAlertDialog(
                 onDismissRequest = { vm.showPlaylistPicker.value = false },
@@ -340,6 +344,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
 
 @Composable
 private fun MainContent(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
+    val libraryVm: LibraryViewModel = viewModel()
     Box(
         Modifier
             .fillMaxSize()
@@ -349,7 +354,7 @@ private fun MainContent(screen: Screen, vm: SpotifyViewModel, hazeState: HazeSta
         when (screen) {
             Screen.HOME -> HomeScreen(vm)
             Screen.SEARCH -> SearchScreen(vm)
-            Screen.LIBRARY -> { LaunchedEffect(Unit) { vm.loadLibrary() }; LibraryScreen(vm) }
+            Screen.LIBRARY -> { LaunchedEffect(Unit) { libraryVm.loadLibrary() }; LibraryScreen() }
             Screen.ACCOUNT -> AccountScreen(vm)
             Screen.QUEUE -> QueueScreen(vm)
             Screen.PLAYLIST_DETAIL, Screen.ALBUM_DETAIL, Screen.ARTIST_DETAIL, Screen.SHOW_DETAIL -> DetailScreen(vm)

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/LibraryViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/LibraryViewModel.kt
@@ -1,0 +1,106 @@
+package ch.snepilatch.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ch.snepilatch.app.data.LibraryItem
+import ch.snepilatch.app.data.toUiLibraryList
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.util.LokiLogger
+import kotify.api.album.Album
+import kotify.api.artist.Artist
+import kotify.api.playlist.Playlist
+import kotify.session.Session
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the "Your Library" screen: the saved list + pagination, plus create/remove.
+ *
+ * Reads the session (and, for mutations, the username) from [SessionHolder], and loads the first
+ * page in [init] — the old eager load lived in `SpotifyViewModel.initialize`, which runs before any
+ * composable exists; loading here instead fires as soon as the post-login shell composes this VM,
+ * which is well before the library-backed playlist picker can be opened.
+ *
+ * `followArtist`/`savePlaylist` and the add-to-playlist picker stay on [SpotifyViewModel] — they emit
+ * snackbars and are triggered from non-composable search builders, i.e. "add external content to the
+ * library" rather than browsing it.
+ */
+class LibraryViewModel : ViewModel() {
+
+    private val tag = "LibraryVM"
+
+    private val _library = MutableStateFlow<List<LibraryItem>>(emptyList())
+    val library: StateFlow<List<LibraryItem>> = _library
+    private val _libraryTotal = MutableStateFlow(-1)
+    val libraryTotal: StateFlow<Int> = _libraryTotal
+    private val _isLoadingMore = MutableStateFlow(false)
+    val isLoadingMore: StateFlow<Boolean> = _isLoadingMore
+
+    init { loadLibrary() }
+
+    fun loadLibrary() {
+        launchSession("loadLibrary") { sess ->
+            val page = Playlist(sess).getLibrary(limit = 50, offset = 0)
+            _library.value = page.toUiLibraryList()
+            _libraryTotal.value = page.total
+        }
+    }
+
+    fun loadMoreLibrary() {
+        if (_isLoadingMore.value) return
+        val loaded = _library.value.size
+        val total = _libraryTotal.value
+        if (total in 0..loaded) return
+        _isLoadingMore.value = true
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                val sess = SessionHolder.session ?: return@launch
+                val page = Playlist(sess).getLibrary(limit = 50, offset = loaded)
+                val more = page.toUiLibraryList()
+                _library.value = _library.value + more
+                _libraryTotal.value = page.total
+            } catch (e: Exception) {
+                LokiLogger.e(tag, "loadMoreLibrary", e)
+            } finally {
+                _isLoadingMore.value = false
+            }
+        }
+    }
+
+    fun removeFromLibrary(item: LibraryItem) {
+        launchSession("removeFromLibrary") { sess ->
+            val id = item.uri.substringAfterLast(":")
+            when (item.type) {
+                "album" -> Album(sess).removeFromLibrary(id)
+                "artist" -> Artist(sess).unfollow(id)
+                "playlist" -> Playlist(sess).deletePlaylist(id, SessionHolder.username)
+            }
+            loadLibrary()
+        }
+    }
+
+    fun createPlaylist(name: String) {
+        launchSession("createPlaylist") { sess ->
+            Playlist(sess).createPlaylist(name, SessionHolder.username)
+            delay(1000)
+            loadLibrary()
+        }
+    }
+
+    private fun launchSession(tag: String, block: suspend (Session) -> Unit): Job =
+        viewModelScope.launch(Dispatchers.IO) {
+            val sess = SessionHolder.session ?: return@launch
+            try {
+                block(sess)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LokiLogger.e(this@LibraryViewModel.tag, tag, e)
+            }
+        }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -16,7 +16,6 @@ import ch.snepilatch.app.playback.SessionHolder
 import ch.snepilatch.app.playback.engine.SpotifyCdnResolver
 import ch.snepilatch.app.playback.engine.SpotifyStream
 import ch.snepilatch.app.data.*
-import kotify.api.album.Album
 import kotify.api.artist.Artist
 import kotify.api.home.Home
 import kotify.api.home.HomeData
@@ -241,13 +240,8 @@ class SpotifyViewModel : ViewModel() {
 
     // Search state was extracted into SearchViewModel — see viewmodel/SearchViewModel.kt
 
-    // Library
-    private val _library = MutableStateFlow<List<LibraryItem>>(emptyList())
-    val library: StateFlow<List<LibraryItem>> = _library
-    private val _libraryTotal = MutableStateFlow(-1)
-    val libraryTotal: StateFlow<Int> = _libraryTotal
-    private val _isLoadingMoreLibrary = MutableStateFlow(false)
-    val isLoadingMoreLibrary: StateFlow<Boolean> = _isLoadingMoreLibrary
+    // Library list + pagination moved to LibraryViewModel. followArtist/savePlaylist and the
+    // add-to-playlist picker stay here (snackbar + non-composable callers).
 
     // Queue
     private val _queue = MutableStateFlow<List<TrackInfo>>(emptyList())
@@ -389,14 +383,14 @@ class SpotifyViewModel : ViewModel() {
                 cdnResolver = SpotifyCdnResolver(sess, sp)
                 LokiLogger.i(TAG, "Session loaded")
 
-                // Start loading home and library immediately after session is ready
-                // These run in parallel with user profile and player setup
+                // Start loading home immediately after session is ready, in parallel with user
+                // profile and player setup. The library loads itself from LibraryViewModel.init.
                 loadHome()
-                loadLibrary()
 
                 val userApi = User(sess)
                 val me = userApi.getCurrentUser()
                 username = me.username
+                SessionHolder.username = me.username
                 val isPremium = userApi.hasPremium()
                 // Get public profile (display name + avatar) from user-profile-view API
                 val pubProfile = userApi.getProfile(username)
@@ -2835,48 +2829,6 @@ class SpotifyViewModel : ViewModel() {
         }
     }
 
-    // --- Library ---
-
-    fun loadLibrary() {
-        launchWithSession("loadLibrary") { sess ->
-            val page = Playlist(sess).getLibrary(limit = 50, offset = 0)
-            _library.value = page.toUiLibraryList()
-            _libraryTotal.value = page.total
-        }
-    }
-
-    fun loadMoreLibrary() {
-        if (_isLoadingMoreLibrary.value) return
-        val loaded = _library.value.size
-        val total = _libraryTotal.value
-        if (total in 0..loaded) return
-        _isLoadingMoreLibrary.value = true
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                val sess = session ?: return@launch
-                val page = Playlist(sess).getLibrary(limit = 50, offset = loaded)
-                val more = page.toUiLibraryList()
-                _library.value = _library.value + more
-                _libraryTotal.value = page.total
-            } catch (e: Exception) { LokiLogger.e(TAG, "loadMoreLibrary", e) }
-            finally { _isLoadingMoreLibrary.value = false }
-        }
-    }
-
-    // --- Library actions ---
-
-    fun removeFromLibrary(item: ch.snepilatch.app.data.LibraryItem) {
-        launchWithSession("removeFromLibrary") { sess ->
-            val id = item.uri.substringAfterLast(":")
-            when (item.type) {
-                "album" -> Album(sess).removeFromLibrary(id)
-                "artist" -> Artist(sess).unfollow(id)
-                "playlist" -> kotify.api.playlist.Playlist(sess).deletePlaylist(id, username)
-            }
-            loadLibrary()
-        }
-    }
-
     // --- Devices ---
 
     fun loadDevices() {
@@ -2908,14 +2860,6 @@ class SpotifyViewModel : ViewModel() {
 
     // --- Playlist Management ---
 
-    fun createPlaylist(name: String) {
-        launchWithSession("createPlaylist") { sess ->
-            Playlist(sess).createPlaylist(name, username)
-            delay(1000)
-            loadLibrary()
-        }
-    }
-
     fun followArtist(artistId: String) {
         launchWithSession("followArtist") { sess ->
             Artist(sess).follow(artistId)
@@ -2930,10 +2874,6 @@ class SpotifyViewModel : ViewModel() {
             kotify.api.playlist.Playlist(sess).saveToLibrary(playlistId, username)
             _snackbarMessage.tryEmit("Saved to Library")
         }
-    }
-
-    fun unfollowArtist(artistId: String) {
-        launchWithSession("unfollowArtist") { sess -> Artist(sess).unfollow(artistId) }
     }
 
     /** Extract a fresh palette only when the art URL actually changed since the last extraction. */

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/LibraryViewModelTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/LibraryViewModelTest.kt
@@ -1,0 +1,60 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.playback.SessionHolder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [LibraryViewModel]. Like the other feature-VM tests this uses the no-session path
+ * ([SessionHolder.session] == null), where every load short-circuits — so we pin the local-state
+ * contract: construction (which kicks off the init load) and the loaders never populate the list or
+ * crash without a session.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var vm: LibraryViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        SessionHolder.session = null
+        vm = LibraryViewModel()
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test fun startsClean() {
+        // init { loadLibrary() } ran, but with no session it's a no-op.
+        assertTrue(vm.library.value.isEmpty())
+        assertEquals(-1, vm.libraryTotal.value)
+        assertFalse(vm.isLoadingMore.value)
+    }
+
+    @Test fun loadLibraryWithoutSessionKeepsListEmpty() {
+        vm.loadLibrary()
+        assertTrue(vm.library.value.isEmpty())
+        assertEquals(-1, vm.libraryTotal.value)
+    }
+
+    @Test fun loadMoreWithoutSessionKeepsListEmpty() {
+        vm.loadMoreLibrary()
+        assertTrue(vm.library.value.isEmpty())
+    }
+
+    @Test fun createPlaylistWithoutSessionIsSafeNoOp() {
+        vm.createPlaylist("My Playlist")
+        assertTrue(vm.library.value.isEmpty())
+    }
+}

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -7,7 +7,7 @@
     <ID>BlockCommentInitialStarAlignment:Type.kt$/* Other default text styles to override titleLarge = TextStyle( fontFamily = FontFamily.Default, fontWeight = FontWeight.Normal, fontSize = 22.sp, lineHeight = 28.sp, letterSpacing = 0.sp ), labelSmall = TextStyle( fontFamily = FontFamily.Default, fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 16.sp, letterSpacing = 0.5.sp ) */</ID>
     <ID>CyclomaticComplexMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: SpotifyViewModel)</ID>
-    <ID>CyclomaticComplexMethod:LibraryScreen.kt$@Composable fun LibraryScreen(vm: SpotifyViewModel)</ID>
+    <ID>CyclomaticComplexMethod:LibraryScreen.kt$@Composable fun LibraryScreen()</ID>
     <ID>CyclomaticComplexMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
     <ID>CyclomaticComplexMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: SpotifyViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
     <ID>CyclomaticComplexMethod:SpotifyApp.kt$@Composable fun SpotifyApp(vm: SpotifyViewModel)</ID>
@@ -30,7 +30,7 @@
     <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun AlbumTrackRow( track: ch.snepilatch.app.data.TrackInfo, vm: SpotifyViewModel, contextUri: String, trackIndex: Int? = null )</ID>
     <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun ArtistTrackRow( number: Int, track: ch.snepilatch.app.data.TrackInfo, vm: SpotifyViewModel, contextUri: String, playcount: String? = null )</ID>
     <ID>LongMethod:DevicesDialog.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun DevicesDialog(vm: SpotifyViewModel)</ID>
-    <ID>LongMethod:LibraryScreen.kt$@Composable fun LibraryScreen(vm: SpotifyViewModel)</ID>
+    <ID>LongMethod:LibraryScreen.kt$@Composable fun LibraryScreen()</ID>
     <ID>LongMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
     <ID>LongMethod:MainActivity.kt$MainActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:NowPlayingScreen.kt$@Composable fun PlayerBackground(vm: SpotifyViewModel, modifier: Modifier = Modifier)</ID>


### PR DESCRIPTION
Third feature-VM extraction, following the DetailViewModel template.

## What
- New `LibraryViewModel` owns the saved library list + pagination + `createPlaylist`/`removeFromLibrary`. It loads in `init` (the old eager load in `SpfyViewModel.initialize` ran before any composable existed) and reads `username` from `SessionHolder` (lifted there so mutations reach it).
- **LibraryScreen is now fully decoupled from `SpfyViewModel`** — `vm` dropped from it and its cards. The playlist picker (SpfyApp + NowPlayingScreen) reads `libraryVm.library`.
- `followArtist`/`savePlaylist` and the add-to-playlist flow stay on `SpfyViewModel` (snackbar + non-composable callers). Dead `unfollowArtist` and the now-unused `Album` import removed.
- No registry needed — all callers are composable. Adds `LibraryViewModelTest`; detekt baseline updated for LibraryScreen's new signature; CLAUDE.md notes Account/Devices are playback-coupled and stay.

## Verified
- Gate green: `assembleProdDebug testProdDebugUnitTest detekt`.
- On device (Samsung, prod-debug): Library tab loads the saved list, pagination scrolls deep past the first page, and the Add-to-Playlist picker shows the user's playlists (reads `libraryVm.library`). Mutations (create/remove/add) are verbatim moves and were intentionally not executed against the real account.

Closes #444