### PR TITLE
refactor: rename SpfyViewModel to PlaybackViewModel

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,7 +30,7 @@ src/app/src/main/java/ch/snepilatch/app/
 │   ├── SpotifyImageUrl.kt
 │   └── UpdateService.kt
 └── viewmodel/
-    └── SpotifyViewModel.kt  Single ViewModel. See "ViewModel rules" below.
+    └── PlaybackViewModel.kt  Single ViewModel. See "ViewModel rules" below.
 ```
 
 ## Layered responsibility
@@ -38,8 +38,8 @@ src/app/src/main/java/ch/snepilatch/app/
 - **`util/`** is pure. No Compose, no ViewModel, no service. Top-level functions, easy to test.
 - **`data/`** is types + mappers. No business logic. The mappers translate KotifyClient DTOs into the UI models defined here.
 - **`playback/`** owns everything Android about playback: the foreground service, ExoPlayer, the media buttons, the session holder. Code here can use Android APIs but should not reach into the ViewModel.
-- **`ui/`** is Compose only. Screens take a `SpotifyViewModel` and read its state flows. No direct API calls, no service references — go through the ViewModel.
-- **`viewmodel/`** holds the single `SpotifyViewModel`. It owns the UI state, dispatches user actions, and bridges between the UI layer and the playback / data layers.
+- **`ui/`** is Compose only. Screens take a `PlaybackViewModel` and read its state flows. No direct API calls, no service references — go through the ViewModel.
+- **`viewmodel/`** holds the single `PlaybackViewModel`. It owns the UI state, dispatches user actions, and bridges between the UI layer and the playback / data layers.
 
 ## Session ownership
 
@@ -63,7 +63,7 @@ If you're going to refactor playback, **add a unit test first** (see `app/src/te
 
 ## ViewModel rules
 
