### PR TITLE
fix: control the active remote device instead of stealing playback

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -262,6 +262,12 @@ class PlaybackViewModel : ViewModel() {
     // fully determine which indicator branch runs, so re-running (and its loadDevices() network call)
     // is only needed when they change — not on every onState push (~5/track).
     private var lastDeviceIndicatorKey: Pair<Boolean, Boolean>? = null
+
+    // True while some OTHER Connect device holds playback. Written from the state handler on every
+    // push, read by the transport commands: the local* state reports below describe THIS device, so
+    // they're meaningless when the active device is someone else's — those cases need a real command.
+    @Volatile private var foreignDeviceActive = false
+
     private val playlistNameCache = mutableMapOf<String, String>()
 
     // Loading (detail loading moved to DetailViewModel.isLoading)
@@ -998,7 +1004,8 @@ class PlaybackViewModel : ViewModel() {
 
         // Detect playback transfer away — stop local ExoPlayer
         LokiLogger.d(TAG, "Transfer check: streaming=${isStreaming.value} hasActive=${state.has_active_device} isOurs=${state.is_active_device}")
-        if (isStreaming.value && state.has_active_device && !state.is_active_device) {
+        foreignDeviceActive = state.has_active_device && !state.is_active_device
+        if (isStreaming.value && foreignDeviceActive) {
             LokiLogger.i(TAG, "Playback transferred to another device — stopping local stream")
             isStreaming.value = false
             streamProvider.value = null
@@ -1127,6 +1134,19 @@ class PlaybackViewModel : ViewModel() {
             try {
                 val p = player ?: return@launch
                 val t0 = System.currentTimeMillis()
+                if (foreignDeviceActive) {
+                    // Another device holds playback: act as a remote control for it. The local* state
+                    // reports below describe THIS device, so they'd be ignored, and the cold-start path
+                    // would claim the device and pull the audio over here. Moving playback to the phone
+                    // stays an explicit action via the devices dialog (transferPlayback).
+                    if (action == "resume") p.resume() else p.pause()
+                    // Optimistic flip so the button responds now; the cluster push confirms it.
+                    val resuming = action == "resume"
+                    _playback.value = _playback.value.copy(isPlaying = resuming, isPaused = !resuming)
+                    if (resuming) startPositionTicker() else stopPositionTicker()
+                    LokiLogger.i(TAG, "[Timing] CMD $action (remote device) done in ${System.currentTimeMillis() - t0}ms")
+                    return@launch
+                }
                 if (action == "resume") {
                     if (isStreaming.value) {
                         // Hot path: ExoPlayer is already loaded — flip the UI to playing
@@ -2197,6 +2217,22 @@ class PlaybackViewModel : ViewModel() {
      */
     internal fun setSuppressRemotePauseForTest(suppress: Boolean) {
         suppressRemotePause = suppress
+    }
+
+    /**
+     * Test seam: simulate another Connect device holding playback, so [togglePlayPause] must issue a
+     * remote command instead of a local state report / cold start.
+     */
+    internal fun setForeignDeviceActiveForTest(active: Boolean) {
+        foreignDeviceActive = active
+    }
+
+    /**
+     * Test seam: await the in-flight transport command. [togglePlayPause] and friends launch on
+     * [Dispatchers.IO], so assertions would otherwise race the coroutine.
+     */
+    internal suspend fun awaitCommandForTest() {
+        commandJob?.join()
     }
 
     /** Poll every 100ms up to [maxAttempts] times, returning as soon as [ready] is true (or attempts run

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackTestRig.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackTestRig.kt
@@ -3,6 +3,7 @@ package ch.snepilatch.app.viewmodel
 import ch.snepilatch.app.data.PlaybackUiState
 import ch.snepilatch.app.data.TrackInfo
 import ch.snepilatch.app.playback.MusicPlaybackService
+import ch.snepilatch.app.playback.SessionHolder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -13,6 +14,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import kotify.api.playerconnect.PlayerConnect
 
 /**
  * Test rig for [PlaybackViewModel] playback logic. Wires up:
@@ -32,16 +34,23 @@ class PlaybackTestRig {
     lateinit var vm: PlaybackViewModel
         private set
 
+    /** Stand-in for the Connect player, so transport commands can be observed with `coVerify`. */
+    lateinit var player: PlayerConnect
+        private set
+
     fun install() {
         Dispatchers.setMain(testDispatcher)
         service = mockk(relaxed = true)
         mockkObject(MusicPlaybackService.Companion)
         every { MusicPlaybackService.instance } returns service
+        player = mockk(relaxed = true)
+        SessionHolder.player = player
         vm = PlaybackViewModel()
     }
 
     fun uninstall() {
         unmockkObject(MusicPlaybackService.Companion)
+        SessionHolder.player = null
         Dispatchers.resetMain()
     }
 

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/RemoteDeviceTransportTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/RemoteDeviceTransportTest.kt
@@ -1,0 +1,92 @@
+package ch.snepilatch.app.viewmodel
+
+import io.mockk.coVerify
+import io.mockk.excludeRecords
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression tests for issue #456: with another Connect device holding playback (e.g. the desktop
+ * app), the transport buttons must control THAT device.
+ *
+ * Previously [PlaybackViewModel.togglePlayPause] only asked "is ExoPlayer loaded here?", so pause
+ * sent a local state report describing this idle phone (which the remote device ignored) and play
+ * fell through to the cold-start path, claiming the device and pulling the audio onto the phone.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RemoteDeviceTransportTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() {
+        rig.install()
+        rig.vm.setForeignDeviceActiveForTest(true)
+        excludeRecords { rig.player.ourDeviceId() }
+    }
+
+    @After
+    fun tearDown() {
+        rig.uninstall()
+    }
+
+    /** The "pause does nothing" half of the bug. */
+    @Test
+    fun pauseWithForeignDeviceActive_sendsRemotePause() {
+        rig.vm._playback.value = rig.vm._playback.value.copy(isPlaying = true, isPaused = false)
+
+        rig.vm.togglePlayPause()
+        runBlocking { rig.vm.awaitCommandForTest() }
+
+        coVerify(exactly = 1) { rig.player.pause() }
+        coVerify(exactly = 0) { rig.player.localPause(any()) }
+        assertTrue("UI should flip to paused immediately", rig.vm._playback.value.isPaused)
+    }
+
+    /** The "play steals playback" half: resume must NOT claim the device. */
+    @Test
+    fun resumeWithForeignDeviceActive_sendsRemoteResumeAndDoesNotTransfer() {
+        rig.vm._playback.value = rig.vm._playback.value.copy(isPlaying = false, isPaused = true)
+
+        rig.vm.togglePlayPause()
+        runBlocking { rig.vm.awaitCommandForTest() }
+
+        coVerify(exactly = 1) { rig.player.resume() }
+        coVerify(exactly = 0) { rig.player.transferPlaybackHere(any()) }
+        coVerify(exactly = 0) { rig.player.localResume(any()) }
+        assertTrue("UI should flip to playing immediately", rig.vm._playback.value.isPlaying)
+        assertFalse(rig.vm._playback.value.isPaused)
+    }
+
+    /** No cold start means no spinner — the loading indicator was the visible symptom. */
+    @Test
+    fun resumeWithForeignDeviceActive_doesNotShowStreamLoading() {
+        rig.vm._playback.value = rig.vm._playback.value.copy(isPlaying = false, isPaused = true)
+
+        rig.vm.togglePlayPause()
+        runBlocking { rig.vm.awaitCommandForTest() }
+
+        assertFalse("remote resume must not enter the cold-start path", rig.vm.isStreamLoading.value)
+    }
+
+    /**
+     * The phone being the active device is the normal case and must keep using the local state
+     * reports — they're what makes transport uncapped.
+     */
+    @Test
+    fun pauseWhenThisDeviceIsActive_stillUsesLocalStateReport() {
+        rig.vm.setForeignDeviceActiveForTest(false)
+        rig.seedStreaming(positionMs = 30_000L, isPaused = false)
+
+        rig.vm.togglePlayPause()
+        runBlocking { rig.vm.awaitCommandForTest() }
+
+        coVerify(exactly = 1) { rig.player.localPause(any()) }
+        coVerify(exactly = 0) { rig.player.pause() }
+    }
+}


### PR DESCRIPTION
Closes #456

## Problem

With another Connect device active (e.g. the desktop app), the transport buttons didn't control it:

- **Pause did nothing.** `togglePlayPause` sent `p.localPause(...)` — a Connect state report describing *this phone*. With the phone idle and the desktop active, Spfy had no reason to act on it.
- **Play stole playback.** `isStreaming` was false, so resume fell through to `coldStartPlay()` → `isStreamLoading` (spinner) → `transferPlaybackHere()`, yanking the audio onto the phone.

The decision only ever asked *"is ExoPlayer loaded here?"*, never *"who is actually playing?"* — even though `updatePlaybackFromState` already computes `has_active_device && !is_active_device` for its transfer-away check.

## Change

- Hoist that condition into `foreignDeviceActive`, written on every state push and reused by the existing transfer-away check (no new computation, no extra network call).
- Branch on it at the top of `togglePlayPause`: send `PlayerConnect.pause()` / `resume()`, flip the UI optimistically, and return before any local-path logic.

The `local*` state reports stay on the path where they're correct — and where they keep transport uncapped. Moving playback to the phone remains explicit, via the devices dialog.

## Tests

New `RemoteDeviceTransportTest` (4 cases): remote pause/resume are issued, `transferPlaybackHere` and the `local*` reports are *not*, no spinner, and the phone-is-active case still uses the local reports.

`PlaybackTestRig` gains a `PlayerConnect` mock; `awaitCommandForTest()` joins the `Dispatchers.IO` command job so the assertions are deterministic rather than racing it.

## Device verification

Real S25 Ultra + Spfy desktop ("NICLAS-PC"):

| Case | Result |
|---|---|
| Desktop active → pause | `CMD pause (remote device) done in 205ms`; position frozen at 0:57 across 36 s |
| Desktop active → play | `CMD resume (remote device) done in 165ms`; no `[ColdStart]`, no spinner, `streaming=false` |
| Devices dialog → PC | transfers, `isOurs=false` |
| Devices dialog → phone | transfers back, `isOurs=true` |
| Local playback | cold start → 6 CDN mirrors → ExoPlayer → `state=PLAYING(3)` |

Gate green: `:app:assembleProdDebug :app:testProdDebugUnitTest detekt`.