### PR TITLE
refactor: hoist feature ViewModels' session-launch helpers into a base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,8 @@ The pre-resolved cache (`nextCdnUrl` + `nextCdnFileId` from `onNextPlaybackId`) 
 **Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `SpotifyViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly — that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `SpotifyViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
 
 Pattern (proven by `SearchViewModel`/`LyricsViewModel`):
-1. Move the feature's state + methods into a new `<Feature>ViewModel : ViewModel()`.
-2. It reads `Session` from `SessionHolder` and rolls its own small `launchWith…` helper (the ones on `SpotifyViewModel` are private; copy the shape).
+1. Move the feature's state + methods into a new `<Feature>ViewModel : SessionViewModel("<Tag>")`.
+2. `SessionViewModel` (the base for all five feature VMs) provides `launchWithSession(op) { sess -> }` and `launchWithSessionLoading(op, loadingFlag) { sess -> }` — both null-check `SessionHolder.session`, rethrow cancellation, and log against the tag. Don't re-roll these. `SpotifyViewModel` is NOT a `SessionViewModel` (it owns the session lifecycle and needs player-scoped launches too).
 3. A screen can hold **both** ViewModels at once — obtain the feature VM in the body with `val featureVm: <Feature>ViewModel = viewModel()`. `LyricsScreen` reads playback/transport/theme from `SpotifyViewModel` and lyrics content from `LyricsViewModel` side by side. The feature VM doesn't need to own the whole screen.
 4. Pass the inputs the feature needs down from the screen (e.g. `lyricsVm.fetch(track.uri)`), rather than having the feature VM reach back into `SpotifyViewModel` state.
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
@@ -1,6 +1,5 @@
 package ch.snepilatch.app.viewmodel
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.snepilatch.app.data.*
 import ch.snepilatch.app.playback.SessionHolder
@@ -11,9 +10,7 @@ import kotify.api.playlist.Playlist
 import kotify.api.podcast.Podcast
 import kotify.api.song.Song
 import kotify.session.Session
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -31,9 +28,7 @@ import kotlinx.coroutines.launch
  * need PlayerConnect / playingContext, so they stay there and reach the openers
  * through [DetailRoutes] rather than holding a reference to this ViewModel.
  */