-`SpotifyViewModel` is large (~2200 lines). It owns:
+`PlaybackViewModel` is large (~2200 lines). It owns:
 - Navigation state (current screen, screen stack)
 - Session state (via `SessionHolder` accessors)
 - Playback state (`_playback`, `isStreaming`, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ When fixing a playback bug, add a test that would have caught it.
 
 ## ViewModel coroutine helpers
 
-Two helpers in `SpotifyViewModel` cover most IO launches:
+Two helpers in `PlaybackViewModel` cover most IO launches:
 
 - **`launchWithSession("tag") { sess -> ... }`** — null-checks the session, runs on `Dispatchers.IO`, catches and logs against the tag.
 - **`launchWithPlayer("tag") { pc -> ... }`** — same shape, but for transport commands that need `PlayerConnect`.
@@ -58,20 +58,20 @@ The pre-resolved cache (`nextCdnUrl` + `nextCdnFileId` from `onNextPlaybackId`) 
 
 ## ViewModel split strategy
 
-`SpotifyViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`, `LibraryViewModel`, `HomeViewModel`** (Detail/Library built on the shared `Navigator`; Home/Library load their feed in `init`). Each lands with its own tests. That's the clean feature set — what's left on `SpotifyViewModel` is playback, the playback-coupled features (Queue/Account/Devices), and cross-cutting settings/theme.
+`PlaybackViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`, `LibraryViewModel`, `HomeViewModel`** (Detail/Library built on the shared `Navigator`; Home/Library load their feed in `init`). Each lands with its own tests. That's the clean feature set — what's left on `PlaybackViewModel` is playback, the playback-coupled features (Queue/Account/Devices), and cross-cutting settings/theme.
 
-**Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `SpotifyViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly — that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `SpotifyViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
+**Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `PlaybackViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly — that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `PlaybackViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
 
 Pattern (proven by `SearchViewModel`/`LyricsViewModel`):
 1. Move the feature's state + methods into a new `<Feature>ViewModel : SessionViewModel("<Tag>")`.
-2. `SessionViewModel` (the base for all five feature VMs) provides `launchWithSession(op) { sess -> }` and `launchWithSessionLoading(op, loadingFlag) { sess -> }` — both null-check `SessionHolder.session`, rethrow cancellation, and log against the tag. Don't re-roll these. `SpotifyViewModel` is NOT a `SessionViewModel` (it owns the session lifecycle and needs player-scoped launches too).
-3. A screen can hold **both** ViewModels at once — obtain the feature VM in the body with `val featureVm: <Feature>ViewModel = viewModel()`. `LyricsScreen` reads playback/transport/theme from `SpotifyViewModel` and lyrics content from `LyricsViewModel` side by side. The feature VM doesn't need to own the whole screen.
-4. Pass the inputs the feature needs down from the screen (e.g. `lyricsVm.fetch(track.uri)`), rather than having the feature VM reach back into `SpotifyViewModel` state.
+2. `SessionViewModel` (the base for all five feature VMs) provides `launchWithSession(op) { sess -> }` and `launchWithSessionLoading(op, loadingFlag) { sess -> }` — both null-check `SessionHolder.session`, rethrow cancellation, and log against the tag. Don't re-roll these. `PlaybackViewModel` is NOT a `SessionViewModel` (it owns the session lifecycle and needs player-scoped launches too).
+3. A screen can hold **both** ViewModels at once — obtain the feature VM in the body with `val featureVm: <Feature>ViewModel = viewModel()`. `LyricsScreen` reads playback/transport/theme from `PlaybackViewModel` and lyrics content from `LyricsViewModel` side by side. The feature VM doesn't need to own the whole screen.
+4. Pass the inputs the feature needs down from the screen (e.g. `lyricsVm.fetch(track.uri)`), rather than having the feature VM reach back into `PlaybackViewModel` state.
 
 **What makes a feature safe to extract now vs. what's blocked:**
-- Clean = the feature reads the session, writes its own state, and navigates through `Navigator`. `Lyrics` needed no navigation at all; `Detail` navigates via `Navigator` and exposes `DetailRoutes` for the `SpotifyViewModel`/non-composable callers.
-- **`Account` and `Devices` are NOT clean extractions — leave them on `SpotifyViewModel`.** They're playback-coupled: `AccountInfo.isPremium` gates audio-source logic inside the VM, and `activeDeviceName` is written from the playback state handler (`updatePlaybackFromState`) while `loadDevices`/`transferPlayback` need `PlayerConnect`. Extracting them would drag playback state across a VM boundary — the same reason we don't extract playback itself.
-- **`LibraryViewModel`** took the clean part: the library list + pagination + `createPlaylist`/`removeFromLibrary`. It loads in `init` (the old eager load lived in `SpotifyViewModel.initialize`, which runs before any composable exists) and reads `username` from `SessionHolder`. The snackbar-emitting `followArtist`/`savePlaylist` and the add-to-playlist picker stayed on `SpotifyViewModel` (they'd have needed the snackbar channel + a router for non-composable callers) — "add external content to the library" is a separable concern from browsing it.
+- Clean = the feature reads the session, writes its own state, and navigates through `Navigator`. `Lyrics` needed no navigation at all; `Detail` navigates via `Navigator` and exposes `DetailRoutes` for the `PlaybackViewModel`/non-composable callers.
+- **`Account` and `Devices` are NOT clean extractions — leave them on `PlaybackViewModel`.** They're playback-coupled: `AccountInfo.isPremium` gates audio-source logic inside the VM, and `activeDeviceName` is written from the playback state handler (`updatePlaybackFromState`) while `loadDevices`/`transferPlayback` need `PlayerConnect`. Extracting them would drag playback state across a VM boundary — the same reason we don't extract playback itself.
+- **`LibraryViewModel`** took the clean part: the library list + pagination + `createPlaylist`/`removeFromLibrary`. It loads in `init` (the old eager load lived in `PlaybackViewModel.initialize`, which runs before any composable exists) and reads `username` from `SessionHolder`. The snackbar-emitting `followArtist`/`savePlaylist` and the add-to-playlist picker stayed on `PlaybackViewModel` (they'd have needed the snackbar channel + a router for non-composable callers) — "add external content to the library" is a separable concern from browsing it.
 
 Don't try to extract playback. The handler-extraction + test rig pattern (see `RemotePlayPauseHandlerTest`) is the safer route for that area.
 
@@ -85,7 +85,7 @@ cd ../KotifyClient
 cp build/libs/KotifyClient-obfuscated.jar ../Snepilatch/src/app/libs/KotifyClient.jar
 ```
 
-**Symptom of a stale jar:** `:app:compileProdDebugKotlin` fails with a wall of unresolved references in `SpotifyViewModel.kt` (`onAd`, `onSeek`, `artistNames`, `passthroughUrl`, `saveToLibrary`, wrong `playTrack` arity). That is the committed jar lagging the app source — rebuild it with the recipe above. It is not a bug in whatever file you were editing.
+**Symptom of a stale jar:** `:app:compileProdDebugKotlin` fails with a wall of unresolved references in `PlaybackViewModel.kt` (`onAd`, `onSeek`, `artistNames`, `passthroughUrl`, `saveToLibrary`, wrong `playTrack` arity). That is the committed jar lagging the app source — rebuild it with the recipe above. It is not a bug in whatever file you were editing.
 
 ## Logging
 

--- a/PERFORMANCE_AUDIT.md
+++ b/PERFORMANCE_AUDIT.md
@@ -77,7 +77,7 @@ The completeness-critic pass re-checked the plan against source and found correc
   _Thermal:_ Low. Background snapshot churn only; the service wakelock keeps the CPU awake regardless, so the incremental cost is small. Include only if cheap. · _Effort:_ M (broad but mechanical)
 
 
-_Critic scoping note:_ The plan's four P0 frame-loop items are well-targeted and correctly identified as the dominant continuous heat, and I verified each in source (FluidBackground.kt L82-92; SharedComponents.kt rememberSmoothPositionMs L164-182; NowPlayingScreen.kt MarqueeText L1371-1389 iterations=Int.MAX_VALUE; LyricsScreen.kt L81-89 gated only on isPlaying). Secondary items also check out: DeezerDecryptProxy creates a fresh Cipher.getInstance per block (L213-216), Jukebox viz emits at 120ms with no paused/unchanged skip (JukeboxController.kt L311-330), and the derived flows currentTrackUri/isPlayingFlow already use distinctUntilChanged (SpotifyViewModel L187-193). Derived StateFlows are clean and SpotifyImage relies on Coil's automatic target-size downsampling, so no gap there. Two continuous-load sources are MISSING from the plan: (1) the Canvas video ExoPlayer, which is as hot as the Fluid warp when enabled and is never paused when audio pauses; and (2) the app-wide 2Hz whole-PlaybackUiState recomposition of MiniPlayerContent, which survives the planned rememberSmoothPositionMs fix and affects every screen, not just the player. Important scoping context the plan slightly overstates: the Fluid warp only runs when the user's background mode is 'fluid' (gradient off; AlbumBackdrop picks one or the other at NowPlayingScreen L228-243) AND only while the full player is expanded (bgFade>0.001, SpotifyApp L417) — likewise Canvas — so 'always-on during normal use' is accurate for the expanded-player screen but not while browsing with the mini bar (where gap #2 is the relevant continuous cost). The three plan risks above (FluidBackground fix semantics, MarqueeText UX, out-of-repo HttpClient target) should be resolved before implementation.
+_Critic scoping note:_ The plan's four P0 frame-loop items are well-targeted and correctly identified as the dominant continuous heat, and I verified each in source (FluidBackground.kt L82-92; SharedComponents.kt rememberSmoothPositionMs L164-182; NowPlayingScreen.kt MarqueeText L1371-1389 iterations=Int.MAX_VALUE; LyricsScreen.kt L81-89 gated only on isPlaying). Secondary items also check out: DeezerDecryptProxy creates a fresh Cipher.getInstance per block (L213-216), Jukebox viz emits at 120ms with no paused/unchanged skip (JukeboxController.kt L311-330), and the derived flows currentTrackUri/isPlayingFlow already use distinctUntilChanged (PlaybackViewModel L187-193). Derived StateFlows are clean and SpotifyImage relies on Coil's automatic target-size downsampling, so no gap there. Two continuous-load sources are MISSING from the plan: (1) the Canvas video ExoPlayer, which is as hot as the Fluid warp when enabled and is never paused when audio pauses; and (2) the app-wide 2Hz whole-PlaybackUiState recomposition of MiniPlayerContent, which survives the planned rememberSmoothPositionMs fix and affects every screen, not just the player. Important scoping context the plan slightly overstates: the Fluid warp only runs when the user's background mode is 'fluid' (gradient off; AlbumBackdrop picks one or the other at NowPlayingScreen L228-243) AND only while the full player is expanded (bgFade>0.001, SpotifyApp L417) — likewise Canvas — so 'always-on during normal use' is accurate for the expanded-player screen but not while browsing with the mini bar (where gap #2 is the relevant continuous cost). The three plan risks above (FluidBackground fix semantics, MarqueeText UX, out-of-repo HttpClient target) should be resolved before implementation.
 
 
 ---
@@ -486,7 +486,7 @@ _Risk:_ None if the Cipher stays local to the streaming thread. Verified: doFina
 **severity** low · **thermal** low (radio waste while remote, not local decode) · **effort** S
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -784,7 +784,7 @@ _Acceptance:_
 _Risk:_ Over-migrating a collector a background code path needs could freeze state; audit each site. Broad but mechanical.
 
 
-## P2 · WS-P2-VIEWMODEL — SpotifyViewModel decomposition and de-duplication (KISS)
+## P2 · WS-P2-VIEWMODEL — PlaybackViewModel decomposition and de-duplication (KISS)
 
 Zero runtime/thermal cost, but the 3199-line god-object and its repeated boilerplate (duplicate stream-commit helpers, 15 hand-rolled IO launches, 5 copy-paste detail loaders, a 190-line resolveAndPlay, ~12 loose state flags) impede reasoning about which coroutine touches which state. Continue the incremental feature-ViewModel extraction (SearchViewModel is the one already split out) and land each with its own tests. Order: cheap mechanical dedups first; the god-object extraction and the state-flag refactor (the riskiest, touching the fragile cold-start ordering) LAST.
 
@@ -794,7 +794,7 @@ Zero runtime/thermal cost, but the 3199-line god-object and its repeated boilerp
 **severity** medium · **thermal** none · **effort** M
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -821,7 +821,7 @@ _Risk:_ Call sites differ in startPlaying/startPositionMs — parameterize expli
 **severity** low · **thermal** none · **effort** M
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -848,7 +848,7 @@ _Risk:_ A few sites set extra state in finally — keep explicit or extend the h
 **severity** low · **thermal** none · **effort** M
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -873,7 +873,7 @@ _Risk:_ Low, mechanical; preserve per-type specifics in the load lambda.
 **severity** low · **thermal** none · **effort** S
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -898,7 +898,7 @@ _Risk:_ None — identical semantics.
 **severity** low · **thermal** none · **effort** S
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -923,7 +923,7 @@ _Risk:_ None — same observable behavior. Confirm the delayed re-sync is still 
 **severity** medium · **thermal** none · **effort** M · **depends on** P2-VM1
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -948,14 +948,14 @@ _Risk:_ Highest-traffic correctness path. Preserve the fallback catch; run the r
 **severity** medium · **thermal** none · **effort** L · **depends on** P2-VM2, P2-VM3
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
 
 - [ ] Follow the the code plan (Search done -> Library -> Account -> Lyrics -> Detail). Extract read-only areas first as feature ViewModels that read Session from SessionHolder and reuse the launchWithSession shape SearchViewModel already uses: LibraryViewModel (library + detail loaders + save/follow), LyricsViewModel, DevicesViewModel, and a SettingsRepository for loadPreferences/effectiveRegion/setX.
 
-- [ ] Screens call viewModel<FeatureViewModel>() instead of pulling the field off SpotifyViewModel. Move state+methods verbatim; no behavior change.
+- [ ] Screens call viewModel<FeatureViewModel>() instead of pulling the field off PlaybackViewModel. Move state+methods verbatim; no behavior change.
 
 - [ ] Inline or event-bus cross-feature triggers (loadLibrary after createPlaylist L3113/L3071, refreshQueue after onTrackChange L597).
 
@@ -964,7 +964,7 @@ _Steps:_
 
 _Acceptance:_
 
-- [ ] Each extracted feature compiles with its screen calling viewModel<Feature>(); SpotifyViewModel shrinks per feature.
+- [ ] Each extracted feature compiles with its screen calling viewModel<Feature>(); PlaybackViewModel shrinks per feature.
 
 - [ ] Full suite green after each landing: `:app:assembleDebug`, `:app:testProdDebugUnitTest`, detekt.
 
@@ -977,7 +977,7 @@ _Risk:_ Mechanical but touches many screens and cross-feature triggers; extract 
 **severity** low · **thermal** none · **effort** M · **depends on** P2-VM7
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -1004,7 +1004,7 @@ _Risk:_ Riskiest item in the set — touches the fragile cold-start ordering the
 **severity** low · **thermal** none · **effort** M · **depends on** P2-VM6
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -1228,7 +1228,7 @@ _Risk:_ Low — preview already shows only 4; slicing raw items first is behavio
 **severity** low · **thermal** none · **effort** S
 
 
-_Files:_ `app/ui/screens/QueueScreen.kt`, `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/ui/screens/QueueScreen.kt`, `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -1397,7 +1397,7 @@ _Risk:_ None; progress advances in 1% steps.
 **severity** low · **thermal** low · **effort** S
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -1445,12 +1445,12 @@ _Risk:_ A wrong readiness signal could reintroduce the wire/autoplay race the de
 Zero runtime impact. Fix the four misplaced KDoc blocks that actively mislead (they document the wrong function), remove dead diagnostic scaffolding and cargo-cult suppressions, and trim pure widget-naming restatement comments. Preserve the load-bearing protocol/rationale comments (ad-skip, cold-start, DRM, wake-lock, karaoke-mask) this repo intentionally keeps.
 
 
-#### [ ] `P3-1` — SpotifyViewModel: reattach 4 misplaced KDoc blocks and delete 3 cast-free @Suppress
+#### [ ] `P3-1` — PlaybackViewModel: reattach 4 misplaced KDoc blocks and delete 3 cast-free @Suppress
 
 **severity** low · **thermal** none · **effort** S
 
 
-_Files:_ `app/viewmodel/SpotifyViewModel.kt`
+_Files:_ `app/viewmodel/PlaybackViewModel.kt`
 
 
 _Steps:_
@@ -1677,13 +1677,13 @@ _Risk:_ None.
   `app/ui/components/FluidBackground.kt` — KawarpBackground warp clock L82-92; WarpedLayer graphicsLayer L127-149
 
 - **[low/therm:low]** File-id 100ms poll loops duplicate the event-driven CompletableDeferred cold-start already uses  
-  `app/viewmodel/SpotifyViewModel.kt` — resolveAndPlay L2487-2491 (`for (i in 1..15) { delay(100); fileId = latestFileId; if (fileId != null) break }`) and resolveAndPlayEpisode L2661-2666 (`for (i in 1..8) { delay(100); ... }`); cold-start deferred armed L1231/completed L510-513/awaited L1251
+  `app/viewmodel/PlaybackViewModel.kt` — resolveAndPlay L2487-2491 (`for (i in 1..15) { delay(100); fileId = latestFileId; if (fileId != null) break }`) and resolveAndPlayEpisode L2661-2666 (`for (i in 1..8) { delay(100); ... }`); cold-start deferred armed L1231/completed L510-513/awaited L1251
 
 - **[low/therm:low]** Queue-skip no-uid fallback fires localNext() index+1 times at 300ms intervals  
-  `app/viewmodel/SpotifyViewModel.kt` — skipToQueueIndex L1729-1745, specifically L1741 `repeat(index + 1) { p.localNext(); delay(300) }`
+  `app/viewmodel/PlaybackViewModel.kt` — skipToQueueIndex L1729-1745, specifically L1741 `repeat(index + 1) { p.localNext(); delay(300) }`
 
 - **[low/therm:low]** Position ticker cancel+relaunched on every state push, resetting the 30s Connect-report counter  
-  `app/viewmodel/SpotifyViewModel.kt` — startPositionTicker() L1095 called per-push from updatePlaybackFromState L1011-1012 (+ L647, L725, L1155, L2314, L2324); PositionInterpolator.start() L29-33 (`job?.cancel(); tickCount = 0; job = scope.launch{ while(true){...} }`), report gate L45 `if (isStreaming.value && tickCount % 60 == 0)`
+  `app/viewmodel/PlaybackViewModel.kt` — startPositionTicker() L1095 called per-push from updatePlaybackFromState L1011-1012 (+ L647, L725, L1155, L2314, L2324); PositionInterpolator.start() L29-33 (`job?.cancel(); tickCount = 0; job = scope.launch{ while(true){...} }`), report gate L45 `if (isStreaming.value && tickCount % 60 == 0)`
 
 - **[low/therm:low · PLAUSIBLE]** PARTIAL_WAKE_LOCK held through transient focus loss and past STATE_ENDED  
   `app/playback/MusicPlaybackService.kt` — onPlayWhenReadyChanged lines 271-300; onPlaybackSuppressionReasonChanged lines 302-322; acquire/release L153-198
@@ -1812,7 +1812,7 @@ _Risk:_ None.
   `app/MainActivity.kt` — LaunchedEffect(Unit) L89-111 (updateInfo remember L86, loadPreferences L90, loadCookies L92, checkForUpdates L102-110); AndroidManifest.xml L26-31 (MainActivity has no android:configChanges)
 
 - **[low/therm:low]** loadDevices() fires a network getDevices() on every state push while a foreign device is active  
-  `app/viewmodel/SpotifyViewModel.kt` — updatePlaybackFromState L1038-1045 (`else if (state.has_active_device) { loadDevices() }`), invoked per onState push at L567-570; loadDevices L3078-3095 (`player?.getDevices()`)
+  `app/viewmodel/PlaybackViewModel.kt` — updatePlaybackFromState L1038-1045 (`else if (state.has_active_device) { loadDevices() }`), invoked per onState push at L567-570; loadDevices L3078-3095 (`player?.getDevices()`)
 
 - **[low/therm:low]** Palette request decodes full-resolution art though Palette only needs ~112px  
   `app/util/AlbumArtPalette.kt` — extractThemeColorsFromArt, request builder L21-24; Palette.from(bitmap).generate() L28
@@ -1841,20 +1841,20 @@ _Risk:_ None.
 
 ### KISS / structure (19)
 
-- **[medium/therm:none]** SpotifyViewModel is a 3199-line god-object owning ~15 unrelated feature domains  
-  `app/viewmodel/SpotifyViewModel.kt` — whole file; class decl L55-56 (@Suppress("TooManyFunctions")); 3199 lines; 50 viewModelScope.launch sites
+- **[medium/therm:none]** PlaybackViewModel is a 3199-line god-object owning ~15 unrelated feature domains  
+  `app/viewmodel/PlaybackViewModel.kt` — whole file; class decl L55-56 (@Suppress("TooManyFunctions")); 3199 lines; 50 viewModelScope.launch sites
 
 - **[medium/therm:none]** Five near-identical RadioButton picker dialogs are copy-pasted inline in AccountScreen (~250 lines of duplication)  
   `app/ui/screens/AccountScreen.kt` — Language 163-190, Lyrics 204-252, Region 355-413, Left notif 454-482, Right notif 495-523
 
 - **[medium/therm:none]** God-object ViewModel: ~18 unrelated responsibilities in one 3199-line class  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — whole class SpotifyViewModel, L56-3199 (@Suppress("TooManyFunctions") L55)
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — whole class PlaybackViewModel, L56-3199 (@Suppress("TooManyFunctions") L55)
 
 - **[medium/therm:none]** Two byte-identical stream-commit helpers + ~6 copies of the DRM stop→play→commit tail  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — commitRecoveredStream L1481-1485 & commitEpisodeStream L2636-2640 (identical bodies); DRM load+commit tail at L1327-1337, L1673-1684, L1468-1477, L2513-2528, L2614-2622, L2692-2703
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — commitRecoveredStream L1481-1485 & commitEpisodeStream L2636-2640 (identical bodies); DRM load+commit tail at L1327-1337, L1673-1684, L1468-1477, L2513-2528, L2614-2622, L2692-2703
 
 - **[medium/therm:none]** resolveAndPlay is a ~190-line, deeply-nested method with a duplicated load tail  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — resolveAndPlay L2380-2570; Spotify-CDN branch L2464-2535
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — resolveAndPlay L2380-2570; Spotify-CDN branch L2464-2535
 
 - **[medium/therm:low]** NowPlayingScreen portrait and landscape branches duplicate ~400 lines of controls, progress, bottom bar and effects  
   `app/ui/screens/NowPlayingScreen.kt` — Landscape L303-695 vs Portrait L696-1129. Duplicates: jukebox ticker L462-468 vs L888-894; smooth/seek/slider L469-503 vs L895-929; time Row L504-507 vs L930-933; transport Row L512-591 vs L938-1025; AudioDeviceCallback DisposableEffect L602-611 vs L1035-1044; audioIcon/remoteDevice/outIcon L612-622 vs L1045-1056; bottom bar L623-691 vs L1057-1126. Share intent triplicated L659-666, L1095-1101, L1324-1330.
@@ -1875,22 +1875,22 @@ _Risk:_ None.
   `app/MainActivity.kt` — LaunchedEffect(initialized) L114-119 (delay 500 before wireServiceControls); autoplay LaunchedEffect(initialized) L125-133 (delay 600)
 
 - **[low/therm:none]** 15 hand-rolled IO launches duplicate the boilerplate launchWithSession exists to replace  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — fetchLyrics L1784, refreshQueue L1801, openAlbumFromCurrentTrack L1862, openArtistFromCurrentTrack L1908, fetchCanvasForTrack L2106, loadMoreLibrary L2873, openLikedSongs L2893, loadMoreDetail L2910, openPlaylist L2971, openAlbum L2984, openArtist L2997, openShow L3014, checkDetailSaved L3035, toggleDetailSaved L3048, removeFromLibrary L3062, loadDevices L3079
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — fetchLyrics L1784, refreshQueue L1801, openAlbumFromCurrentTrack L1862, openArtistFromCurrentTrack L1908, fetchCanvasForTrack L2106, loadMoreLibrary L2873, openLikedSongs L2893, loadMoreDetail L2910, openPlaylist L2971, openAlbum L2984, openArtist L2997, openShow L3014, checkDetailSaved L3035, toggleDetailSaved L3048, removeFromLibrary L3062, loadDevices L3079
 
 - **[low/therm:none]** 5 near-identical open* detail loaders and 7 identical SharedPreferences setters ("kotify_prefs" ×10)  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — openLikedSongs/openPlaylist/openAlbum/openArtist/openShow L2891-3027; setPreferredAudioSource/setContentRegion/setLyricsAnimDirection/setNotificationLeftButton/setNotificationRightButton/setCanvasEnabled/setPlayerGradientBg L1973-2093
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — openLikedSongs/openPlaylist/openAlbum/openArtist/openShow L2891-3027; setPreferredAudioSource/setContentRegion/setLyricsAnimDirection/setNotificationLeftButton/setNotificationRightButton/setCanvasEnabled/setPlayerGradientBg L1973-2093
 
 - **[low/therm:none]** `art != lastPaletteUrl` palette-update guard duplicated 3×  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — updatePlaybackFromState L998-1001, optimisticTapPlay L1669, resolveAndPlay L2425-2428
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — updatePlaybackFromState L998-1001, optimisticTapPlay L1669, resolveAndPlay L2425-2428
 
 - **[low/therm:none]** resolve paths poll latestFileId with delay(100) loops instead of awaiting the existing deferred  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — resolveAndPlay L2487-2491 (1..15 ×100ms), resolveAndPlayEpisode L2661-2666 (1..8 ×100ms); cold-start deferred L1231/L1251, completed L510-513
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — resolveAndPlay L2487-2491 (1..15 ×100ms), resolveAndPlayEpisode L2661-2666 (1..8 ×100ms); cold-start deferred L1231/L1251, completed L510-513
 
 - **[low/therm:none]** Cold-start / ad / recovery state machines coordinated by ~12 loose mutable flags  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — coldStartPending/coldStartFileId L142-143, suppressRemotePause L161, pendingUserPlay L123, advancePendingReconnect L167, isStreamLoading L245, adSkipStartTs L132, playbackErrorRetries L149, recoveringUri L156, savedRepeatForJukebox/jukeboxRepeatObserverStarted L108-109, authRecovering L294; resetColdStart L1349
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — coldStartPending/coldStartFileId L142-143, suppressRemotePause L161, pendingUserPlay L123, advancePendingReconnect L167, isStreamLoading L245, adSkipStartTs L132, playbackErrorRetries L149, recoveringUri L156, savedRepeatForJukebox/jukeboxRepeatObserverStarted L108-109, authRecovering L294; resetColdStart L1349
 
 - **[low/therm:none]** delay(300)→sync-notification block copy-pasted across three notification callbacks  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — wireNotificationButtonCallbacks onLikeToggle L2177-2181, onShuffleToggle L2185-2189, onRepeatToggle L2193-2197 (cf pushLikeToNotification L1941, pushTransportButtonsToNotification L1565)
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — wireNotificationButtonCallbacks onLikeToggle L2177-2181, onShuffleToggle L2185-2189, onRepeatToggle L2193-2197 (cf pushLikeToNotification L1941, pushTransportButtonsToNotification L1565)
 
 - **[low/therm:none]** formatReleaseDate uses redundant non-null assertions after an in-range check  
   `app/data/KotifyMappers.kt` — formatReleaseDate L34-63 (`MONTHS[month!! - 1]` at L44 and L54).
@@ -1902,7 +1902,7 @@ _Risk:_ None.
 ### Comments (8)
 
 - **[low/therm:none]** Four orphaned/misplaced KDoc blocks document the wrong function; ~627 comment lines  
-  `app/viewmodel/SpotifyViewModel.kt` — L1098-1106 (toggleJukebox doc sits above startJukeboxRepeatGuard; real toggleJukebox at L1127 has no doc), L1361-1377 (recoverFromPlaybackError doc sits above refillRetryBudgetOnReady), L2201-2212 (lifecycle-callbacks doc sits above armAdAdvanceWatchdog), L2571-2588 (episode-path doc sits above resolveEpisodeViaSoundfinder)
+  `app/viewmodel/PlaybackViewModel.kt` — L1098-1106 (toggleJukebox doc sits above startJukeboxRepeatGuard; real toggleJukebox at L1127 has no doc), L1361-1377 (recoverFromPlaybackError doc sits above refillRetryBudgetOnReady), L2201-2212 (lifecycle-callbacks doc sits above armAdAdvanceWatchdog), L2571-2588 (episode-path doc sits above resolveEpisodeViaSoundfinder)
 
 - **[low/therm:none]** Screen ON/OFF BroadcastReceiver exists only to emit a diagnostic Loki log on every screen toggle  
   `app/playback/MusicPlaybackService.kt` — screenReceiver lines 140-150; register L206-210; unregister in onDestroy L1205
@@ -1911,7 +1911,7 @@ _Risk:_ None.
   `app/playback/MusicPlaybackService.kt` — lines 663-679 (two consecutive KDoc blocks before fun refreshStreamingMetadata at 680); setIdleMetadata at 692
 
 - **[low/therm:none]** Misattached KDoc blocks (×4) + three cargo-cult @Suppress("UNCHECKED_CAST") with no cast  
-  `src/app/src/main/java/ch/snepilatch/app/viewmodel/SpotifyViewModel.kt` — KDoc L1098-1101, L1361-1369, L2201-2204, L2572-2581; @Suppress("UNCHECKED_CAST") L1768, L1860, L2786
+  `src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt` — KDoc L1098-1101, L1361-1369, L2201-2204, L2572-2581; @Suppress("UNCHECKED_CAST") L1768, L1860, L2786
 
 - **[low/therm:none]** MusicPlaybackService: orphaned KDoc leaves setIdleMetadata undocumented  
   `app/playback/MusicPlaybackService.kt` — L663-692

--- a/REFACTOR_ROADMAP.md
+++ b/REFACTOR_ROADMAP.md
@@ -1,11 +1,11 @@
 # Refactor roadmap
 
-A practical, step-by-step plan for the rest of the SpotifyViewModel decomposition. Read [ARCHITECTURE.md](ARCHITECTURE.md) first for the layout and the playback rules. This document is the work plan, not the architecture.
+A practical, step-by-step plan for the rest of the PlaybackViewModel decomposition. Read [ARCHITECTURE.md](ARCHITECTURE.md) first for the layout and the playback rules. This document is the work plan, not the architecture.
 
 ## Current state (April 2026)
 
 ```
-SpotifyViewModel.kt   2153 lines   (started at 2208 — net −2.5%)
+PlaybackViewModel.kt   2153 lines   (started at 2208 — net −2.5%)
 NowPlayingScreen.kt   1117 lines
 MusicPlaybackService  711 lines
 DetailScreen.kt       710 lines
@@ -46,7 +46,7 @@ Extract one feature at a time, each as its own PR, each landing with at least on
 | 10 | `ThemeViewModel` | ~40 | low | Album art palette, theme colors |
 | 11 | `CanvasViewModel` | ~30 | low | Canvas video URL fetch |
 
-After all 11 are done, `SpotifyViewModel` should be ~600 lines containing only the playback orchestration (init, session lifecycle, the WS callback wiring, cold-start, transport commands, state mirroring). At that point it's a candidate for renaming to `PlaybackViewModel`.
+After all 11 are done, `PlaybackViewModel` should be ~600 lines containing only the playback orchestration (init, session lifecycle, the WS callback wiring, cold-start, transport commands, state mirroring). At that point it's a candidate for renaming to `PlaybackViewModel`.
 
 ### Phase 2 — Playback decomposition (after Phase 1)
 
@@ -72,19 +72,19 @@ This is the exact recipe used for `SearchViewModel`. Follow it for every Phase 1
 ### Step 1 — Create the issue and branch
 
 ```sh
-gh issue create --title "Extract <Feature>ViewModel" --label refactor --body "Move <feature> state and logic out of SpotifyViewModel into a dedicated <Feature>ViewModel. Pattern: see SearchViewModel (PR #201)."
+gh issue create --title "Extract <Feature>ViewModel" --label refactor --body "Move <feature> state and logic out of PlaybackViewModel into a dedicated <Feature>ViewModel. Pattern: see SearchViewModel (PR #201)."
 git checkout -b feature/<issue#>_Extract<Feature>ViewModel
 ```
 
 ### Step 2 — Identify what to move
 
-In `SpotifyViewModel.kt`, find:
+In `PlaybackViewModel.kt`, find:
 - Public state flows for the feature (e.g. `val currentTrackLiked = MutableStateFlow(false)`)
 - Private state (`var lastLikeCheckUri: String? = null`)
 - All public methods that read or mutate that state
 - Any helper methods only called from those methods
 
-Use `grep -n` to make sure nothing outside the feature reads the same fields. If it does, you have a coupling — note it for later (you may need to keep an event bus or callback into `SpotifyViewModel`).
+Use `grep -n` to make sure nothing outside the feature reads the same fields. If it does, you have a coupling — note it for later (you may need to keep an event bus or callback into `PlaybackViewModel`).
 
 ### Step 3 — Create the new ViewModel
 
@@ -116,7 +116,7 @@ class <Feature>ViewModel : ViewModel() {
     // ----- private state -----
     private var someJob: Job? = null
 
-    // ----- methods (move from SpotifyViewModel) -----
+    // ----- methods (move from PlaybackViewModel) -----
     fun doSomething(arg: Foo) {
         launchWithSession("doSomething") { sess ->
             // body
@@ -147,7 +147,7 @@ class <Feature>ViewModel : ViewModel() {
 ```kotlin
 @Composable
 fun <Feature>Screen(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     featureVm: <Feature>ViewModel = viewModel()
 ) {
     val state by featureVm.someState.collectAsState()
@@ -155,9 +155,9 @@ fun <Feature>Screen(
 }
 ```
 
-The `vm: SpotifyViewModel` parameter stays for things the feature still needs from the main VM (like `playTrack`, `togglePlayPause`, theme colors during the transition).
+The `vm: PlaybackViewModel` parameter stays for things the feature still needs from the main VM (like `playTrack`, `togglePlayPause`, theme colors during the transition).
 
-### Step 5 — Delete from `SpotifyViewModel`
+### Step 5 — Delete from `PlaybackViewModel`
 
 Remove the moved state and methods. Replace each section with a one-line breadcrumb:
 ```kotlin
@@ -249,7 +249,7 @@ Each feature ViewModel has its own `tag` constant: `private val tag = "<Feature>
 
 ### 5. Snackbar / cross-feature events
 
-If a feature ViewModel needs to surface a message (e.g. "Added to playlist"), forward it to `SpotifyViewModel.snackbarMessage`:
+If a feature ViewModel needs to surface a message (e.g. "Added to playlist"), forward it to `PlaybackViewModel.snackbarMessage`:
 
 ```kotlin
 class <Feature>ViewModel(private val onSnackbar: (String) -> Unit = {}) : ViewModel()
@@ -295,7 +295,7 @@ Then `LyricsViewModel`, then `LibraryViewModel`. After three extractions, the he
 
 ## What to avoid
 
-- **Do not touch `SpotifyViewModel.initialize`** during Phase 1 — that function owns the bootstrap order and is the most fragile non-playback code.
+- **Do not touch `PlaybackViewModel.initialize`** during Phase 1 — that function owns the bootstrap order and is the most fragile non-playback code.
 - **Do not touch `wirePlayerConnectCallbacks`** during Phase 1 — that's where the playback ordering invariants live.
 - **Do not introduce a `coordinator` / `mediator` class** — every "coordinator" eventually grows into a mini-monolith. Feature ViewModels should be flat and independent.
 - **Do not modularize** (split into multiple Gradle modules) until Phase 1 + 2 + 3 are done. Modularization on top of the current structure adds friction without untangling anything.

--- a/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
@@ -28,7 +28,7 @@ import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.util.UpdateInfo
 import ch.snepilatch.app.util.UpdateService
 import ch.snepilatch.app.util.loadCookies
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -84,7 +84,7 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            val vm: SpotifyViewModel = viewModel()
+            val vm: PlaybackViewModel = viewModel()
             val initialized by vm.isInitialized.collectAsState()
             val error by vm.initError.collectAsState()
             val needsLogin by vm.needsLogin.collectAsState()

--- a/src/app/src/main/java/ch/snepilatch/app/playback/PositionInterpolator.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/PositionInterpolator.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
  * position from ExoPlayer when streaming locally, and periodically reports the
  * position back to Spotify Connect so other clients stay in sync.
  *
- * Extracted from SpotifyViewModel as a pure refactor — behavior is unchanged.
+ * Extracted from PlaybackViewModel as a pure refactor — behavior is unchanged.
  */
 class PositionInterpolator(
     private val scope: CoroutineScope,

--- a/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
@@ -8,7 +8,7 @@ import kotify.session.Session
 /**
  * Process-scoped holder for the Kotify session and its derived objects.
  *
- * Ownership used to live on [ch.snepilatch.app.viewmodel.SpotifyViewModel] (which
+ * Ownership used to live on [ch.snepilatch.app.viewmodel.PlaybackViewModel] (which
  * ties lifetime to the Activity) and was duplicated onto
  * [MusicPlaybackService] static fields for the service to reach. Neither
  * location works when we need to start playback from a cold process — e.g.

--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpotifyCdnResolver.kt
@@ -20,7 +20,7 @@ data class SpotifyStream(
 
 /**
  * Resolves Spotify CDN URLs for a given file id and builds the Widevine
- * license request metadata. Extracted from SpotifyViewModel to remove
+ * license request metadata. Extracted from PlaybackViewModel to remove
  * duplication between coldStartPlay and resolveAndPlay.
  */
 class SpotifyCdnResolver(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/BottomNav.kt
@@ -33,7 +33,7 @@ import ch.snepilatch.app.R
 import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.theme.SpotifyBlack
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import coil.compose.AsyncImage
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeEffect
@@ -41,7 +41,7 @@ import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
 
 @Composable
-fun BottomNav(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
+fun BottomNav(screen: Screen, vm: PlaybackViewModel, hazeState: HazeState) {
     val account by vm.account.collectAsState()
 
     Column(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/DevicesDialog.kt
@@ -50,11 +50,11 @@ import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyGray
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DevicesDialog(vm: SpotifyViewModel) {
+fun DevicesDialog(vm: PlaybackViewModel) {
     val devices by vm.devices.collectAsState()
     val playback by vm.playback.collectAsState()
     val theme by vm.themeColors.collectAsState()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MiniPlayer.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.theme.SpotifyElevated
 import ch.snepilatch.app.ui.theme.SpotifyLightGray
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 /**
  * Base fill colour of the mini-player card. Shared with the expanding-player morph
@@ -57,7 +57,7 @@ fun miniCardBaseColor(primary: Color): Color = lerp(SpotifyElevated, primary, 0.
  */
 @Composable
 fun MiniPlayer(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     modifier: Modifier = Modifier
 ) {
     val theme by vm.themeColors.collectAsState()
@@ -89,7 +89,7 @@ fun MiniPlayer(
  */
 @Composable
 fun MiniPlayerContent(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     modifier: Modifier = Modifier
 ) {
     // Collect only the fields the mini bar draws, each distinctUntilChanged, instead of the whole
@@ -164,7 +164,7 @@ fun MiniPlayerContent(
  * interpolator's position ticks recompose this tiny bar instead of the whole MiniPlayerContent body.
  */
 @Composable
-private fun MiniProgressBar(vm: SpotifyViewModel, durationMs: Long, color: Color) {
+private fun MiniProgressBar(vm: PlaybackViewModel, durationMs: Long, color: Color) {
     val positionMs by vm.positionFlow.collectAsState()
     val isPlaying by vm.isPlayingFlow.collectAsState()
     val smoothPos = rememberSmoothPositionMs(positionMs, durationMs, isPlaying)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -69,7 +69,7 @@ import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.util.formatTime
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import coil.compose.AsyncImage
 
 /**
@@ -189,7 +189,7 @@ fun rememberSmoothPositionMs(positionMs: Long, durationMs: Long, isPlaying: Bool
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null, trackIndex: Int? = null) {
+fun TrackRow(track: TrackInfo, vm: PlaybackViewModel, contextUri: String? = null, trackIndex: Int? = null) {
     val detailVm: DetailViewModel = viewModel()
     var showMenu by remember { mutableStateOf(false) }
     val context = androidx.compose.ui.platform.LocalContext.current

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -35,13 +35,13 @@ import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.UpdateInfo
 import ch.snepilatch.app.util.UpdateService
 import ch.snepilatch.app.util.clearCookies
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @Composable
-fun AccountScreen(vm: SpotifyViewModel) {
+fun AccountScreen(vm: PlaybackViewModel) {
     val account by vm.account.collectAsState()
     val theme by vm.themeColors.collectAsState()
     val animatedPrimary by animateColorAsState(theme.primary, tween(800), label = "accPrimary")

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -45,10 +45,10 @@ import ch.snepilatch.app.util.stripHtml
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailRoutes
 import ch.snepilatch.app.viewmodel.DetailViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 @Composable
-fun DetailScreen(vm: SpotifyViewModel) {
+fun DetailScreen(vm: PlaybackViewModel) {
     val detailVm: DetailViewModel = viewModel()
     val detail by detailVm.detail.collectAsState()
     val isLoading by detailVm.isLoading.collectAsState()
@@ -512,7 +512,7 @@ fun DetailScreen(vm: SpotifyViewModel) {
 private fun ArtistTrackRow(
     number: Int,
     track: ch.snepilatch.app.data.TrackInfo,
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     contextUri: String,
     playcount: String? = null
 ) {
@@ -652,7 +652,7 @@ private fun ArtistTrackRow(
 @Composable
 private fun AlbumTrackRow(
     track: ch.snepilatch.app.data.TrackInfo,
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     contextUri: String,
     trackIndex: Int? = null
 ) {
@@ -786,7 +786,7 @@ private fun AlbumTrackRow(
 @Composable
 private fun DetailHeaderMenu(
     detail: ch.snepilatch.app.data.DetailData,
-    vm: ch.snepilatch.app.viewmodel.SpotifyViewModel,
+    vm: ch.snepilatch.app.viewmodel.PlaybackViewModel,
     context: android.content.Context,
     onDismiss: () -> Unit,
 ) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -49,12 +49,12 @@ import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.HomeViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 // --- Home Screen ---
 
 @Composable
-fun HomeScreen(vm: SpotifyViewModel) {
+fun HomeScreen(vm: PlaybackViewModel) {
     val homeVm: HomeViewModel = viewModel()
     val homeData by homeVm.homeData.collectAsState()
     val isHomeLoading by homeVm.isLoading.collectAsState()
@@ -117,7 +117,7 @@ fun HomeScreen(vm: SpotifyViewModel) {
 }
 
 @Composable
-fun QuickPickGrid(items: List<kotify.api.home.HomeSectionItem>, vm: SpotifyViewModel) {
+fun QuickPickGrid(items: List<kotify.api.home.HomeSectionItem>, vm: PlaybackViewModel) {
     val detailVm: DetailViewModel = viewModel()
     Column(
         Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
@@ -218,7 +218,7 @@ fun HomeShimmer() {
 }
 
 @Composable
-fun HomeSectionCard(item: kotify.api.home.HomeSectionItem, vm: SpotifyViewModel, modifier: Modifier = Modifier) {
+fun HomeSectionCard(item: kotify.api.home.HomeSectionItem, vm: PlaybackViewModel, modifier: Modifier = Modifier) {
     val detailVm: DetailViewModel = viewModel()
     val isArtist = item.type == "artist"
     Column(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LoginScreen.kt
@@ -31,10 +31,10 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import ch.snepilatch.app.util.parseCookieString
 import ch.snepilatch.app.util.saveCookies
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 @Composable
-fun SpotifyLoginScreen(vm: SpotifyViewModel) {
+fun SpotifyLoginScreen(vm: PlaybackViewModel) {
     Column(
         Modifier
             .fillMaxSize()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/LyricsScreen.kt
@@ -44,14 +44,14 @@ import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.viewmodel.LyricsViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotify.api.lyrics.LyricsData
 import kotify.api.lyrics.SyncedLine
 
 @Composable
-fun LyricsScreen(vm: SpotifyViewModel) {
+fun LyricsScreen(vm: PlaybackViewModel) {
     val lyricsVm: LyricsViewModel = viewModel()
     // Narrow projections — the lyrics scaffold must not recompose on the 2Hz position tick; position
     // is consumed only through the smoothPosition state below (mutated off the flow, not read here).

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -51,7 +51,7 @@ import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.formatTime
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.LibraryViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 /**
  * The seek bar + elapsed/duration labels (or the jukebox remix timeline), pulled into its own leaf
@@ -61,7 +61,7 @@ import ch.snepilatch.app.viewmodel.SpotifyViewModel
  */
 @Composable
 private fun PlaybackProgress(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     animatedPrimary: Color,
     timeColor: Color,
     timeFontSize: TextUnit,
@@ -265,7 +265,7 @@ private fun CanvasVideoBackground(canvasVideoUrl: String, audioPlaying: Boolean)
 }
 
 @Composable
-fun PlayerBackground(vm: SpotifyViewModel, modifier: Modifier = Modifier) {
+fun PlayerBackground(vm: PlaybackViewModel, modifier: Modifier = Modifier) {
     // Narrow projections only — the background never shows position, so it must not recompose at 2Hz.
     val track by vm.currentTrack.collectAsState()
     val isPlaying by vm.isPlayingFlow.collectAsState()
@@ -351,7 +351,7 @@ private fun AlbumBackdrop(gradient: Boolean, top: Color, mid: Color, artUrl: Str
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NowPlayingScreen(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     /** When false, the screen paints no background of its own — the morphing card
      *  in SpotifyApp supplies a card-anchored background that grows with it. */
     drawBackground: Boolean = true,
@@ -883,7 +883,7 @@ private fun shareTrack(context: android.content.Context, trackUri: String?, choo
 
 /** Keep the audio-output name current while the player is shown (registers an AudioDeviceCallback). */
 @Composable
-private fun AudioDeviceEffect(vm: SpotifyViewModel) {
+private fun AudioDeviceEffect(vm: PlaybackViewModel) {
     val ctx = LocalContext.current
     DisposableEffect(Unit) {
         val am = ctx.getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager
@@ -934,7 +934,7 @@ private fun TonalIconToggle(
  *  bodies don't recompose on those flows. */
 @Composable
 private fun PlayerControls(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     animatedPrimary: Color,
     buttonBg: Color,
     spinnerActive: Boolean,
@@ -1004,7 +1004,7 @@ private fun PlayerControls(
  *  orientations; compact = landscape. Collects its audio/provider projections internally. */
 @Composable
 private fun PlayerBottomBar(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     animatedPrimary: Color,
     buttonBg: Color,
     shareTrackLabel: String,
@@ -1112,7 +1112,7 @@ private fun NowPlayingMenu(
     showMore: Boolean,
     onShowMore: (Boolean) -> Unit,
     onShowPlaylistPicker: () -> Unit,
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     track: ch.snepilatch.app.data.TrackInfo?,
     shareContext: android.content.Context,
     buttonBg: Color

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SpotifyImage
 import ch.snepilatch.app.ui.theme.*
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 @Composable
-fun QueueScreen(vm: SpotifyViewModel) {
+fun QueueScreen(vm: PlaybackViewModel) {
     val queue by vm.queue.collectAsState()
     val playback by vm.playback.collectAsState()
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
@@ -78,7 +78,7 @@ import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import ch.snepilatch.app.ui.theme.SpotifyWhite
 import ch.snepilatch.app.viewmodel.DetailRoutes
 import ch.snepilatch.app.viewmodel.SearchViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import kotify.api.song.SearchAlbum
 import kotify.api.song.SearchArtist
 import kotify.api.song.SearchPlaylist
@@ -111,7 +111,7 @@ private val browseCategories = listOf(
 )
 
 @Composable
-fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel()) {
+fun SearchScreen(vm: PlaybackViewModel, searchVm: SearchViewModel = viewModel()) {
     val query by searchVm.query.collectAsState()
     val submittedQuery by searchVm.submittedQuery.collectAsState()
     val suggestions by searchVm.suggestions.collectAsState()
@@ -304,7 +304,7 @@ private fun shareAction(ctx: Context, uri: String) = OverflowAction(
     ctx.startActivity(android.content.Intent.createChooser(intent, ctx.getString(R.string.share)))
 }
 
-private fun SearchTrack.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedResult(
+private fun SearchTrack.toUnified(vm: PlaybackViewModel, ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
     subtitle = ctx.getString(R.string.search_subtitle_song, artists.joinToString(", ") { it.name }),
@@ -331,7 +331,7 @@ private fun SearchTrack.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedR
     )
 )
 
-private fun SearchArtist.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedResult(
+private fun SearchArtist.toUnified(vm: PlaybackViewModel, ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
     subtitle = ctx.getString(R.string.search_subtitle_artist),
@@ -360,7 +360,7 @@ private fun SearchAlbum.toUnified(ctx: Context): UnifiedResult {
     )
 }
 
-private fun SearchPlaylist.toUnified(vm: SpotifyViewModel, ctx: Context) = UnifiedResult(
+private fun SearchPlaylist.toUnified(vm: PlaybackViewModel, ctx: Context) = UnifiedResult(
     uri = uri,
     title = name,
     subtitle = listOfNotNull(ctx.getString(R.string.search_subtitle_playlist), ownerName).joinToString(" · "),
@@ -399,7 +399,7 @@ private fun SearchUser.toUnified(ctx: Context) = UnifiedResult(
 @Composable
 private fun CategorizedResults(
     results: kotify.api.song.SearchResult?,
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     selectedFilter: SearchViewModel.SearchFilter,
     onFilterChange: (SearchViewModel.SearchFilter) -> Unit
 ) {
@@ -456,7 +456,7 @@ private val DEFAULT_CHIP_ORDER = listOf("TRACKS", "ARTISTS", "ALBUMS", "PLAYLIST
 private fun sectionFor(
     type: String,
     results: kotify.api.song.SearchResult,
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     ctx: Context
 ): Pair<SearchViewModel.SearchFilter, List<UnifiedResult>>? = when (type) {
     "TRACKS" ->
@@ -482,7 +482,7 @@ private fun sectionFor(
 
 private fun singleFilterRows(
     results: kotify.api.song.SearchResult,
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     ctx: Context,
     filter: SearchViewModel.SearchFilter
 ): List<UnifiedResult> = when (filter) {
@@ -495,7 +495,7 @@ private fun singleFilterRows(
     SearchViewModel.SearchFilter.ALL -> emptyList()
 }
 
-private fun SearchTopResult.toUnified(vm: SpotifyViewModel, ctx: Context): UnifiedResult = when (this) {
+private fun SearchTopResult.toUnified(vm: PlaybackViewModel, ctx: Context): UnifiedResult = when (this) {
     is SearchTopResult.Track -> track.toUnified(vm, ctx)
     is SearchTopResult.Artist -> artist.toUnified(vm, ctx)
     is SearchTopResult.Album -> album.toUnified(ctx)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -58,7 +58,7 @@ import ch.snepilatch.app.ui.theme.SpotifyLightGray
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.LibraryViewModel
-import ch.snepilatch.app.viewmodel.SpotifyViewModel
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.hazeSource
 import androidx.compose.runtime.compositionLocalOf
@@ -97,7 +97,7 @@ private val MorphCardPadV = 6.dp
 // --- App Shell ---
 
 @Composable
-fun SpotifyApp(vm: SpotifyViewModel) {
+fun SpotifyApp(vm: PlaybackViewModel) {
     // Eagerly create the DetailViewModel from the post-login shell so it registers itself in
     // DetailRoutes before any deep link or playback-context bridge tries to open a detail.
     viewModel<DetailViewModel>()
@@ -343,7 +343,7 @@ fun SpotifyApp(vm: SpotifyViewModel) {
 }
 
 @Composable
-private fun MainContent(screen: Screen, vm: SpotifyViewModel, hazeState: HazeState) {
+private fun MainContent(screen: Screen, vm: PlaybackViewModel, hazeState: HazeState) {
     val libraryVm: LibraryViewModel = viewModel()
     Box(
         Modifier
@@ -370,7 +370,7 @@ private fun MainContent(screen: Screen, vm: SpotifyViewModel, hazeState: HazeSta
  */
 @Composable
 private fun PlayerMorph(
-    vm: SpotifyViewModel,
+    vm: PlaybackViewModel,
     expand: Animatable<Float, *>,
     miniBounds: Rect,
     fullSize: IntSize,
@@ -479,7 +479,7 @@ fun LoadingScreen(
             when {
                 isRateLimited -> {
                     // The cooldown total can vary (20s on first retry, 40s on
-                    // second, etc. — see SpotifyViewModel). Track the highest
+                    // second, etc. — see PlaybackViewModel). Track the highest
                     // value we've seen so the progress bar fills correctly
                     // regardless of the starting length.
                     var totalSeconds by remember { mutableIntStateOf(cooldownSecondsRemaining) }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
@@ -21,9 +21,9 @@ import kotlinx.coroutines.launch
  * Owns the detail data + its pagination + the follow/save toggle, and the
  * openers that navigate to a detail and load it. Navigation goes through the
  * process-scoped [Navigator]; the session comes from [SessionHolder]. Screens
- * obtain this via `viewModel()` alongside [SpotifyViewModel].
+ * obtain this via `viewModel()` alongside [PlaybackViewModel].
  *
- * [SpotifyViewModel]'s deep-link handler and playback-context bridges
+ * [PlaybackViewModel]'s deep-link handler and playback-context bridges
  * (openAlbumFromCurrentTrack / openArtistFromCurrentTrack / navigateToContext)
  * need PlayerConnect / playingContext, so they stay there and reach the openers
  * through [DetailRoutes] rather than holding a reference to this ViewModel.
@@ -197,7 +197,7 @@ class DetailViewModel : SessionViewModel("DetailVM") {
 }
 
 /**
- * Process-scoped hop so [SpotifyViewModel]'s deep-link + playback-context code can open a detail
+ * Process-scoped hop so [PlaybackViewModel]'s deep-link + playback-context code can open a detail
  * without a reference to the (screen-scoped) [DetailViewModel]. The live ViewModel registers itself
  * on construction; calls before one exists are dropped (in practice a screen — normally Home — is
  * always composed before a deep link is processed, so one is registered).

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/HomeViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/HomeViewModel.kt
@@ -8,11 +8,11 @@ import kotlinx.coroutines.flow.StateFlow
 
 /**
  * ViewModel for the Home feed. Loads the feed in [init] — the old eager load lived in
- * `SpotifyViewModel.initialize`, which runs before any composable exists; loading here fires as soon
+ * `PlaybackViewModel.initialize`, which runs before any composable exists; loading here fires as soon
  * as the Home screen composes (the default post-login screen), with [isLoading] driving the shimmer
  * until the first feed arrives.
  *
- * HomeScreen keeps [SpotifyViewModel] (for `playTrack`) and [DetailViewModel] (for opening items);
+ * HomeScreen keeps [PlaybackViewModel] (for `playTrack`) and [DetailViewModel] (for opening items);
  * this VM only owns the feed data.
  */
 class HomeViewModel : SessionViewModel("HomeVM") {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/LibraryViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/LibraryViewModel.kt
@@ -18,11 +18,11 @@ import kotlinx.coroutines.launch
  * ViewModel for the "Your Library" screen: the saved list + pagination, plus create/remove.
  *
  * Reads the session (and, for mutations, the username) from [SessionHolder], and loads the first
- * page in [init] — the old eager load lived in `SpotifyViewModel.initialize`, which runs before any
+ * page in [init] — the old eager load lived in `PlaybackViewModel.initialize`, which runs before any
  * composable exists; loading here instead fires as soon as the post-login shell composes this VM,
  * which is well before the library-backed playlist picker can be opened.
  *
- * `followArtist`/`savePlaylist` and the add-to-playlist picker stay on [SpotifyViewModel] — they emit
+ * `followArtist`/`savePlaylist` and the add-to-playlist picker stay on [PlaybackViewModel] — they emit
  * snackbars and are triggered from non-composable search builders, i.e. "add external content to the
  * library" rather than browsing it.
  */

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/LyricsViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/LyricsViewModel.kt
@@ -11,9 +11,9 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * Owns only the lyrics *data* concern (fetch + result + loading flag). The
  * [ch.snepilatch.app.ui.screens.LyricsScreen] still reads playback state,
- * transport controls and theme from [SpotifyViewModel]; the two ViewModels
+ * transport controls and theme from [PlaybackViewModel]; the two ViewModels
  * sit side by side. Navigation to the overlay stays on
- * [SpotifyViewModel.openLyrics] — this class never navigates.
+ * [PlaybackViewModel.openLyrics] — this class never navigates.
  */
 class LyricsViewModel : SessionViewModel("LyricsVM") {
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/Navigator.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/Navigator.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.flow.StateFlow
  * Single source of truth for which [Screen] is showing, plus the back stack.
  *
  * Process-scoped (like [ch.snepilatch.app.playback.SessionHolder]) so feature
- * ViewModels can drive navigation without routing through [SpotifyViewModel].
- * [SpotifyViewModel] delegates its nav methods here and calls [reset] on
+ * ViewModels can drive navigation without routing through [PlaybackViewModel].
+ * [PlaybackViewModel] delegates its nav methods here and calls [reset] on
  * construction — a freshly constructed ViewModel means a fresh app entry
  * (Activity finished + recreated, or cold process), which mirrors the old
  * behaviour where `currentScreen` lived on the ViewModel and reset to HOME.

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -47,9 +47,9 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
 
 @Suppress("TooManyFunctions") // central view-model; split-by-feature is tracked separately
-class SpotifyViewModel : ViewModel() {
+class PlaybackViewModel : ViewModel() {
 
-    private val TAG = "SpotifyVM"
+    private val TAG = "PlaybackVM"
 
     // Navigation lives in the process-scoped Navigator; the ViewModel delegates (see navigateTo/goBack
     // below). Reset on construction so a fresh ViewModel (cold process / recreated Activity) starts at
@@ -244,7 +244,7 @@ class SpotifyViewModel : ViewModel() {
     // Next track info (always available from WebSocket state for mini player swipe)
     val nextTrackPreview = MutableStateFlow<TrackInfo?>(null)
 
-    // Detail state + openers live in DetailViewModel; SpotifyViewModel's deep-link/playback bridges
+    // Detail state + openers live in DetailViewModel; PlaybackViewModel's deep-link/playback bridges
     // reach them through DetailRoutes.
 
     // Devices

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/SessionViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/SessionViewModel.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
  * session, rethrow cancellation, log everything else against [logTag]" boilerplate each of them
  * was duplicating.
  *
- * Not used by [SpotifyViewModel], which owns the session lifecycle and also needs player-scoped
+ * Not used by [PlaybackViewModel], which owns the session lifecycle and also needs player-scoped
  * launches.
  */
 abstract class SessionViewModel(protected val logTag: String) : ViewModel() {

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/DetailViewModelTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/DetailViewModelTest.kt
@@ -59,7 +59,7 @@ class DetailViewModelTest {
     }
 
     @Test fun detailRoutesForwardsToTheConstructedViewModel() {
-        // SpotifyViewModel's deep-link/playback bridges reach the detail openers through this hop.
+        // PlaybackViewModel's deep-link/playback bridges reach the detail openers through this hop.
         DetailRoutes.openArtist("a2")
         assertEquals(Screen.ARTIST_DETAIL, Navigator.currentScreen.value)
     }

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/NavigationStackTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/NavigationStackTest.kt
@@ -17,11 +17,11 @@ import org.junit.Test
 class NavigationStackTest {
 
     private val dispatcher = UnconfinedTestDispatcher()
-    private lateinit var vm: SpotifyViewModel
+    private lateinit var vm: PlaybackViewModel
 
     @Before fun setUp() {
         Dispatchers.setMain(dispatcher)
-        vm = SpotifyViewModel()
+        vm = PlaybackViewModel()
     }
 
     @After fun tearDown() {

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackTestRig.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackTestRig.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 
 /**
- * Test rig for [SpotifyViewModel] playback logic. Wires up:
+ * Test rig for [PlaybackViewModel] playback logic. Wires up:
  *  - a mocked [MusicPlaybackService.instance] so handler calls can be observed
  *  - the Main dispatcher swapped for an unconfined test dispatcher so the
  *    ViewModel's coroutines run synchronously
@@ -29,7 +29,7 @@ class PlaybackTestRig {
     val testScope = TestScope(testDispatcher)
     lateinit var service: MusicPlaybackService
         private set
-    lateinit var vm: SpotifyViewModel
+    lateinit var vm: PlaybackViewModel
         private set
 
     fun install() {
@@ -37,7 +37,7 @@ class PlaybackTestRig {
         service = mockk(relaxed = true)
         mockkObject(MusicPlaybackService.Companion)
         every { MusicPlaybackService.instance } returns service
-        vm = SpotifyViewModel()
+        vm = PlaybackViewModel()
     }
 
     fun uninstall() {

--- a/src/detekt-baseline.xml
+++ b/src/detekt-baseline.xml
@@ -5,14 +5,14 @@
     <ID>AnnotationOnSeparateLine:MediaButtonReceiver.kt$MediaButtonReceiver$@Suppress("DEPRECATION") intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT)</ID>
     <ID>BlockCommentInitialStarAlignment:Theme.kt$/* Other default colors to override background = Color(0xFFFFFBFE), surface = Color(0xFFFFFBFE), onPrimary = Color.White, onSecondary = Color.White, onTertiary = Color.White, onBackground = Color(0xFF1C1B1F), onSurface = Color(0xFF1C1B1F), */</ID>
     <ID>BlockCommentInitialStarAlignment:Type.kt$/* Other default text styles to override titleLarge = TextStyle( fontFamily = FontFamily.Default, fontWeight = FontWeight.Normal, fontSize = 22.sp, lineHeight = 28.sp, letterSpacing = 0.sp ), labelSmall = TextStyle( fontFamily = FontFamily.Default, fontWeight = FontWeight.Medium, fontSize = 11.sp, lineHeight = 16.sp, letterSpacing = 0.5.sp ) */</ID>
-    <ID>CyclomaticComplexMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: SpotifyViewModel)</ID>
-    <ID>CyclomaticComplexMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: SpotifyViewModel)</ID>
+    <ID>CyclomaticComplexMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: PlaybackViewModel)</ID>
+    <ID>CyclomaticComplexMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: PlaybackViewModel)</ID>
     <ID>CyclomaticComplexMethod:LibraryScreen.kt$@Composable fun LibraryScreen()</ID>
-    <ID>CyclomaticComplexMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
-    <ID>CyclomaticComplexMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: SpotifyViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
-    <ID>CyclomaticComplexMethod:SpotifyApp.kt$@Composable fun SpotifyApp(vm: SpotifyViewModel)</ID>
-    <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
-    <ID>CyclomaticComplexMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun updatePlaybackFromState(state: PlayerStateData)</ID>
+    <ID>CyclomaticComplexMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: PlaybackViewModel)</ID>
+    <ID>CyclomaticComplexMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: PlaybackViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
+    <ID>CyclomaticComplexMethod:SpotifyApp.kt$@Composable fun SpotifyApp(vm: PlaybackViewModel)</ID>
+    <ID>CyclomaticComplexMethod:PlaybackViewModel.kt$PlaybackViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
+    <ID>CyclomaticComplexMethod:PlaybackViewModel.kt$PlaybackViewModel$private suspend fun updatePlaybackFromState(state: PlayerStateData)</ID>
     <ID>Filename:AudioOutputDetector.kt$ch.snepilatch.app.util.AudioOutputDetector.kt</ID>
     <ID>FinalNewline:ExampleUnitTest.kt$ch.snepilatch.app.ExampleUnitTest.kt</ID>
     <ID>FinalNewline:Theme.kt$ch.snepilatch.app.ui.theme.Theme.kt</ID>
@@ -25,24 +25,24 @@
     <ID>Indentation:MusicPlaybackService.kt$MusicPlaybackService$ </ID>
     <ID>Indentation:NowPlayingScreen.kt$ </ID>
     <ID>Indentation:SpotifyApp.kt$ </ID>
-    <ID>LongMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: SpotifyViewModel)</ID>
-    <ID>LongMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: SpotifyViewModel)</ID>
-    <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun AlbumTrackRow( track: ch.snepilatch.app.data.TrackInfo, vm: SpotifyViewModel, contextUri: String, trackIndex: Int? = null )</ID>
-    <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun ArtistTrackRow( number: Int, track: ch.snepilatch.app.data.TrackInfo, vm: SpotifyViewModel, contextUri: String, playcount: String? = null )</ID>
-    <ID>LongMethod:DevicesDialog.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun DevicesDialog(vm: SpotifyViewModel)</ID>
+    <ID>LongMethod:AccountScreen.kt$@Composable fun AccountScreen(vm: PlaybackViewModel)</ID>
+    <ID>LongMethod:DetailScreen.kt$@Composable fun DetailScreen(vm: PlaybackViewModel)</ID>
+    <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun AlbumTrackRow( track: ch.snepilatch.app.data.TrackInfo, vm: PlaybackViewModel, contextUri: String, trackIndex: Int? = null )</ID>
+    <ID>LongMethod:DetailScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun ArtistTrackRow( number: Int, track: ch.snepilatch.app.data.TrackInfo, vm: PlaybackViewModel, contextUri: String, playcount: String? = null )</ID>
+    <ID>LongMethod:DevicesDialog.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun DevicesDialog(vm: PlaybackViewModel)</ID>
     <ID>LongMethod:LibraryScreen.kt$@Composable fun LibraryScreen()</ID>
-    <ID>LongMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: SpotifyViewModel)</ID>
+    <ID>LongMethod:LyricsScreen.kt$@Composable fun LyricsScreen(vm: PlaybackViewModel)</ID>
     <ID>LongMethod:MainActivity.kt$MainActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
-    <ID>LongMethod:NowPlayingScreen.kt$@Composable fun PlayerBackground(vm: SpotifyViewModel, modifier: Modifier = Modifier)</ID>
-    <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: SpotifyViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
-    <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun NowPlayingMenu( showMore: Boolean, onShowMore: (Boolean) -&gt; Unit, onShowPlaylistPicker: () -&gt; Unit, vm: SpotifyViewModel, track: ch.snepilatch.app.data.TrackInfo?, shareContext: android.content.Context, buttonBg: Color )</ID>
-    <ID>LongMethod:SearchScreen.kt$@Composable fun SearchScreen(vm: SpotifyViewModel, searchVm: SearchViewModel = viewModel())</ID>
-    <ID>LongMethod:SharedComponents.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun TrackRow(track: TrackInfo, vm: SpotifyViewModel, contextUri: String? = null, trackIndex: Int? = null)</ID>
-    <ID>LongMethod:SpotifyApp.kt$@Composable fun SpotifyApp(vm: SpotifyViewModel)</ID>
-    <ID>LongMethod:SpotifyViewModel.kt$SpotifyViewModel$fun initialize(cookies: Map&lt;String, String&gt;)</ID>
-    <ID>LongMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun coldStartPlay()</ID>
-    <ID>LongMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
-    <ID>LongMethod:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun updatePlaybackFromState(state: PlayerStateData)</ID>
+    <ID>LongMethod:NowPlayingScreen.kt$@Composable fun PlayerBackground(vm: PlaybackViewModel, modifier: Modifier = Modifier)</ID>
+    <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun NowPlayingScreen( vm: PlaybackViewModel, /** When false, the screen paints no background of its own — the morphing card * in SpotifyApp supplies a card-anchored background that grows with it. */ drawBackground: Boolean = true, /** Per-frame vertical drag (px, down = positive) for finger-tracked collapse; * when set, replaces the standalone swipe-down-to-dismiss. */ onMorphDrag: ((Float) -&gt; Unit)? = null, /** Drag release with vertical velocity (px/s) so the morph can settle. */ onMorphDragEnd: ((Float) -&gt; Unit)? = null )</ID>
+    <ID>LongMethod:NowPlayingScreen.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable private fun NowPlayingMenu( showMore: Boolean, onShowMore: (Boolean) -&gt; Unit, onShowPlaylistPicker: () -&gt; Unit, vm: PlaybackViewModel, track: ch.snepilatch.app.data.TrackInfo?, shareContext: android.content.Context, buttonBg: Color )</ID>
+    <ID>LongMethod:SearchScreen.kt$@Composable fun SearchScreen(vm: PlaybackViewModel, searchVm: SearchViewModel = viewModel())</ID>
+    <ID>LongMethod:SharedComponents.kt$@OptIn(ExperimentalMaterial3Api::class) @Composable fun TrackRow(track: TrackInfo, vm: PlaybackViewModel, contextUri: String? = null, trackIndex: Int? = null)</ID>
+    <ID>LongMethod:SpotifyApp.kt$@Composable fun SpotifyApp(vm: PlaybackViewModel)</ID>
+    <ID>LongMethod:PlaybackViewModel.kt$PlaybackViewModel$fun initialize(cookies: Map&lt;String, String&gt;)</ID>
+    <ID>LongMethod:PlaybackViewModel.kt$PlaybackViewModel$private suspend fun coldStartPlay()</ID>
+    <ID>LongMethod:PlaybackViewModel.kt$PlaybackViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
+    <ID>LongMethod:PlaybackViewModel.kt$PlaybackViewModel$private suspend fun updatePlaybackFromState(state: PlayerStateData)</ID>
     <ID>LongMethod:UpdateDialog.kt$@Composable fun UpdateDialog( updateInfo: UpdateInfo, onDismiss: () -&gt; Unit )</ID>
     <ID>LongParameterList:MusicPlaybackService.kt$MusicPlaybackService$(url: String, licenseUrl: String, licenseHeaders: Map&lt;String, String&gt;, title: String, artist: String, albumArtUrl: String?, startPlaying: Boolean = true, startPositionMs: Long = 0L)</ID>
     <ID>LoopWithTooManyJumpStatements:LyricsScreen.kt$for</ID>
@@ -52,14 +52,14 @@
     <ID>MaxLineLength:MusicPlaybackService.kt$MusicPlaybackService.&lt;no name provided&gt;$LokiLogger.i(TAG, "Audio session ID changed: $currentAudioSessionId -&gt; $audioSessionId, playWhenReady=${player.playWhenReady}, openSession=$openAudioEffectSession")</ID>
     <ID>MaxLineLength:NowPlayingScreen.kt$eqIntent.putExtra(android.media.audiofx.AudioEffect.EXTRA_CONTENT_TYPE, android.media.audiofx.AudioEffect.CONTENT_TYPE_MUSIC)</ID>
     <ID>MaxLineLength:QueueScreen.kt$LazyColumn</ID>
-    <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$?:</ID>
-    <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$LokiLogger.i(TAG, "[Timing] WS onTrackChange arrived (${delta}ms after CMD '$lastCommandName') -&gt; ${event.current?.uri} fileId=${event.currentFileId}")</ID>
-    <ID>MaxLineLength:SpotifyViewModel.kt$SpotifyViewModel$LokiLogger.i(TAG, "[Timing] resolveAndPlay DRM loaded in ${System.currentTimeMillis() - resolveStart}ms (${System.currentTimeMillis() - lastCommandTs}ms total from CMD)")</ID>
+    <ID>MaxLineLength:PlaybackViewModel.kt$PlaybackViewModel$?:</ID>
+    <ID>MaxLineLength:PlaybackViewModel.kt$PlaybackViewModel$LokiLogger.i(TAG, "[Timing] WS onTrackChange arrived (${delta}ms after CMD '$lastCommandName') -&gt; ${event.current?.uri} fileId=${event.currentFileId}")</ID>
+    <ID>MaxLineLength:PlaybackViewModel.kt$PlaybackViewModel$LokiLogger.i(TAG, "[Timing] resolveAndPlay DRM loaded in ${System.currentTimeMillis() - resolveStart}ms (${System.currentTimeMillis() - lastCommandTs}ms total from CMD)")</ID>
     <ID>MaximumLineLength:DetailScreen.kt$ </ID>
     <ID>MaximumLineLength:MusicPlaybackService.kt$MusicPlaybackService.&lt;no name provided&gt;$ </ID>
     <ID>MaximumLineLength:NowPlayingScreen.kt$ </ID>
     <ID>MaximumLineLength:QueueScreen.kt$ </ID>
-    <ID>MaximumLineLength:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
+    <ID>MaximumLineLength:PlaybackViewModel.kt$PlaybackViewModel$ </ID>
     <ID>MultiLineIfElse:BottomNav.kt$Modifier</ID>
     <ID>MultiLineIfElse:BottomNav.kt$Modifier.border(2.dp, SpotifyWhite, CircleShape)</ID>
     <ID>MultiLineIfElse:DetailScreen.kt$String.format("%,d", detail.followers)</ID>
@@ -76,38 +76,38 @@
     <ID>MultiLineIfElse:ReleaseNotesScreen.kt$MaterialTheme.colorScheme.primary</ID>
     <ID>MultiLineIfElse:ReleaseNotesScreen.kt$SpotifyGray</ID>
     <ID>MultiLineIfElse:SpotifyImageUrl.kt$raw</ID>
-    <ID>MultiLineIfElse:SpotifyViewModel.kt$SpotifyViewModel$false</ID>
-    <ID>MultiLineIfElse:SpotifyViewModel.kt$SpotifyViewModel$null</ID>
-    <ID>MultiLineIfElse:SpotifyViewModel.kt$SpotifyViewModel$pt.info</ID>
-    <ID>MultiLineIfElse:SpotifyViewModel.kt$SpotifyViewModel$throw e</ID>
-    <ID>NestedBlockDepth:SpotifyViewModel.kt$SpotifyViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
+    <ID>MultiLineIfElse:PlaybackViewModel.kt$PlaybackViewModel$false</ID>
+    <ID>MultiLineIfElse:PlaybackViewModel.kt$PlaybackViewModel$null</ID>
+    <ID>MultiLineIfElse:PlaybackViewModel.kt$PlaybackViewModel$pt.info</ID>
+    <ID>MultiLineIfElse:PlaybackViewModel.kt$PlaybackViewModel$throw e</ID>
+    <ID>NestedBlockDepth:PlaybackViewModel.kt$PlaybackViewModel$private suspend fun resolveAndPlay(event: kotify.api.playerstatus.TrackChangeEvent)</ID>
     <ID>NewLineAtEndOfFile:ExampleUnitTest.kt$ch.snepilatch.app.ExampleUnitTest.kt</ID>
     <ID>NewLineAtEndOfFile:Theme.kt$ch.snepilatch.app.ui.theme.Theme.kt</ID>
     <ID>NewLineAtEndOfFile:Type.kt$ch.snepilatch.app.ui.theme.Type.kt</ID>
-    <ID>NoConsecutiveBlankLines:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
+    <ID>NoConsecutiveBlankLines:PlaybackViewModel.kt$PlaybackViewModel$ </ID>
     <ID>NoMultipleSpaces:MusicPlaybackService.kt$MusicPlaybackService$ </ID>
     <ID>NoMultipleSpaces:ReleaseNotesScreen.kt$ </ID>
-    <ID>NoMultipleSpaces:SpotifyViewModel.kt$SpotifyViewModel$ </ID>
-    <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$catch</ID>
-    <ID>SpacingAroundKeyword:SpotifyViewModel.kt$SpotifyViewModel$finally</ID>
+    <ID>NoMultipleSpaces:PlaybackViewModel.kt$PlaybackViewModel$ </ID>
+    <ID>SpacingAroundKeyword:PlaybackViewModel.kt$PlaybackViewModel$catch</ID>
+    <ID>SpacingAroundKeyword:PlaybackViewModel.kt$PlaybackViewModel$finally</ID>
     <ID>SpacingBetweenDeclarationsWithAnnotations:SessionHolder.kt$SessionHolder$@Volatile var cdnResolver: SpotifyCdnResolver? = null</ID>
     <ID>SpacingBetweenDeclarationsWithAnnotations:SessionHolder.kt$SessionHolder$@Volatile var player: PlayerConnect? = null</ID>
     <ID>SpacingBetweenDeclarationsWithAnnotations:SessionHolder.kt$SessionHolder$@Volatile var spotifyPlayback: SpotifyPlayback? = null</ID>
     <ID>SpacingBetweenDeclarationsWithComments:MusicPlaybackService.kt$MusicPlaybackService$// Which extra buttons to show: "like", "shuffle", "repeat"</ID>
     <ID>SpacingBetweenDeclarationsWithComments:PositionInterpolator.kt$PositionInterpolator.Companion$// Report every 30s (60 * 500ms)</ID>
-    <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Canvas background</ID>
-    <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Content region for CDN resolution</ID>
-    <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Language preference: "system", "en", "de", "ru", "gsw"</ID>
-    <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"</ID>
-    <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Next track info (always available from WebSocket state for mini player swipe)</ID>
-    <ID>SpacingBetweenDeclarationsWithComments:SpotifyViewModel.kt$SpotifyViewModel$// Notification button preferences: "like", "shuffle", "repeat"</ID>
-    <ID>ThrowsCount:SpotifyViewModel.kt$SpotifyViewModel$fun togglePlayPause()</ID>
+    <ID>SpacingBetweenDeclarationsWithComments:PlaybackViewModel.kt$PlaybackViewModel$// Canvas background</ID>
+    <ID>SpacingBetweenDeclarationsWithComments:PlaybackViewModel.kt$PlaybackViewModel$// Content region for CDN resolution</ID>
+    <ID>SpacingBetweenDeclarationsWithComments:PlaybackViewModel.kt$PlaybackViewModel$// Language preference: "system", "en", "de", "ru", "gsw"</ID>
+    <ID>SpacingBetweenDeclarationsWithComments:PlaybackViewModel.kt$PlaybackViewModel$// Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"</ID>
+    <ID>SpacingBetweenDeclarationsWithComments:PlaybackViewModel.kt$PlaybackViewModel$// Next track info (always available from WebSocket state for mini player swipe)</ID>
+    <ID>SpacingBetweenDeclarationsWithComments:PlaybackViewModel.kt$PlaybackViewModel$// Notification button preferences: "like", "shuffle", "repeat"</ID>
+    <ID>ThrowsCount:PlaybackViewModel.kt$PlaybackViewModel$fun togglePlayPause()</ID>
     <ID>TooGenericExceptionThrown:ReleaseNotesScreen.kt$throw Exception("HTTP ${response.code}")</ID>
     <ID>UseCheckOrError:SpotifyCdnResolver.kt$SpotifyCdnResolver$throw IllegalStateException("No CDN mirrors for fileId=$fileId")</ID>
-    <ID>UseCheckOrError:SpotifyViewModel.kt$SpotifyViewModel$throw IllegalStateException("CdnResolver not initialized")</ID>
-    <ID>UseCheckOrError:SpotifyViewModel.kt$SpotifyViewModel$throw IllegalStateException("No file ID available")</ID>
-    <ID>VariableNaming:SpotifyViewModel.kt$SpotifyViewModel$// Playback (internal so tests can seed state without going through the // network-dependent initialize/resolve paths) internal val _playback = MutableStateFlow(PlaybackUiState())</ID>
-    <ID>VariableNaming:SpotifyViewModel.kt$SpotifyViewModel$private val TAG = "SpotifyVM"</ID>
+    <ID>UseCheckOrError:PlaybackViewModel.kt$PlaybackViewModel$throw IllegalStateException("CdnResolver not initialized")</ID>
+    <ID>UseCheckOrError:PlaybackViewModel.kt$PlaybackViewModel$throw IllegalStateException("No file ID available")</ID>
+    <ID>VariableNaming:PlaybackViewModel.kt$PlaybackViewModel$// Playback (internal so tests can seed state without going through the // network-dependent initialize/resolve paths) internal val _playback = MutableStateFlow(PlaybackUiState())</ID>
+    <ID>VariableNaming:PlaybackViewModel.kt$PlaybackViewModel$private val TAG = "PlaybackVM"</ID>
     <ID>Wrapping:AccountScreen.kt$(</ID>
     <ID>Wrapping:AccountScreen.kt$;</ID>
     <ID>Wrapping:AccountScreen.kt$Text( if (canvasOn) stringResource(R.string.canvas_on) else stringResource(R.string.canvas_off), color = SpotifyLightGray )</ID>
@@ -139,8 +139,8 @@
     <ID>Wrapping:SharedComponents.kt$(</ID>
     <ID>Wrapping:SharedComponents.kt$;</ID>
     <ID>Wrapping:SpotifyApp.kt$;</ID>
-    <ID>Wrapping:SpotifyViewModel.kt$SpotifyViewModel$(</ID>
-    <ID>Wrapping:SpotifyViewModel.kt$SpotifyViewModel$;</ID>
-    <ID>Wrapping:SpotifyViewModel.kt$SpotifyViewModel$it.key == activeId || it.key == "hobs_$activeId" || "hobs_${it.key}" == activeId</ID>
+    <ID>Wrapping:PlaybackViewModel.kt$PlaybackViewModel$(</ID>
+    <ID>Wrapping:PlaybackViewModel.kt$PlaybackViewModel$;</ID>
+    <ID>Wrapping:PlaybackViewModel.kt$PlaybackViewModel$it.key == activeId || it.key == "hobs_$activeId" || "hobs_${it.key}" == activeId</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
With the feature concerns (Search/Lyrics/Detail/Library/Home) extracted into their own ViewModels, the class is now the playback engine + its inherent state — 'SpfyViewModel' was a misleading god-object name.

## What
- Rename the class + file `SpfyViewModel` → `PlaybackViewModel` across all ~27 files, the log tag `SpfyVM` → `PlaybackVM`, the detekt-baseline keys, and the docs (CLAUDE/ARCHITECTURE/PERFORMANCE_AUDIT/REFACTOR_ROADMAP).
- **Zero `SpfyViewModel` references remain anywhere in the repo.**

## Verified
- Gate green: `assembleProdDebug testProdDebugUnitTest detekt` (baseline keys updated so the pre-existing suppressions still match).
- On device (Samsung, prod-debug): session init, home feed load, and transport (play → PLAYING) all work.

First step of 'slim + rename'; the settings slim (persisted store) follows as its own PR.

Closes #450