### PR TITLE
refactor: extract HomeViewModel (home feed)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ The pre-resolved cache (`nextCdnUrl` + `nextCdnFileId` from `onNextPlaybackId`) 
 
 ## ViewModel split strategy
 
-`SpotifyViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`, `LibraryViewModel`** (the last two built on the shared `Navigator`). Each lands with its own tests.
+`SpotifyViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`, `LibraryViewModel`, `HomeViewModel`** (Detail/Library built on the shared `Navigator`; Home/Library load their feed in `init`). Each lands with its own tests. That's the clean feature set — what's left on `SpotifyViewModel` is playback, the playback-coupled features (Queue/Account/Devices), and cross-cutting settings/theme.
 
 **Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `SpotifyViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly — that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `SpotifyViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -48,14 +48,16 @@ import ch.snepilatch.app.ui.theme.SpotifyCardBg
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailViewModel
+import ch.snepilatch.app.viewmodel.HomeViewModel
 import ch.snepilatch.app.viewmodel.SpotifyViewModel
 
 // --- Home Screen ---
 
 @Composable
 fun HomeScreen(vm: SpotifyViewModel) {
-    val homeData by vm.homeData.collectAsState()
-    val isHomeLoading by vm.isHomeLoading.collectAsState()
+    val homeVm: HomeViewModel = viewModel()
+    val homeData by homeVm.homeData.collectAsState()
+    val isHomeLoading by homeVm.isLoading.collectAsState()
 
     if (isHomeLoading && homeData == null) {
         HomeShimmer()

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/HomeViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/HomeViewModel.kt
@@ -1,0 +1,59 @@
+package ch.snepilatch.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.util.LokiLogger
+import kotify.api.home.Home
+import kotify.api.home.HomeData
+import kotify.session.Session
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * ViewModel for the Home feed. Loads the feed in [init] — the old eager load lived in
+ * `SpotifyViewModel.initialize`, which runs before any composable exists; loading here fires as soon
+ * as the Home screen composes (the default post-login screen), with [isLoading] driving the shimmer
+ * until the first feed arrives.
+ *
+ * HomeScreen keeps [SpotifyViewModel] (for `playTrack`) and [DetailViewModel] (for opening items);
+ * this VM only owns the feed data.
+ */
+class HomeViewModel : ViewModel() {
+
+    private val tag = "HomeVM"
+
+    private val _homeData = MutableStateFlow<HomeData?>(null)
+    val homeData: StateFlow<HomeData?> = _homeData
+    val isLoading = MutableStateFlow(true)
+
+    init { loadHome() }
+
+    fun loadHome() {
+        launchSession("loadHome") { sess ->
+            try {
+                val feed = Home(sess).getHomeFeed()
+                _homeData.value = feed
+                LokiLogger.i(tag, "Home loaded: ${feed?.sections?.size} sections")
+            } finally {
+                isLoading.value = false
+            }
+        }
+    }
+
+    private fun launchSession(tag: String, block: suspend (Session) -> Unit): Job =
+        viewModelScope.launch(Dispatchers.IO) {
+            val sess = SessionHolder.session ?: return@launch
+            try {
+                block(sess)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LokiLogger.e(this@HomeViewModel.tag, tag, e)
+            }
+        }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt
@@ -17,8 +17,6 @@ import ch.snepilatch.app.playback.engine.SpotifyCdnResolver
 import ch.snepilatch.app.playback.engine.SpotifyStream
 import ch.snepilatch.app.data.*
 import kotify.api.artist.Artist
-import kotify.api.home.Home
-import kotify.api.home.HomeData
 import kotify.api.playerconnect.PlayerConnect
 import kotify.api.playlist.Playlist
 import kotify.api.playerstatus.DeviceInfo
@@ -233,10 +231,7 @@ class SpotifyViewModel : ViewModel() {
     private var commandJob: Job? = null
     private var userPlayJob: Job? = null  // Cancel an in-flight user-initiated play when another track is tapped
 
-    // Home
-    private val _homeData = MutableStateFlow<HomeData?>(null)
-    val homeData: StateFlow<HomeData?> = _homeData
-    val isHomeLoading = MutableStateFlow(true)
+    // Home feed moved to HomeViewModel.
 
     // Search state was extracted into SearchViewModel — see viewmodel/SearchViewModel.kt
 
@@ -383,9 +378,7 @@ class SpotifyViewModel : ViewModel() {
                 cdnResolver = SpotifyCdnResolver(sess, sp)
                 LokiLogger.i(TAG, "Session loaded")
 
-                // Start loading home immediately after session is ready, in parallel with user
-                // profile and player setup. The library loads itself from LibraryViewModel.init.
-                loadHome()
+                // Home and library load themselves from HomeViewModel.init / LibraryViewModel.init.
 
                 val userApi = User(sess)
                 val me = userApi.getCurrentUser()
@@ -2812,20 +2805,6 @@ class SpotifyViewModel : ViewModel() {
             }
         } catch (e: Exception) {
             LokiLogger.e(TAG, "preResolveNextTrack failed", e)
-        }
-    }
-
-    // --- Home ---
-
-    private fun loadHome() {
-        launchWithSession("loadHome") { sess ->
-            try {
-                val feed = Home(sess).getHomeFeed()
-                _homeData.value = feed
-                LokiLogger.i(TAG, "Home loaded: ${feed?.sections?.size} sections")
-            } finally {
-                isHomeLoading.value = false
-            }
         }
     }
 

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/HomeViewModelTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/HomeViewModelTest.kt
@@ -1,0 +1,44 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.playback.SessionHolder
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [HomeViewModel]. Like the other feature-VM tests this uses the no-session path
+ * ([SessionHolder.session] == null): construction kicks off the init load, which short-circuits, so
+ * the feed stays null and nothing crashes.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var vm: HomeViewModel
+
+    @Before fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        SessionHolder.session = null
+        vm = HomeViewModel()
+    }
+
+    @After fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test fun startsWithNoFeed() {
+        // init { loadHome() } ran, but with no session it's a no-op.
+        assertNull(vm.homeData.value)
+    }
+
+    @Test fun loadHomeWithoutSessionKeepsFeedNull() {
+        vm.loadHome()
+        assertNull(vm.homeData.value)
+    }
+}


### PR DESCRIPTION
Final clean feature-VM extraction.

## What
- New `HomeViewModel` owns `homeData` + the loading flag + `loadHome` (session-only). Loads in `init` (the old eager load in `SpfyViewModel.initialize` ran before any composable existed); the Home screen is the default post-login screen so this fires immediately, shimmer until the feed arrives.
- HomeScreen keeps `SpfyViewModel` (playTrack) + `DetailViewModel` (opens), reads the feed from `HomeViewModel`. Unused `Home`/`HomeData` imports removed. Adds `HomeViewModelTest`.

## Verified
- Gate green: `assembleProdDebug testProdDebugUnitTest detekt`.
- On device (Samsung, prod-debug): fresh cold launch loads the full home feed (quick-picks, Made For You mixes, Jump back in) via `HomeViewModel.init`. Behavior-preserving.

After this the clean feature set is done — what's left on `SpfyViewModel` is playback, playback-coupled features (Queue/Account/Devices), and cross-cutting settings/theme.

Closes #446