-class DetailViewModel : ViewModel() {
-
-    private val tag = "DetailVM"
+class DetailViewModel : SessionViewModel("DetailVM") {
 
     private val _detail = MutableStateFlow(DetailData())
     val detail: StateFlow<DetailData> = _detail
@@ -54,9 +49,9 @@ class DetailViewModel : ViewModel() {
 
     /** Navigate to a detail screen and load it under [isLoading]; a null result leaves the previous
      *  detail unchanged (used by openShow when the podcast has no info). */
-    private fun openDetail(screen: Screen, tag: String, load: suspend (Session) -> DetailData?) {
+    private fun openDetail(screen: Screen, op: String, load: suspend (Session) -> DetailData?) {
         Navigator.navigateTo(screen)
-        launchLoading(tag) { sess -> load(sess)?.let { _detail.value = it } }
+        launchWithSessionLoading(op, isLoading) { sess -> load(sess)?.let { _detail.value = it } }
     }
 
     fun openLikedSongs() = openDetail(Screen.PLAYLIST_DETAIL, "openLikedSongs") { sess ->
@@ -84,23 +79,23 @@ class DetailViewModel : ViewModel() {
         openDetail(Screen.SHOW_DETAIL, "openShow") { sess ->
             Podcast(sess, showId).getPodcastInfo(limit = 50, offset = 0)
                 ?.toDetailData(showId, publisher, imageUrl)
-                .also { if (it == null) LokiLogger.e(tag, "openShow: no podcast info for $showId") }
+                .also { if (it == null) LokiLogger.e(logTag, "openShow: no podcast info for $showId") }
         }
 
     fun openAlbumForTrack(trackUri: String) {
-        launchSession("openAlbumForTrack") { sess ->
+        launchWithSession("openAlbumForTrack") { sess ->
             val trackId = trackUri.removePrefix("spotify:track:")
-            val track = Song(sess).getSong(trackId) ?: return@launchSession
-            val albumUri = track.album.uri.takeIf { it.isNotBlank() } ?: return@launchSession
+            val track = Song(sess).getSong(trackId) ?: return@launchWithSession
+            val albumUri = track.album.uri.takeIf { it.isNotBlank() } ?: return@launchWithSession
             openAlbum(albumUri.substringAfterLast(":"))
         }
     }
 
     fun openArtistForTrack(trackUri: String) {
-        launchSession("openArtistForTrack") { sess ->
+        launchWithSession("openArtistForTrack") { sess ->
             val trackId = trackUri.removePrefix("spotify:track:")
-            val track = Song(sess).getSong(trackId) ?: return@launchSession
-            val artistUri = track.artists.firstOrNull()?.uri?.takeIf { it.isNotBlank() } ?: return@launchSession
+            val track = Song(sess).getSong(trackId) ?: return@launchWithSession
+            val artistUri = track.artists.firstOrNull()?.uri?.takeIf { it.isNotBlank() } ?: return@launchWithSession
             openArtist(artistUri.substringAfterLast(":"))
         }
     }
@@ -165,7 +160,7 @@ class DetailViewModel : ViewModel() {
                     )
                 }
             } catch (e: Exception) {
-                LokiLogger.e(tag, "loadMoreDetail", e)
+                LokiLogger.e(logTag, "loadMoreDetail", e)
             } finally {
                 _isLoadingMore.value = false
             }
@@ -186,7 +181,7 @@ class DetailViewModel : ViewModel() {
     }
 
     fun toggleDetailSaved(type: String, id: String) {
-        launchSession("toggleDetailSaved") { sess ->
+        launchWithSession("toggleDetailSaved") { sess ->
             val currentlySaved = detailSaved.value
             when (type) {
                 "album" -> if (currentlySaved) Album(sess).removeFromLibrary(id) else Album(sess).saveToLibrary(id)
@@ -195,33 +190,6 @@ class DetailViewModel : ViewModel() {
             detailSaved.value = !currentlySaved
         }
     }
-
-    private fun launchSession(tag: String, block: suspend (Session) -> Unit): Job =
-        viewModelScope.launch(Dispatchers.IO) {
-            val sess = SessionHolder.session ?: return@launch
-            try {
-                block(sess)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                LokiLogger.e(this@DetailViewModel.tag, tag, e)
-            }
-        }
-
-    private fun launchLoading(tag: String, block: suspend (Session) -> Unit): Job =
-        viewModelScope.launch(Dispatchers.IO) {
-            val sess = SessionHolder.session ?: return@launch
-            isLoading.value = true
-            try {
-                block(sess)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                LokiLogger.e(this@DetailViewModel.tag, tag, e)
-            } finally {
-                isLoading.value = false
-            }
-        }
 
     companion object {
         private const val DETAIL_PAGE_SIZE = 50

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/HomeViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/HomeViewModel.kt
@@ -1,18 +1,10 @@
 package ch.snepilatch.app.viewmodel
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import ch.snepilatch.app.playback.SessionHolder
 import ch.snepilatch.app.util.LokiLogger
 import kotify.api.home.Home
 import kotify.api.home.HomeData
-import kotify.session.Session
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the Home feed. Loads the feed in [init] — the old eager load lived in
@@ -23,9 +15,7 @@ import kotlinx.coroutines.launch
  * HomeScreen keeps [SpotifyViewModel] (for `playTrack`) and [DetailViewModel] (for opening items);
  * this VM only owns the feed data.
  */
-class HomeViewModel : ViewModel() {
-
-    private val tag = "HomeVM"
+class HomeViewModel : SessionViewModel("HomeVM") {
 
     private val _homeData = MutableStateFlow<HomeData?>(null)
     val homeData: StateFlow<HomeData?> = _homeData
@@ -34,26 +24,14 @@ class HomeViewModel : ViewModel() {
     init { loadHome() }
 
     fun loadHome() {
-        launchSession("loadHome") { sess ->
+        launchWithSession("loadHome") { sess ->
             try {
                 val feed = Home(sess).getHomeFeed()
                 _homeData.value = feed
-                LokiLogger.i(tag, "Home loaded: ${feed?.sections?.size} sections")
+                LokiLogger.i(logTag, "Home loaded: ${feed?.sections?.size} sections")
             } finally {
                 isLoading.value = false
             }
         }
     }
-
-    private fun launchSession(tag: String, block: suspend (Session) -> Unit): Job =
-        viewModelScope.launch(Dispatchers.IO) {
-            val sess = SessionHolder.session ?: return@launch
-            try {
-                block(sess)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                LokiLogger.e(this@HomeViewModel.tag, tag, e)
-            }
-        }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/LibraryViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/LibraryViewModel.kt
@@ -1,6 +1,5 @@
 package ch.snepilatch.app.viewmodel
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ch.snepilatch.app.data.LibraryItem
 import ch.snepilatch.app.data.toUiLibraryList
@@ -9,10 +8,7 @@ import ch.snepilatch.app.util.LokiLogger
 import kotify.api.album.Album
 import kotify.api.artist.Artist
 import kotify.api.playlist.Playlist
-import kotify.session.Session
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -30,9 +26,7 @@ import kotlinx.coroutines.launch
  * snackbars and are triggered from non-composable search builders, i.e. "add external content to the
  * library" rather than browsing it.
  */
-class LibraryViewModel : ViewModel() {
-
-    private val tag = "LibraryVM"
+class LibraryViewModel : SessionViewModel("LibraryVM") {
 
     private val _library = MutableStateFlow<List<LibraryItem>>(emptyList())
     val library: StateFlow<List<LibraryItem>> = _library
@@ -44,7 +38,7 @@ class LibraryViewModel : ViewModel() {
     init { loadLibrary() }
 
     fun loadLibrary() {
-        launchSession("loadLibrary") { sess ->
+        launchWithSession("loadLibrary") { sess ->
             val page = Playlist(sess).getLibrary(limit = 50, offset = 0)
             _library.value = page.toUiLibraryList()
             _libraryTotal.value = page.total
@@ -65,7 +59,7 @@ class LibraryViewModel : ViewModel() {
                 _library.value = _library.value + more
                 _libraryTotal.value = page.total
             } catch (e: Exception) {
-                LokiLogger.e(tag, "loadMoreLibrary", e)
+                LokiLogger.e(logTag, "loadMoreLibrary", e)
             } finally {
                 _isLoadingMore.value = false
             }
@@ -73,7 +67,7 @@ class LibraryViewModel : ViewModel() {
     }
 
     fun removeFromLibrary(item: LibraryItem) {
-        launchSession("removeFromLibrary") { sess ->
+        launchWithSession("removeFromLibrary") { sess ->
             val id = item.uri.substringAfterLast(":")
             when (item.type) {
                 "album" -> Album(sess).removeFromLibrary(id)
@@ -85,22 +79,10 @@ class LibraryViewModel : ViewModel() {
     }
 
     fun createPlaylist(name: String) {
-        launchSession("createPlaylist") { sess ->
+        launchWithSession("createPlaylist") { sess ->
             Playlist(sess).createPlaylist(name, SessionHolder.username)
             delay(1000)
             loadLibrary()
         }
     }
-
-    private fun launchSession(tag: String, block: suspend (Session) -> Unit): Job =
-        viewModelScope.launch(Dispatchers.IO) {
-            val sess = SessionHolder.session ?: return@launch
-            try {
-                block(sess)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                LokiLogger.e(this@LibraryViewModel.tag, tag, e)
-            }
-        }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/LyricsViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/LyricsViewModel.kt
@@ -1,18 +1,10 @@
 package ch.snepilatch.app.viewmodel
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import ch.snepilatch.app.playback.SessionHolder
-import ch.snepilatch.app.util.LokiLogger
 import kotify.api.lyrics.Lyrics
 import kotify.api.lyrics.LyricsData
-import kotify.session.Session
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the lyrics overlay's content.
@@ -20,12 +12,10 @@ import kotlinx.coroutines.launch
  * Owns only the lyrics *data* concern (fetch + result + loading flag). The
  * [ch.snepilatch.app.ui.screens.LyricsScreen] still reads playback state,
  * transport controls and theme from [SpotifyViewModel]; the two ViewModels
- * sit side by side on the screen. Navigation to the overlay stays on
+ * sit side by side. Navigation to the overlay stays on
  * [SpotifyViewModel.openLyrics] — this class never navigates.
  */
-class LyricsViewModel : ViewModel() {
-
-    private val tag = "LyricsVM"
+class LyricsViewModel : SessionViewModel("LyricsVM") {
 
     private val _lyrics = MutableStateFlow<LyricsData?>(null)
     val lyrics: StateFlow<LyricsData?> = _lyrics
@@ -41,7 +31,7 @@ class LyricsViewModel : ViewModel() {
     fun fetch(trackUri: String) {
         if (trackUri == lastTrackUri && _lyrics.value != null) return
         lastTrackUri = trackUri
-        launchLoading { sess ->
+        launchWithSessionLoading("fetch", isLoading) { sess ->
             try {
                 val trackId = trackUri.removePrefix("spotify:track:")
                 _lyrics.value = Lyrics(sess).getLyrics(trackId)
@@ -54,19 +44,4 @@ class LyricsViewModel : ViewModel() {
             }
         }
     }
-
-    private fun launchLoading(block: suspend (Session) -> Unit): Job =
-        viewModelScope.launch(Dispatchers.IO) {
-            val sess = SessionHolder.session ?: return@launch
-            isLoading.value = true
-            try {
-                block(sess)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                LokiLogger.e(tag, "fetch", e)
-            } finally {
-                isLoading.value = false
-            }
-        }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SearchViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SearchViewModel.kt
@@ -1,20 +1,13 @@
 package ch.snepilatch.app.viewmodel
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import ch.snepilatch.app.playback.SessionHolder
 import ch.snepilatch.app.util.LokiLogger
 import kotify.api.song.SearchResult
 import kotify.api.song.SearchSuggestion
 import kotify.api.song.Song
-import kotify.session.Session
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the Spotify-style search screen.
@@ -29,9 +22,7 @@ import kotlinx.coroutines.launch
  *    results from [results]. The user got here by tapping a suggestion or
  *    pressing the keyboard's search action.
  */
-class SearchViewModel : ViewModel() {
-
-    private val tag = "SearchVM"
+class SearchViewModel : SessionViewModel("SearchVM") {
 
     val query = MutableStateFlow("")
 
@@ -127,7 +118,7 @@ class SearchViewModel : ViewModel() {
                 if (submittedQuery.value == text) {
                     _results.value = response
                     LokiLogger.i(
-                        tag,
+                        logTag,
                         "Search '$text': tracks=${response.tracks.items.size}, " +
                             "artists=${response.artists.items.size}, " +
                             "albums=${response.albums.items.size}, " +
@@ -141,18 +132,6 @@ class SearchViewModel : ViewModel() {
             }
         }
     }
-
-    private fun launchWithSession(label: String, block: suspend (Session) -> Unit): Job =
-        viewModelScope.launch(Dispatchers.IO) {
-            val sess = SessionHolder.session ?: return@launch
-            try {
-                block(sess)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                LokiLogger.e(tag, label, e)
-            }
-        }
 
     companion object {
         private const val MIN_SUGGEST_LENGTH = 2

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SessionViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SessionViewModel.kt
@@ -1,0 +1,57 @@
+package ch.snepilatch.app.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.util.LokiLogger
+import kotify.session.Session
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Base for the feature ViewModels that only read the Kotify [Session] from [SessionHolder]
+ * (Search / Lyrics / Detail / Library / Home). Centralizes the "launch on IO, null-check the
+ * session, rethrow cancellation, log everything else against [logTag]" boilerplate each of them
+ * was duplicating.
+ *
+ * Not used by [SpotifyViewModel], which owns the session lifecycle and also needs player-scoped
+ * launches.
+ */
+abstract class SessionViewModel(protected val logTag: String) : ViewModel() {
+
+    /** Launch [block] on IO with a non-null session; rethrows cancellation, logs other failures. */
+    protected fun launchWithSession(op: String, block: suspend (Session) -> Unit): Job =
+        viewModelScope.launch(Dispatchers.IO) {
+            val sess = SessionHolder.session ?: return@launch
+            try {
+                block(sess)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LokiLogger.e(logTag, op, e)
+            }
+        }
+
+    /** [launchWithSession] that flips [loading] true around the block and always resets it. */
+    protected fun launchWithSessionLoading(
+        op: String,
+        loading: MutableStateFlow<Boolean>,
+        block: suspend (Session) -> Unit
+    ): Job =
+        viewModelScope.launch(Dispatchers.IO) {
+            val sess = SessionHolder.session ?: return@launch
+            loading.value = true
+            try {
+                block(sess)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LokiLogger.e(logTag, op, e)
+            } finally {
+                loading.value = false
+            }
+        }
+}


### PR DESCRIPTION
Follow-up KISS pass on the just-completed decomposition.

## What
The five feature ViewModels (Search/Lyrics/Detail/Library/Home) each duplicated the same `launchWithSession` helper — launch on IO, null-check `SessionHolder.session`, rethrow cancellation, log the rest — and two of them the loading-flag variant. Pull both into a shared `SessionViewModel` base; each VM now `extends SessionViewModel("<Tag>")` and drops its private copy.

`SpfyViewModel` intentionally stays off the base — it owns the session lifecycle and also needs player-scoped launches.

## Verified
- Gate green: `assembleProdDebug testProdDebugUnitTest detekt`. Byte-identical behavior, so the existing five per-VM tests cover it.
- On device (Samsung, prod-debug): home feed loads (HomeViewModel via base `launchWithSession`) and a playlist detail opens (DetailViewModel via base `launchWithSessionLoading`).

Closes #448