### PR TITLE
Add an in-app equalizer with automatic EQ headroom

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
@@ -2,7 +2,7 @@ package ch.snepilatch.app.data
 
 import androidx.compose.ui.graphics.Color
 
-enum class Screen { LOGIN, HOME, SEARCH, LIBRARY, NOW_PLAYING, QUEUE, PLAYLIST_DETAIL, ALBUM_DETAIL, ARTIST_DETAIL, SHOW_DETAIL, ACCOUNT, LYRICS }
+enum class Screen { LOGIN, HOME, SEARCH, LIBRARY, NOW_PLAYING, QUEUE, PLAYLIST_DETAIL, ALBUM_DETAIL, ARTIST_DETAIL, SHOW_DETAIL, ACCOUNT, LYRICS, EQUALIZER }
 
 data class TrackInfo(
     val uri: String,

--- a/src/app/src/main/java/ch/snepilatch/app/data/UiMessage.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/UiMessage.kt
@@ -1,0 +1,17 @@
+package ch.snepilatch.app.data
+
+import android.content.Context
+import androidx.annotation.StringRes
+
+/**
+ * User-facing text a ViewModel wants shown, as a string resource plus its format args. ViewModels
+ * have no Context, and resolving in the UI is what makes the text follow the picked app language.
+ * [raw] carries text that has no resource to begin with (an exception message from the server).
+ */
+data class UiMessage(
+    @param:StringRes val id: Int = 0,
+    val args: List<Any> = emptyList(),
+    val raw: String? = null
+) {
+    fun resolve(context: Context): String = raw ?: context.getString(id, *args.toTypedArray())
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/EqualizerController.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/EqualizerController.kt
@@ -1,0 +1,163 @@
+package ch.snepilatch.app.playback
+
+import android.media.audiofx.DynamicsProcessing
+import android.os.Build
+import ch.snepilatch.app.util.LokiLogger
+
+/**
+ * Band layout and the input-gain math for the in-app EQ. Pure Kotlin so it unit-tests without a
+ * device — [EqualizerController] holds everything that needs Android.
+ */
+object EqualizerHeadroom {
+
+    val FREQUENCIES = floatArrayOf(31f, 62f, 125f, 250f, 500f, 1000f, 2000f, 4000f, 8000f, 16000f)
+    val BANDS = FREQUENCIES.size
+    const val MAX_GAIN_DB = 12f
+
+    /**
+     * The input gain that keeps the loudest boosted band at unity: `-(largest positive band gain)`.
+     * A curve peaking at +9 dB gets −9 dB in, so the boost fills headroom instead of clipping. Curves
+     * that only cut get 0 — cutting needs no headroom, and attenuating further would just lose level.
+     */
+    fun inputGainDb(bands: FloatArray): Float {
+        val peak = (bands.maxOrNull() ?: 0f).coerceAtLeast(0f)
+        // Guard the negation: -0f would render as "-0.0 dB" in the preamp readout.
+        return if (peak == 0f) 0f else -peak
+    }
+}
+
+/**
+ * 10-band EQ on the player's audio session, via [DynamicsProcessing] (API 28+). Unlike an external EQ
+ * it does its own gain staging — see [EqualizerHeadroom.inputGainDb] — with the limiter left on purely
+ * as a safety net for inter-band overshoot.
+ *
+ * On API 26–27 this is unsupported and stays inert: `audiofx.Equalizer` has no input-gain control, so
+ * it could only ship the boost without the headroom that makes it sound clean. The EQ screen says so,
+ * and the "EQ headroom" setting still covers external EQs there.
+ */
+class EqualizerController {
+
+    private var dynamics: DynamicsProcessing? = null
+    private var sessionId = 0
+
+    /**
+     * Debug builds only: attach at priority 0 instead of [PRIORITY], which reproduces the
+     * non-controlling-client state (every write comes back as `INVALID_OPERATION`) whenever another
+     * effect app holds the session. The service sets it from a marker file; see its `lowPriorityDebug`.
+     */
+    @Volatile var debugLowPriority: Boolean = false
+
+    val supported: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+
+    val attached: Boolean get() = dynamics != null
+
+    /**
+     * (Re)create the effect on [sessionId] with [bands] baked into its config. Always releases the
+     * previous instance first.
+     *
+     * The whole curve goes in through [DynamicsProcessing.Config] rather than through the per-band
+     * setters, because on a Galaxy (Android 16) every live setter — `setPreEqBandAllChannelsTo`,
+     * `setInputGainAllChannelsTo` — throws `UnsupportedOperationException: invalid parameter
+     * operation` once audio is running on the session. Construction with a full config is the only
+     * write path that device honours, and there is no `setConfig`, so a curve change means a rebuild.
+     */
+    fun attach(sessionId: Int, bands: FloatArray) {
+        release()
+        if (!supported || sessionId == 0) return
+        val inputGain = EqualizerHeadroom.inputGainDb(bands)
+        try {
+            val eq = DynamicsProcessing.Eq(true, true, EqualizerHeadroom.BANDS)
+            for (b in 0 until EqualizerHeadroom.BANDS) {
+                eq.setBand(
+                    b,
+                    DynamicsProcessing.EqBand(true, EqualizerHeadroom.FREQUENCIES[b], bands.getOrElse(b) { 0f })
+                )
+            }
+            // inputGain, preEq in use with our bands, no MBC, no post-EQ, limiter in use.
+            val channel = DynamicsProcessing.Channel(
+                inputGain,
+                true, EqualizerHeadroom.BANDS,
+                false, 0,
+                false, 0,
+                true
+            )
+            channel.setPreEq(eq)
+            // inUse, enabled, linkGroup, attack ms, release ms, ratio, threshold dB, post gain dB.
+            channel.setLimiter(DynamicsProcessing.Limiter(true, true, 0, 1f, 60f, 10f, -1f, 0f))
+
+            val config = DynamicsProcessing.Config.Builder(
+                DynamicsProcessing.VARIANT_FAVOR_FREQUENCY_RESOLUTION,
+                CHANNELS,
+                true, EqualizerHeadroom.BANDS,
+                false, 0,
+                false, 0,
+                true
+            ).setAllChannelsTo(channel).build()
+
+            val priority = if (debugLowPriority) 0 else PRIORITY
+            dynamics = DynamicsProcessing(priority, sessionId, config).apply { setEnabled(true) }
+            this.sessionId = sessionId
+            LokiLogger.i(TAG, "EQ attached to session $sessionId: ${bands.joinToString()} inputGain=${inputGain}dB")
+        } catch (e: RuntimeException) {
+            // Device without the effect, or a session that went away between the callback and here.
+            LokiLogger.e(TAG, "EQ attach failed for session $sessionId", e)
+            dynamics = null
+        }
+    }
+
+    /**
+     * Push a new curve onto the live effect. Cheap — no detach/attach, so no risk of a click mid-song.
+     *
+     * These setters only work while we hold effect CONTROL (see [PRIORITY]); a non-controlling client
+     * gets `INVALID_OPERATION` on every write. If that happens we lost control to another effect app,
+     * and rebuilding at our priority is the way to take it back.
+     */
+    fun applyCurve(bands: FloatArray): Boolean {
+        val dp = dynamics ?: return true // nothing attached, so nothing to fail
+        val inputGain = EqualizerHeadroom.inputGainDb(bands)
+        try {
+            for (b in 0 until EqualizerHeadroom.BANDS) {
+                dp.setPreEqBandAllChannelsTo(
+                    b,
+                    DynamicsProcessing.EqBand(true, EqualizerHeadroom.FREQUENCIES[b], bands.getOrElse(b) { 0f })
+                )
+            }
+            dp.setInputGainAllChannelsTo(inputGain)
+            LokiLogger.i(TAG, "EQ curve ${bands.joinToString()} inputGain=${inputGain}dB")
+            return true
+        } catch (e: RuntimeException) {
+            LokiLogger.e(TAG, "EQ curve write rejected, rebuilding to reclaim control", e)
+            // Exactly one rebuild, and no write after it — [attach] bakes the curve into the config.
+            // If that fails too the caller disables the feature; a retry loop here would be a loop
+            // with an audio effect in it.
+            attach(sessionId, bands)
+            return attached
+        }
+    }
+
+    /** Release the effect. Safe to call repeatedly — leaking one across session changes is the bug. */
+    fun release() {
+        dynamics?.let {
+            try {
+                it.release()
+                LokiLogger.i(TAG, "EQ released")
+            } catch (e: RuntimeException) {
+                LokiLogger.e(TAG, "EQ release failed", e)
+            }
+        }
+        dynamics = null
+    }
+
+    private companion object {
+        const val TAG = "Equalizer"
+        const val CHANNELS = 2
+
+        // Ask for the top priority band. AudioFlinger gives effect CONTROL to the highest-priority
+        // client on the session; every other client's writes come back as INVALID_OPERATION
+        // ("invalid parameter operation"). Wavelet attaches with Integer.MAX_VALUE, so at priority 0
+        // we were a spectator on our own effect — nothing we set ever reached the chain. Control is
+        // only handed over on a strictly higher priority, so we also attach as early as possible
+        // (on the session id, before playback), which is when nothing else has claimed it yet.
+        const val PRIORITY = Int.MAX_VALUE
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/GainAudioProcessor.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/GainAudioProcessor.kt
@@ -1,0 +1,88 @@
+package ch.snepilatch.app.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import androidx.media3.common.audio.BaseAudioProcessor
+import ch.snepilatch.app.util.LokiLogger
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Attenuates the decoded PCM by a settable linear gain — the headroom that lets an EQ (Wavelet, or our
+ * own) boost without clipping. Sits AFTER [JukeboxAudioTap] in the sink's processor chain so the tap
+ * still sees the unmodified signal its beat matching was tuned on.
+ *
+ * 16-bit PCM only; anything else returns [AudioProcessor.AudioFormat.NOT_SET] from [onConfigure] so the
+ * sink bypasses us instead of us mangling the buffer. Gain changes ramp over [RAMP_MS] to avoid a click.
+ */
+class GainAudioProcessor : BaseAudioProcessor() {
+
+    @Volatile private var targetGain = 1f
+    private var currentGain = 1f
+    private var channels = 1
+    private var rampPerFrame = 1f
+
+    /** Set the linear gain (attenuation only — values above 1 would re-introduce the clipping). */
+    fun setGain(gain: Float) {
+        targetGain = gain.coerceIn(0f, 1f)
+    }
+
+    fun gain(): Float = targetGain
+
+    // Zero cost when there is nothing to apply. Re-read on a pipeline flush, so a gain set mid-track
+    // takes effect on the next seek / track change — which is when normalization is applied anyway.
+    override fun isActive(): Boolean = targetGain != 1f || currentGain != 1f
+
+    override fun onConfigure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
+        if (inputAudioFormat.encoding != C.ENCODING_PCM_16BIT) {
+            LokiLogger.i(TAG, "unsupported encoding ${inputAudioFormat.encoding} — bypassing gain")
+            return AudioProcessor.AudioFormat.NOT_SET
+        }
+        channels = inputAudioFormat.channelCount
+        rampPerFrame = 1f / (inputAudioFormat.sampleRate * RAMP_MS / 1000f)
+        // A fresh configure is a new track: start at the target so there is no audible level jump.
+        currentGain = targetGain
+        LokiLogger.i(TAG, "gain configured: ${inputAudioFormat.sampleRate}Hz ch=$channels gain=$targetGain")
+        return inputAudioFormat
+    }
+
+    override fun onFlush(streamMetadata: AudioProcessor.StreamMetadata) {
+        currentGain = targetGain
+    }
+
+    override fun queueInput(inputBuffer: ByteBuffer) {
+        val remaining = inputBuffer.remaining()
+        if (remaining == 0) return
+
+        val src = inputBuffer.duplicate().order(ByteOrder.LITTLE_ENDIAN).asShortBuffer()
+        val out = replaceOutputBuffer(remaining)
+        val dst = out.asShortBuffer()
+
+        val target = targetGain
+        var g = currentGain
+        var i = 0
+        val total = remaining / 2
+        while (i < total) {
+            if (g != target) {
+                g = if (target > g) minOf(target, g + rampPerFrame) else maxOf(target, g - rampPerFrame)
+            }
+            // One gain step per frame, so both channels of a frame are scaled identically.
+            var c = 0
+            while (c < channels && i < total) {
+                dst.put((src.get() * g).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort())
+                c++
+                i++
+            }
+        }
+        currentGain = g
+
+        inputBuffer.position(inputBuffer.limit())
+        out.position(total * 2)
+        out.flip()
+    }
+
+    private companion object {
+        const val TAG = "GainProcessor"
+        const val RAMP_MS = 30f
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/LoudnessNormalization.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/LoudnessNormalization.kt
@@ -1,0 +1,25 @@
+package ch.snepilatch.app.playback
+
+import kotlin.math.pow
+
+/**
+ * Turns a track's loudness into the linear gain [GainAudioProcessor] applies. Attenuation only: a
+ * quieter-than-target track is left alone rather than boosted, since boosting is what clips.
+ *
+ * Spotify's media manifest carries a per-file `gain_db`, but it is null in every response we have
+ * captured, and the third-party FLAC path has no Spotify metadata at all — so in practice every track
+ * takes the fallback branch (see [gainFor]).
+ */
+object LoudnessNormalization {
+
+    const val TARGET_LUFS = -14.0
+    const val DEFAULT_FALLBACK_DB = -6.0
+
+    /** Linear gain for [trackLoudnessDb], or a flat [fallbackDb] attenuation when loudness is unknown. */
+    fun gainFor(trackLoudnessDb: Double?, fallbackDb: Double = DEFAULT_FALLBACK_DB): Float {
+        val db = if (trackLoudnessDb != null) TARGET_LUFS - trackLoudnessDb else fallbackDb
+        return dbToLinear(db.coerceAtMost(0.0))
+    }
+
+    fun dbToLinear(db: Double): Float = 10.0.pow(db / 20.0).toFloat()
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -239,6 +239,12 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         // Custom renderers factory so our PCM tap sits in the audio processor chain and can read the
         // decoded waveform (for the seamless-jukebox engine). It passes audio through untouched.
         val renderersFactory = object : DefaultRenderersFactory(this) {
+            // enableFloatOutput is deliberately ignored. It only does anything when the decoder
+            // already emits 32-bit float, so it is a no-op for the 16-bit AAC Spotify path and would
+            // apply only to high-bit-depth FLAC — where it would break two things: JukeboxAudioTap
+            // captures into a ShortArray, and GainAudioProcessor bypasses itself on any encoding
+            // other than PCM_16BIT, so the EQ headroom would silently stop working. Teach both
+            // ENCODING_PCM_FLOAT first if this is ever wanted.
             override fun buildAudioSink(
                 context: android.content.Context,
                 enableFloatOutput: Boolean,

--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -20,8 +20,10 @@ import android.support.v4.media.session.PlaybackStateCompat
 import android.os.Bundle
 import androidx.annotation.OptIn
 import androidx.core.app.NotificationCompat
+import ch.snepilatch.app.BuildConfig
 import ch.snepilatch.app.R
 import ch.snepilatch.app.util.LokiLogger
+import ch.snepilatch.app.viewmodel.AppSettings
 import androidx.media.MediaBrowserServiceCompat
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -77,6 +79,15 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     // Taps the decoded PCM in the audio pipeline — the foundation of the waveform-based seamless
     // jukebox. Pass-through; only observes when analyzing is toggled on.
     private val jukeboxTap = JukeboxAudioTap()
+
+    // EQ headroom: attenuates the decoded PCM so an external EQ (Wavelet & co.) has room to boost into.
+    // Strictly after the tap — the tap must keep seeing the unmodified signal its beat matching needs.
+    private val gainProcessor = GainAudioProcessor()
+
+    // In-app 10-band EQ on the audio session. Unlike the headroom above it computes its own input
+    // gain from the curve, so the two are never both needed — the UI disables one when the other is on.
+    private val equalizer = EqualizerController()
+    val equalizerSupported: Boolean get() = equalizer.supported
 
     private data class TrackMetadata(
         val title: String,
@@ -233,7 +244,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                 enableFloatOutput: Boolean,
                 enableAudioTrackPlaybackParams: Boolean
             ): AudioSink = DefaultAudioSink.Builder(context)
-                .setAudioProcessors(arrayOf(jukeboxTap))
+                .setAudioProcessors(arrayOf(jukeboxTap, gainProcessor))
                 .build()
         }
 
@@ -276,6 +287,8 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
                 // Follow Auxio convention: open/close audio effect session on play/pause
                 currentAudioSessionId = player.audioSessionId
+                // Re-insert the in-app EQ now that a track is actually running (see syncEqualizer).
+                if (playWhenReady) syncEqualizer()
                 if (playWhenReady) {
                     if (!openAudioEffectSession) {
                         LokiLogger.i(TAG, "Opening audio effect session (audioSessionId=$currentAudioSessionId)")
@@ -341,6 +354,8 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                 LokiLogger.i(TAG, "Audio session ID changed: $currentAudioSessionId -> $audioSessionId, playWhenReady=${player.playWhenReady}, openSession=$openAudioEffectSession")
                 val oldId = currentAudioSessionId
                 currentAudioSessionId = audioSessionId
+                // Rebuild the in-app EQ on the new session and drop the old effect with it.
+                syncEqualizer()
                 if (audioSessionId != 0 && player.playWhenReady) {
                     if (openAudioEffectSession && oldId != audioSessionId) {
                         // Session changed mid-play, close old and open new
@@ -428,6 +443,75 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
     var onReady: (() -> Unit)? = null
 
+    /**
+     * Apply the EQ-headroom attenuation, before the media item is prepared so the level is right from
+     * the first frame. [trackLoudnessDb] is the track's measured loudness if we ever have one — nothing
+     * supplies it today (Spotify's manifest `gain_db` is always null and the FLAC path has no Spotify
+     * metadata), so every track takes the flat user-set attenuation.
+     */
+    fun applyHeadroomGain(trackLoudnessDb: Double? = null) {
+        val gain = if (AppSettings.eqHeadroomEnabled.value) {
+            LoudnessNormalization.gainFor(trackLoudnessDb, AppSettings.eqHeadroomDb.value.toDouble())
+        } else {
+            1f
+        }
+        val branch = if (trackLoudnessDb != null) "loudness=${trackLoudnessDb}dB" else "flat"
+        LokiLogger.i(TAG, "Headroom gain=$gain ($branch, enabled=${AppSettings.eqHeadroomEnabled.value})")
+        gainProcessor.setGain(gain)
+    }
+
+    /**
+     * Bring the in-app EQ in line with the settings: attached to the current session when enabled,
+     * released when not. Called on every audio-session change (a stale effect on a dead session is a
+     * real leak), whenever the user flips the toggle, and again when playback starts.
+     *
+     * The last one matters: an effect created while the session has no running AudioTrack isn't
+     * necessarily inserted into AudioFlinger's chain — on this Samsung device it stayed silent until
+     * something re-committed the chain (a volume-key press would do it). Re-creating it once audio is
+     * actually running puts it in the live chain instead.
+     */
+    /**
+     * Debug-only switch that makes the EQ attach as a non-controlling client, to exercise the
+     * "another app owns the effect" path on demand:
+     * `adb shell touch /sdcard/Android/data/<pkg>/files/eq_low_priority`
+     */
+    private val lowPriorityDebug: Boolean
+        get() = BuildConfig.DEBUG && java.io.File(getExternalFilesDir(null), "eq_low_priority").exists()
+
+    fun syncEqualizer() {
+        equalizer.debugLowPriority = lowPriorityDebug
+        if (AppSettings.eqEnabled.value) {
+            // Evict external effect apps first — see broadcastAudioEffectAction for why sharing fails.
+            if (openAudioEffectSession) {
+                broadcastAudioEffectAction(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION)
+                openAudioEffectSession = false
+            }
+            equalizer.attach(currentAudioSessionId, AppSettings.eqBands.value)
+            // The effect refused to be created on a live session (some Samsung firmware does this).
+            // Turn the feature off rather than leave the user with neither our EQ nor their external
+            // one: this flips the toggle, releases, and re-advertises the session on the way back in.
+            if (equalizer.supported && currentAudioSessionId != 0 && !equalizer.attached) {
+                LokiLogger.e(TAG, "EQ unavailable on this device — falling back to external effects")
+                AppSettings.setEqEnabled(false, this)
+            }
+        } else {
+            equalizer.release()
+            // Hand the session back to Wavelet & co.
+            if (player.playWhenReady && !openAudioEffectSession) {
+                broadcastAudioEffectAction(AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION)
+                openAudioEffectSession = true
+            }
+        }
+    }
+
+    /** Push a changed curve to the live effect (no-op when the EQ is off). */
+    fun setEqCurve(bands: FloatArray) {
+        if (!equalizer.applyCurve(bands)) {
+            LokiLogger.e(TAG, "EQ curve could not be applied — disabling in-app EQ")
+            AppSettings.setEqEnabled(false, this)
+        }
+    }
+
     fun playUrl(
         url: String,
         title: String,
@@ -439,6 +523,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     ) {
         LokiLogger.i(TAG, "Loading: $title by $artist -> ${url.take(80)} (play=$startPlaying, headers=${headers.keys}, pos=${startPositionMs}ms)")
         isAdSkipping = false  // a real track is loading — end the ad-skip buffering state
+        applyHeadroomGain()
         val meta = TrackMetadata(title, artist, albumArtUrl)
         metadataQueue.clear()
         metadataQueue.add(meta)
@@ -844,6 +929,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                    pssh: String? = null) {
         LokiLogger.i(TAG, "Loading DRM: $title by $artist -> ${url.take(80)} (play=$startPlaying, pos=${startPositionMs}ms, pssh=${pssh != null})")
         isAdSkipping = false  // a real track is loading — end the ad-skip buffering state
+        applyHeadroomGain()
         val meta = TrackMetadata(title, artist, albumArtUrl)
         metadataQueue.clear()
         metadataQueue.add(meta)
@@ -1025,10 +1111,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         val nm = getSystemService(NotificationManager::class.java)
         val channel = NotificationChannel(
             CHANNEL_ID,
-            "Music Playback",
+            getString(R.string.notif_channel_playback),
             NotificationManager.IMPORTANCE_LOW
         ).apply {
-            description = "Shows current playing track"
+            description = getString(R.string.notif_channel_playback_desc)
             setShowBadge(false)
         }
         nm.createNotificationChannel(channel)
@@ -1036,10 +1122,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         // High-importance channel so error alerts surface as a heads-up pop-up.
         val alertChannel = NotificationChannel(
             ALERT_CHANNEL_ID,
-            "Alerts",
+            getString(R.string.notif_channel_alerts),
             NotificationManager.IMPORTANCE_HIGH
         ).apply {
-            description = "Connection and sign-in problems that need your attention"
+            description = getString(R.string.notif_channel_alerts_desc)
         }
         nm.createNotificationChannel(alertChannel)
     }
@@ -1050,7 +1136,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
      * session so the now-playing bar / lockscreen / Android Auto reflect it too. Called from the
      * ViewModel when [kotify.session.Session.onAuthLost] fires. Cleared by [clearError] on recovery.
      */
-    fun showError(title: String, message: String) {
+    fun showError(@androidx.annotation.StringRes titleRes: Int, @androidx.annotation.StringRes messageRes: Int) {
+        val title = getString(titleRes)
+        val message = getString(messageRes)
         mainHandler.post {
             val openApp = packageManager.getLaunchIntentForPackage(packageName)?.apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
@@ -1123,6 +1211,14 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
     private fun broadcastAudioEffectAction(action: String) {
         if (currentAudioSessionId == 0) return
+        // While the in-app EQ owns the session, don't invite external effect apps into it. Measured on
+        // a Galaxy (Android 16): once Samsung's SoundAlive attaches after this broadcast, every
+        // DynamicsProcessing write on the same session fails with "invalid parameter operation" — and
+        // two EQs in one chain would double-process anyway. CLOSE always goes out, so they detach.
+        if (action == AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION && AppSettings.eqEnabled.value) {
+            LokiLogger.i(TAG, "Not advertising session $currentAudioSessionId — in-app EQ owns it")
+            return
+        }
         val pkg = packageName ?: "ch.snepilatch.app"
         LokiLogger.i(TAG, "Broadcasting $action: pkg=$pkg, sessionId=$currentAudioSessionId")
         sendBroadcast(
@@ -1179,6 +1275,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         stopJukebox()
         unregisterNetworkCallback()
         releaseControlPlaneLocks()
+        equalizer.release()
         if (openAudioEffectSession) {
             broadcastAudioEffectAction(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION)
             openAudioEffectSession = false

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ExitToApp
+import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -243,6 +244,63 @@ fun AccountScreen(vm: PlaybackViewModel) {
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
         )
 
+        // EQ headroom — a flat attenuation for people running an EXTERNAL equalizer. Off by default:
+        // with no EQ attached it is pure level loss, and the in-app EQ makes its own headroom.
+        val headroomOn by AppSettings.eqHeadroomEnabled.collectAsState()
+        val headroomDb by AppSettings.eqHeadroomDb.collectAsState()
+        // The in-app EQ owns its own gain staging, so stacking this on top would double-attenuate.
+        val inAppEqOn by AppSettings.eqEnabled.collectAsState()
+
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.equalizer), color = SpotifyWhite) },
+            supportingContent = {
+                Text(stringResource(if (inAppEqOn) R.string.state_on else R.string.state_off), color = SpotifyLightGray)
+            },
+            leadingContent = { Icon(Icons.Rounded.GraphicEq, null, tint = SpotifyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpotifyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { vm.navigateTo(ch.snepilatch.app.data.Screen.EQUALIZER) }
+        )
+
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.eq_headroom), color = SpotifyWhite) },
+            supportingContent = {
+                Text(
+                    when {
+                        inAppEqOn -> stringResource(R.string.eq_headroom_handled)
+                        headroomOn -> stringResource(R.string.eq_headroom_on, headroomDb.toInt())
+                        else -> stringResource(R.string.eq_headroom_off)
+                    },
+                    color = SpotifyLightGray
+                )
+            },
+            leadingContent = { Icon(Icons.AutoMirrored.Rounded.VolumeUp, null, tint = SpotifyLightGray) },
+            trailingContent = {
+                Switch(
+                    checked = headroomOn && !inAppEqOn,
+                    enabled = !inAppEqOn,
+                    onCheckedChange = { AppSettings.setEqHeadroomEnabled(it, audioContext) },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = animatedPrimary,
+                        checkedTrackColor = animatedPrimary.copy(alpha = 0.5f),
+                        uncheckedThumbColor = SpotifyLightGray,
+                        uncheckedTrackColor = SpotifyLightGray.copy(alpha = 0.3f)
+                    )
+                )
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+        )
+        if (headroomOn && !inAppEqOn) {
+            Slider(
+                value = headroomDb,
+                onValueChange = { AppSettings.setEqHeadroomDb(it.toInt().toFloat(), audioContext) },
+                valueRange = -18f..0f,
+                steps = 17,
+                colors = SliderDefaults.colors(thumbColor = animatedPrimary, activeTrackColor = animatedPrimary),
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+        }
+
         // Canvas background
         val canvasOn by AppSettings.canvasEnabled.collectAsState()
         ListItem(
@@ -270,10 +328,10 @@ fun AccountScreen(vm: PlaybackViewModel) {
         // Player background style: album-colour gradient vs. the fluid Kawarp album-art warp.
         val gradientBg by AppSettings.playerGradientBg.collectAsState()
         ListItem(
-            headlineContent = { Text("Gradient background", color = SpotifyWhite) },
+            headlineContent = { Text(stringResource(R.string.gradient_background), color = SpotifyWhite) },
             supportingContent = {
                 Text(
-                    if (gradientBg) "Album colour gradient" else "Flowing album art",
+                    stringResource(if (gradientBg) R.string.gradient_bg_on else R.string.gradient_bg_off),
                     color = SpotifyLightGray
                 )
             },

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/EqualizerScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/EqualizerScreen.kt
@@ -1,0 +1,280 @@
+package ch.snepilatch.app.ui.screens
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
+import ch.snepilatch.app.playback.EqualizerHeadroom
+import ch.snepilatch.app.playback.MusicPlaybackService
+import ch.snepilatch.app.ui.theme.*
+import ch.snepilatch.app.viewmodel.AppSettings
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
+import ch.snepilatch.app.viewmodel.ThemeController
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+private val MAX_DB = EqualizerHeadroom.MAX_GAIN_DB
+private const val GRID_STEP_DB = 6f
+
+@Composable
+fun EqualizerScreen(vm: PlaybackViewModel) {
+    val context = LocalContext.current
+    val enabled by AppSettings.eqEnabled.collectAsState()
+    val bands by AppSettings.eqBands.collectAsState()
+    val theme by ThemeController.themeColors.collectAsState()
+    // Reported by the service; on API 26–27 DynamicsProcessing doesn't exist and the EQ stays inert.
+    val supported = MusicPlaybackService.instance?.equalizerSupported ?: true
+    val preamp = EqualizerHeadroom.inputGainDb(bands)
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(top = 12.dp, bottom = LocalBottomOverlayHeight.current.value + 16.dp)
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = { vm.goBack() }) {
+                Icon(Icons.AutoMirrored.Rounded.ArrowBack, stringResource(R.string.back), tint = SpotifyWhite)
+            }
+            Text(stringResource(R.string.equalizer), color = SpotifyWhite, fontSize = 22.sp, fontWeight = FontWeight.Bold)
+        }
+
+        if (!supported) {
+            Text(
+                stringResource(R.string.eq_requires_p),
+                color = SpotifyLightGray,
+                fontSize = 13.sp,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            )
+        }
+
+        EqualizerHeader(
+            enabled = enabled,
+            supported = supported,
+            preamp = preamp,
+            accent = theme.primary,
+            onEnabledChange = { AppSettings.setEqEnabled(it, context) },
+            onFlat = { AppSettings.setEqBands(FloatArray(EqualizerHeadroom.BANDS), context) }
+        )
+
+        EqualizerCurve(
+            bands = bands,
+            enabled = supported && enabled,
+            accent = theme.primary,
+            onCommit = { AppSettings.setEqBands(it, context) }
+        )
+    }
+}
+
+@Composable
+private fun EqualizerHeader(
+    enabled: Boolean,
+    supported: Boolean,
+    preamp: Float,
+    accent: Color,
+    onEnabledChange: (Boolean) -> Unit,
+    onFlat: () -> Unit
+) {
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.eq_in_app), color = SpotifyWhite) },
+        supportingContent = { Text(stringResource(R.string.eq_in_app_desc), color = SpotifyLightGray) },
+        trailingContent = {
+            // Tint from the album palette like every other toggle; the Material default is the
+            // template's purple, which is what made this one stand out.
+            Switch(
+                checked = enabled,
+                enabled = supported,
+                onCheckedChange = onEnabledChange,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = accent,
+                    checkedTrackColor = accent.copy(alpha = 0.5f),
+                    uncheckedThumbColor = SpotifyLightGray,
+                    uncheckedTrackColor = SpotifyLightGray.copy(alpha = 0.3f)
+                )
+            )
+        },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+    )
+
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(stringResource(R.string.eq_preamp, "%.1f".format(preamp)), color = SpotifyWhite, fontSize = 15.sp)
+            Text(stringResource(R.string.eq_preamp_auto), color = SpotifyLightGray, fontSize = 12.sp)
+        }
+        TextButton(onClick = onFlat) { Text(stringResource(R.string.eq_flat), color = accent) }
+    }
+}
+
+/**
+ * Wavelet-style curve editor: one draggable point per band, joined by a Catmull-Rom spline with the
+ * area under it filled. Dragging redraws live but only commits on release — committing rebuilds the
+ * audio effect, which is not a per-frame operation.
+ */
+@Composable
+private fun EqualizerCurve(
+    bands: FloatArray,
+    enabled: Boolean,
+    accent: Color,
+    onCommit: (FloatArray) -> Unit
+) {
+    var live by remember(bands) { mutableStateOf(bands.copyOf()) }
+    var active by remember { mutableIntStateOf(-1) }
+    val alpha = if (enabled) 1f else 0.4f
+
+    BandValueRow(live, accent.copy(alpha = alpha))
+
+    Canvas(
+        Modifier
+            .fillMaxWidth()
+            .height(268.dp)
+            // Vertical inset so a ±12 dB point sits inside the plot instead of on its edge. The
+            // pointer handlers below see this padded box, so touch and drawing stay in one space.
+            .padding(horizontal = 8.dp, vertical = 14.dp)
+            .pointerInput(enabled) {
+                if (!enabled) return@pointerInput
+                detectDragGestures(
+                    // Grab the nearest point and move it BY the drag, never TO the finger — jumping
+                    // the value to wherever the touch landed is what made this feel like it snapped.
+                    onDragStart = { pos -> active = bandAt(pos.x, size.width) },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        val index = active
+                        if (index >= 0) {
+                            val delta = -dragAmount.y / size.height * 2 * MAX_DB
+                            live = live.copyOf().also {
+                                it[index] = (it[index] + delta).coerceIn(-MAX_DB, MAX_DB)
+                            }
+                        }
+                    },
+                    onDragEnd = {
+                        active = -1
+                        onCommit(live.snapped())
+                    }
+                )
+            }
+    ) {
+        drawGrid(accent.copy(alpha = alpha))
+        drawCurve(live, accent.copy(alpha = alpha), active)
+    }
+
+    BandFrequencyRow(SpotifyLightGray.copy(alpha = alpha))
+}
+
+@Composable
+private fun BandValueRow(bands: FloatArray, color: Color) {
+    Row(Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp)) {
+        bands.forEach { gain ->
+            Text(
+                "%.1f".format(gain),
+                color = color,
+                fontSize = 10.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun BandFrequencyRow(color: Color) {
+    Row(Modifier.fillMaxWidth().padding(horizontal = 8.dp)) {
+        EqualizerHeadroom.FREQUENCIES.forEach { frequency ->
+            Text(
+                if (frequency >= 1000f) "${(frequency / 1000).toInt()}k" else "${frequency.toInt()}",
+                color = color,
+                fontSize = 10.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+/** Band whose column contains [x]; columns are equal cells so the label rows line up by weight. */
+private fun bandAt(x: Float, width: Int): Int {
+    val cell = width.toFloat() / EqualizerHeadroom.BANDS
+    return (x / cell).toInt().coerceIn(0, EqualizerHeadroom.BANDS - 1)
+}
+
+/** Round to 0.1 dB on the way to the effect, so stored curves stay tidy. */
+private fun FloatArray.snapped() = FloatArray(size) { (this[it] * 10).roundToInt() / 10f }
+
+private fun DrawScope.pointFor(index: Int, gain: Float): Offset {
+    val cell = size.width / EqualizerHeadroom.BANDS
+    return Offset(cell * (index + 0.5f), (MAX_DB - gain) / (2 * MAX_DB) * size.height)
+}
+
+private fun DrawScope.drawGrid(accent: Color) {
+    var db = -MAX_DB
+    while (db <= MAX_DB) {
+        val y = (MAX_DB - db) / (2 * MAX_DB) * size.height
+        val isZero = abs(db) < 0.01f
+        drawLine(
+            color = if (isZero) accent.copy(alpha = 0.45f) else SpotifyLightGray.copy(alpha = 0.12f),
+            start = Offset(0f, y),
+            end = Offset(size.width, y),
+            strokeWidth = if (isZero) 2f else 1f
+        )
+        db += GRID_STEP_DB
+    }
+}
+
+private fun DrawScope.drawCurve(bands: FloatArray, accent: Color, active: Int) {
+    val points = bands.mapIndexed { index, gain -> pointFor(index, gain) }
+    // Stems, so every band stays visibly grabbable even where the curve is flat.
+    points.forEach { drawLine(accent.copy(alpha = 0.3f), Offset(it.x, 0f), Offset(it.x, size.height), 2f) }
+
+    val path = Path().apply {
+        moveTo(0f, points.first().y)
+        lineTo(points.first().x, points.first().y)
+        for (i in 0 until points.size - 1) {
+            val p0 = points[(i - 1).coerceAtLeast(0)]
+            val p1 = points[i]
+            val p2 = points[i + 1]
+            val p3 = points[(i + 2).coerceAtMost(points.size - 1)]
+            cubicTo(
+                p1.x + (p2.x - p0.x) / 6f, p1.y + (p2.y - p0.y) / 6f,
+                p2.x - (p3.x - p1.x) / 6f, p2.y - (p3.y - p1.y) / 6f,
+                p2.x, p2.y
+            )
+        }
+        lineTo(size.width, points.last().y)
+    }
+    val fill = Path().apply {
+        addPath(path)
+        lineTo(size.width, size.height)
+        lineTo(0f, size.height)
+        close()
+    }
+    drawPath(fill, accent.copy(alpha = 0.18f))
+    drawPath(path, accent, style = Stroke(width = 4f))
+    points.forEachIndexed { index, point ->
+        drawCircle(accent, radius = if (index == active) 18f else 12f, center = point)
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -665,18 +665,10 @@ fun NowPlayingScreen(
                                     )
                                 }
                             }
-                            // EQ button — opens system equalizer
+                            // EQ button: our screen when the in-app EQ owns the session, the system
+                            // effect panel otherwise (see PlaybackViewModel.openEqualizer).
                             FilledTonalIconButton(
-                                onClick = {
-                                    try {
-                                        val eqIntent = android.content.Intent(android.media.audiofx.AudioEffect.ACTION_DISPLAY_AUDIO_EFFECT_CONTROL_PANEL)
-                                        eqIntent.putExtra(android.media.audiofx.AudioEffect.EXTRA_PACKAGE_NAME, shareContext.packageName)
-                                        eqIntent.putExtra(android.media.audiofx.AudioEffect.EXTRA_CONTENT_TYPE, android.media.audiofx.AudioEffect.CONTENT_TYPE_MUSIC)
-                                        shareContext.startActivity(eqIntent)
-                                    } catch (_: Exception) {
-                                        // No EQ app installed
-                                    }
-                                },
+                                onClick = { vm.openEqualizer(shareContext) },
                                 modifier = Modifier.size(44.dp),
                                 colors = IconButtonDefaults.filledTonalIconButtonColors(
                                     containerColor = buttonBg,

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SearchScreen.kt
@@ -368,7 +368,7 @@ private fun SearchPlaylist.toUnified(vm: PlaybackViewModel, ctx: Context) = Unif
     circular = false,
     onClick = { DetailRoutes.openPlaylist(idFromUri(uri)) },
     menu = listOf(
-        OverflowAction(Icons.Rounded.Add, "Save to Library") {
+        OverflowAction(Icons.Rounded.Add, ctx.getString(R.string.save_to_library)) {
             vm.savePlaylist(idFromUri(uri))
         },
         shareAction(ctx, uri)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpotifyApp.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -138,9 +139,13 @@ fun SpotifyApp(vm: PlaybackViewModel) {
         if (screen != Screen.NOW_PLAYING && screen != Screen.LYRICS) contentScreen = screen
     }
 
+    val snackbarContext = androidx.compose.ui.platform.LocalContext.current
     LaunchedEffect(Unit) {
         vm.snackbarMessage.collect { message ->
-            snackbarHostState.showSnackbar(message, duration = SnackbarDuration.Short)
+            snackbarHostState.showSnackbar(
+                snackbarContext.getString(message.id, *message.args.toTypedArray()),
+                duration = SnackbarDuration.Short
+            )
         }
     }
 
@@ -358,6 +363,7 @@ private fun MainContent(screen: Screen, vm: PlaybackViewModel, hazeState: HazeSt
             Screen.LIBRARY -> { LaunchedEffect(Unit) { libraryVm.loadLibrary() }; LibraryScreen() }
             Screen.ACCOUNT -> AccountScreen(vm)
             Screen.QUEUE -> QueueScreen(vm)
+            Screen.EQUALIZER -> EqualizerScreen(vm)
             Screen.PLAYLIST_DETAIL, Screen.ALBUM_DETAIL, Screen.ARTIST_DETAIL, Screen.SHOW_DETAIL -> DetailScreen(vm)
             Screen.NOW_PLAYING, Screen.LYRICS, Screen.LOGIN -> {}
         }
@@ -469,7 +475,7 @@ private fun PlayerMorph(
 
 @Composable
 fun LoadingScreen(
-    error: String?,
+    error: ch.snepilatch.app.data.UiMessage?,
     isRateLimited: Boolean = false,
     cooldownSecondsRemaining: Int = 0,
     onLogin: () -> Unit = {},
@@ -514,7 +520,7 @@ fun LoadingScreen(
                     Spacer(Modifier.height(16.dp))
                     Text(stringResource(R.string.connection_failed), color = SpotifyWhite, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
                     Spacer(Modifier.height(8.dp))
-                    Text(error, color = SpotifyLightGray, fontSize = 13.sp)
+                    Text(error.resolve(LocalContext.current), color = SpotifyLightGray, fontSize = 13.sp)
                     Spacer(Modifier.height(24.dp))
                     Button(
                         onClick = onRetry,

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
@@ -44,6 +44,16 @@ object AppSettings {
     // Canvas background toggle (the URL itself is playback state on PlaybackViewModel).
     val canvasEnabled = MutableStateFlow(false)
 
+    // EQ headroom: a flat attenuation before the audio session, so an EXTERNAL equalizer (Wavelet &
+    // co.) has room to boost into instead of clipping. Off by default — with no EQ attached it is pure
+    // level loss. The in-app EQ doesn't need it; that one computes its own input gain from the curve.
+    val eqHeadroomEnabled = MutableStateFlow(false)
+    val eqHeadroomDb = MutableStateFlow(-6f)
+
+    // In-app 10-band EQ: on/off plus the per-band gains in dB (see EqualizerHeadroom.FREQUENCIES).
+    val eqEnabled = MutableStateFlow(false)
+    val eqBands = MutableStateFlow(FloatArray(ch.snepilatch.app.playback.EqualizerHeadroom.BANDS))
+
     private fun prefs(ctx: Context) = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
     fun load(context: Context) {
@@ -67,6 +77,10 @@ object AppSettings {
             context.resources.updateConfiguration(config, context.resources.displayMetrics)
         }
         canvasEnabled.value = prefs.getBoolean("canvas_enabled", true)
+        eqHeadroomEnabled.value = prefs.getBoolean("eq_headroom_enabled", false)
+        eqHeadroomDb.value = prefs.getFloat("eq_headroom_db", -6f)
+        eqEnabled.value = prefs.getBoolean("eq_enabled", false)
+        eqBands.value = parseBands(prefs.getString("eq_bands", null))
         playerGradientBg.value = prefs.getBoolean("player_gradient_bg", true)
         contentRegion.value = prefs.getString("content_region", "nearest") ?: "nearest"
         notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"
@@ -167,6 +181,41 @@ object AppSettings {
         playerGradientBg.value = enabled
         prefs(context)
             .edit().putBoolean("player_gradient_bg", enabled).apply()
+    }
+
+    /**
+     * Persist the headroom toggle / attenuation and push the new gain to the service. It lands on the
+     * next configure (track change or seek), so the level doesn't jump mid-track.
+     */
+    fun setEqHeadroomEnabled(enabled: Boolean, context: Context) {
+        eqHeadroomEnabled.value = enabled
+        prefs(context).edit().putBoolean("eq_headroom_enabled", enabled).apply()
+        MusicPlaybackService.instance?.applyHeadroomGain()
+    }
+
+    /** Band gains persist as a comma-joined string; anything unparseable falls back to a flat curve. */
+    private fun parseBands(raw: String?): FloatArray {
+        val bands = ch.snepilatch.app.playback.EqualizerHeadroom.BANDS
+        val parsed = raw?.split(",")?.mapNotNull { it.trim().toFloatOrNull() } ?: emptyList()
+        return if (parsed.size == bands) parsed.toFloatArray() else FloatArray(bands)
+    }
+
+    fun setEqEnabled(enabled: Boolean, context: Context) {
+        eqEnabled.value = enabled
+        prefs(context).edit().putBoolean("eq_enabled", enabled).apply()
+        MusicPlaybackService.instance?.syncEqualizer()
+    }
+
+    fun setEqBands(bands: FloatArray, context: Context) {
+        eqBands.value = bands
+        prefs(context).edit().putString("eq_bands", bands.joinToString(",")).apply()
+        MusicPlaybackService.instance?.setEqCurve(bands)
+    }
+
+    fun setEqHeadroomDb(db: Float, context: Context) {
+        eqHeadroomDb.value = db
+        prefs(context).edit().putFloat("eq_headroom_db", db).apply()
+        MusicPlaybackService.instance?.applyHeadroomGain()
     }
 
     /** Persist the canvas toggle. PlaybackViewModel.setCanvasEnabled wraps this to also clear the URL. */

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import ch.snepilatch.app.R
+import ch.snepilatch.app.data.UiMessage
 import ch.snepilatch.app.util.LokiLogger
 import ch.snepilatch.app.util.detectActiveAudioOutput
 import ch.snepilatch.app.util.normalizeSpotifyImageUrl
@@ -68,7 +70,7 @@ class PlaybackViewModel : ViewModel() {
         set(value) { SessionHolder.player = value }
     private var username: String = ""
     val isInitialized = MutableStateFlow(false)
-    val initError = MutableStateFlow<String?>(null)
+    val initError = MutableStateFlow<UiMessage?>(null)
     val rateLimitCooldown = MutableStateFlow(false)
     val cooldownSeconds = MutableStateFlow(0)
     private var initRetryCount = 0
@@ -273,9 +275,11 @@ class PlaybackViewModel : ViewModel() {
     // Loading (detail loading moved to DetailViewModel.isLoading)
     val isStreamLoading = MutableStateFlow(false)
 
-    // Snackbar messages
-    private val _snackbarMessage = kotlinx.coroutines.flow.MutableSharedFlow<String>(extraBufferCapacity = 1)
-    val snackbarMessage: kotlinx.coroutines.flow.SharedFlow<String> = _snackbarMessage
+    // Snackbar messages. Carries a string resource, not a resolved String: the ViewModel has no
+    // Context, and resolving in the UI is what makes the message follow the picked app language.
+    private val _snackbarMessage =
+        kotlinx.coroutines.flow.MutableSharedFlow<UiMessage>(extraBufferCapacity = 1)
+    val snackbarMessage: kotlinx.coroutines.flow.SharedFlow<UiMessage> = _snackbarMessage
 
     // Like state
     val currentTrackLiked = MutableStateFlow(false)
@@ -325,11 +329,11 @@ class PlaybackViewModel : ViewModel() {
     /** Terminal "you must sign in again" state — the notification + now-playing error + loading gate. */
     private fun surfaceAuthLost() {
         authRecovering = false
-        initError.value = "Lost Spotify session — sign in again to continue"
+        initError.value = UiMessage(R.string.auth_lost)
         isInitialized.value = false
         MusicPlaybackService.instance?.showError(
-            "Snepilatch — connection lost",
-            "Tap to reconnect to Spotify"
+            R.string.notif_connection_lost_title,
+            R.string.notif_connection_lost_text
         )
     }
 
@@ -441,14 +445,14 @@ class PlaybackViewModel : ViewModel() {
                     initRetryCount++
                     if (initRetryCount > 5) {
                         LokiLogger.e(TAG, "Rate limited — 5 retries exhausted, giving up")
-                        initError.value = "Connection failed after 5 attempts. Please try again later."
+                        initError.value = UiMessage(R.string.connect_failed)
                         rateLimitCooldown.value = false
                         authRecovering = false
                         return@launch
                     }
                     val cooldownSecs = 20 * initRetryCount // 20s, 40s, 60s...
                     LokiLogger.w(TAG, "Rate limited, attempt $initRetryCount/5, cooling down ${cooldownSecs}s...")
-                    initError.value = "Rate limited — attempt $initRetryCount/5"
+                    initError.value = UiMessage(R.string.rate_limited, listOf(initRetryCount))
                     rateLimitCooldown.value = true
                     for (i in cooldownSecs downTo 1) {
                         cooldownSeconds.value = i
@@ -470,7 +474,7 @@ class PlaybackViewModel : ViewModel() {
                         needsLogin.value = true
                     }
                 } else {
-                    initError.value = msg
+                    initError.value = UiMessage(raw = msg)
                 }
             }
         }
@@ -1705,7 +1709,11 @@ class PlaybackViewModel : ViewModel() {
             kotify.api.playlist.Playlist(sess).addToPlaylist(playlistId, trackUris)
             LokiLogger.i(TAG, "Added ${trackUris.size} tracks to playlist $playlistId")
             _snackbarMessage.tryEmit(
-                if (trackUris.size == 1) "Added to playlist" else "Added ${trackUris.size} tracks to playlist"
+                if (trackUris.size == 1) {
+                    UiMessage(R.string.added_to_playlist)
+                } else {
+                    UiMessage(R.string.added_tracks_to_playlist, listOf(trackUris.size))
+                }
             )
         }
     }
@@ -1762,10 +1770,36 @@ class PlaybackViewModel : ViewModel() {
             try {
                 player?.addToQueue(trackUris)
                 _snackbarMessage.tryEmit(
-                    if (trackUris.size == 1) "Added to queue" else "Added ${trackUris.size} tracks to queue"
+                    if (trackUris.size == 1) {
+                        UiMessage(R.string.added_to_queue_msg)
+                    } else {
+                        UiMessage(R.string.added_tracks_to_queue, listOf(trackUris.size))
+                    }
                 )
             }
             catch (e: Exception) { LokiLogger.e(TAG, "addAllToQueue", e) }
+        }
+    }
+
+    /** In-app EQ on: our screen owns the curve. Off: hand the user to their external EQ app. */
+    fun openEqualizer(context: android.content.Context) {
+        if (AppSettings.eqEnabled.value) {
+            navigateTo(Screen.EQUALIZER)
+            return
+        }
+        try {
+            context.startActivity(
+                android.content.Intent(android.media.audiofx.AudioEffect.ACTION_DISPLAY_AUDIO_EFFECT_CONTROL_PANEL)
+                    .putExtra(android.media.audiofx.AudioEffect.EXTRA_PACKAGE_NAME, context.packageName)
+                    .putExtra(
+                        android.media.audiofx.AudioEffect.EXTRA_CONTENT_TYPE,
+                        android.media.audiofx.AudioEffect.CONTENT_TYPE_MUSIC
+                    )
+            )
+        } catch (e: Exception) {
+            // No system EQ panel on this device; our own screen is the only thing we can offer.
+            LokiLogger.w(TAG, "No external EQ panel: ${e.message}")
+            navigateTo(Screen.EQUALIZER)
         }
     }
 
@@ -1881,7 +1915,7 @@ class PlaybackViewModel : ViewModel() {
             Song(sess).likeSong(trackId)
             currentTrackLiked.value = true
             pushLikeToNotification(true)
-            _snackbarMessage.tryEmit("Added to Liked Songs")
+            _snackbarMessage.tryEmit(UiMessage(R.string.added_to_liked))
         }
     }
 
@@ -1890,7 +1924,7 @@ class PlaybackViewModel : ViewModel() {
             Song(sess).unlikeSong(trackId)
             currentTrackLiked.value = false
             pushLikeToNotification(false)
-            _snackbarMessage.tryEmit("Removed from Liked Songs")
+            _snackbarMessage.tryEmit(UiMessage(R.string.removed_from_liked))
         }
     }
 
@@ -2744,7 +2778,7 @@ class PlaybackViewModel : ViewModel() {
     fun followArtist(artistId: String) {
         launchWithSession("followArtist") { sess ->
             Artist(sess).follow(artistId)
-            _snackbarMessage.tryEmit("Following artist")
+            _snackbarMessage.tryEmit(UiMessage(R.string.following_artist))
         }
     }
 
@@ -2753,7 +2787,7 @@ class PlaybackViewModel : ViewModel() {
             // Playlists live in the rootlist, not the generic library (which rejects PLAYLIST uris),
             // so saveToLibrary needs the current username.
             kotify.api.playlist.Playlist(sess).saveToLibrary(playlistId, username)
-            _snackbarMessage.tryEmit("Saved to Library")
+            _snackbarMessage.tryEmit(UiMessage(R.string.saved_to_library))
         }
     }
 

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -104,8 +104,8 @@
     <string name="playback_ended">Wiedergab fertig</string>
 
     <!-- Backfill -->
-    <string name="tidal_desc">Tidal — FLAC bis 1411 kbps</string>
-    <string name="qobuz_desc">Qobuz — FLAC bis 9216 kbps</string>
+    <string name="tidal_desc">Tidal · FLAC bis 1411 kbps</string>
+    <string name="qobuz_desc">Qobuz · FLAC bis 9216 kbps</string>
 
     <!-- Common (added) -->
     <string name="close">Zuetue</string>
@@ -250,4 +250,45 @@
     <string name="account_section_playback">Abspilig</string>
     <string name="account_section_appearance">Usgsee</string>
     <string name="account_section_notifications">Benachrichtigunge</string>
+
+    <!-- Equalizer -->
+    <string name="state_on">Ii</string>
+    <string name="state_off">Uus</string>
+    <string name="eq_in_app">App-Equalizer</string>
+    <string name="eq_in_app_desc">Übernimmt vo externe Equalizer wie Wavelet</string>
+    <string name="eq_requires_p">Bruucht Android 9 oder nöier.</string>
+    <string name="eq_preamp">Vorverstärkig %1$s dB</string>
+    <string name="eq_preamp_auto">Automatisch</string>
+    <string name="eq_flat">Neutral</string>
+    <string name="eq_headroom">EQ-Headroom</string>
+    <string name="eq_headroom_handled">Macht de App-Equalizer</string>
+    <string name="eq_headroom_on">Wiedergab um %1$d dB abgsenkt. Uf dini grössti EQ-Aahebig istelle</string>
+    <string name="eq_headroom_off">Uus. Ischalte, wenn du en externe Equalizer wie Wavelet bruuchsch</string>
+    <string name="gradient_background">Farbverlauf-Hintergrund</string>
+    <string name="gradient_bg_on">Albumfarbe-Verlauf</string>
+    <string name="gradient_bg_off">Fliessends Albumcover</string>
+    <string name="lossless_on_flac">FLAC</string>
+    <string name="region_nearest">Am nöchste (automatisch)</string>
+    <string name="eternal_jukebox">Eternal Jukebox</string>
+
+    <!-- Snackbars -->
+    <string name="following_artist">Em Künstler folgsch jetz</string>
+    <string name="saved_to_library">Zur Bibliothek dezue</string>
+    <string name="save_to_library">Zur Bibliothek dezuetue</string>
+    <string name="added_to_playlist">Zur Playlist dezue</string>
+    <string name="added_tracks_to_playlist">%1$d Lieder zur Playlist dezue</string>
+    <string name="added_to_queue_msg">Zur Warteschlange dezue</string>
+    <string name="added_tracks_to_queue">%1$d Lieder zur Warteschlange dezue</string>
+
+    <!-- Notification channels -->
+    <string name="notif_channel_playback">Musigwiedergab</string>
+    <string name="notif_channel_playback_desc">Zeigt de Song wo grad lauft</string>
+    <string name="notif_channel_alerts">Warnige</string>
+    <string name="notif_channel_alerts_desc">Verbindigs- und Aamäldigsproblem wo dini Ufmerksamkeit bruuched</string>
+
+    <!-- Connection errors -->
+    <string name="auth_lost">Spotify-Sitzig verlore. Mäld di nomal aa, zum wiitermache</string>
+    <string name="connect_failed">Verbindig na 5 Versüech fehlgschlage. Bitte spöter nomal probiere.</string>
+    <string name="notif_connection_lost_title">Snepilatch: Verbindig verlore</string>
+    <string name="notif_connection_lost_text">Tippe, zum Spotify neu verbinde</string>
 </resources>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -104,8 +104,8 @@
     <string name="playback_ended">Wiedergabe beendet</string>
 
     <!-- Backfill -->
-    <string name="tidal_desc">Tidal — FLAC bis 1411 kbps</string>
-    <string name="qobuz_desc">Qobuz — FLAC bis 9216 kbps</string>
+    <string name="tidal_desc">Tidal · FLAC bis 1411 kbps</string>
+    <string name="qobuz_desc">Qobuz · FLAC bis 9216 kbps</string>
 
     <!-- Common (added) -->
     <string name="close">Schließen</string>
@@ -251,4 +251,44 @@
     <string name="account_section_playback">Wiedergabe</string>
     <string name="account_section_appearance">Erscheinungsbild</string>
     <string name="account_section_notifications">Benachrichtigungen</string>
+
+    <!-- Equalizer -->
+    <string name="state_on">Ein</string>
+    <string name="state_off">Aus</string>
+    <string name="eq_in_app">App-Equalizer</string>
+    <string name="eq_in_app_desc">Übernimmt von externen Equalizern wie Wavelet</string>
+    <string name="eq_requires_p">Benötigt Android 9 oder neuer.</string>
+    <string name="eq_preamp">Vorverstärkung %1$s dB</string>
+    <string name="eq_preamp_auto">Automatisch</string>
+    <string name="eq_flat">Neutral</string>
+    <string name="eq_headroom">EQ-Headroom</string>
+    <string name="eq_headroom_handled">Übernimmt der App-Equalizer</string>
+    <string name="eq_headroom_on">Wiedergabe um %1$d dB gesenkt. Auf deine grösste EQ-Anhebung einstellen</string>
+    <string name="eq_headroom_off">Aus. Einschalten, wenn du einen externen Equalizer wie Wavelet nutzt</string>
+    <string name="gradient_background">Farbverlauf-Hintergrund</string>
+    <string name="gradient_bg_on">Albumfarben-Verlauf</string>
+    <string name="gradient_bg_off">Fliessendes Albumcover</string>
+    <string name="lossless_on_flac">FLAC</string>
+    <string name="region_nearest">Nächstgelegen (automatisch)</string>
+
+    <!-- Snackbars -->
+    <string name="following_artist">Künstler gefolgt</string>
+    <string name="saved_to_library">Zur Bibliothek hinzugefügt</string>
+    <string name="save_to_library">Zur Bibliothek hinzufügen</string>
+    <string name="added_to_playlist">Zur Playlist hinzugefügt</string>
+    <string name="added_tracks_to_playlist">%1$d Titel zur Playlist hinzugefügt</string>
+    <string name="added_to_queue_msg">Zur Warteschlange hinzugefügt</string>
+    <string name="added_tracks_to_queue">%1$d Titel zur Warteschlange hinzugefügt</string>
+
+    <!-- Notification channels -->
+    <string name="notif_channel_playback">Musikwiedergabe</string>
+    <string name="notif_channel_playback_desc">Zeigt den aktuell laufenden Titel</string>
+    <string name="notif_channel_alerts">Warnungen</string>
+    <string name="notif_channel_alerts_desc">Verbindungs- und Anmeldeprobleme, die deine Aufmerksamkeit brauchen</string>
+
+    <!-- Connection errors -->
+    <string name="auth_lost">Spotify-Sitzung verloren. Melde dich erneut an, um fortzufahren</string>
+    <string name="connect_failed">Verbindung nach 5 Versuchen fehlgeschlagen. Bitte später erneut versuchen.</string>
+    <string name="notif_connection_lost_title">Snepilatch: Verbindung verloren</string>
+    <string name="notif_connection_lost_text">Tippen, um Spotify neu zu verbinden</string>
 </resources>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -104,8 +104,8 @@
     <string name="playback_ended">Воспроизведение завершено</string>
 
     <!-- Backfill -->
-    <string name="tidal_desc">Tidal — FLAC до 1411 кбит/с</string>
-    <string name="qobuz_desc">Qobuz — FLAC до 9216 кбит/с</string>
+    <string name="tidal_desc">Tidal · FLAC до 1411 кбит/с</string>
+    <string name="qobuz_desc">Qobuz · FLAC до 9216 кбит/с</string>
 
     <!-- Common (added) -->
     <string name="close">Закрыть</string>
@@ -250,4 +250,45 @@
     <string name="account_section_playback">Воспроизведение</string>
     <string name="account_section_appearance">Внешний вид</string>
     <string name="account_section_notifications">Уведомления</string>
+
+    <!-- Equalizer -->
+    <string name="state_on">Вкл</string>
+    <string name="state_off">Выкл</string>
+    <string name="eq_in_app">Встроенный эквалайзер</string>
+    <string name="eq_in_app_desc">Заменяет внешние эквалайзеры вроде Wavelet</string>
+    <string name="eq_requires_p">Требуется Android 9 или новее.</string>
+    <string name="eq_preamp">Предусиление %1$s дБ</string>
+    <string name="eq_preamp_auto">Автоматически</string>
+    <string name="eq_flat">Сброс</string>
+    <string name="eq_headroom">Запас для эквалайзера</string>
+    <string name="eq_headroom_handled">Управляется встроенным эквалайзером</string>
+    <string name="eq_headroom_on">Громкость снижена на %1$d дБ. Установите по самому большому подъёму эквалайзера</string>
+    <string name="eq_headroom_off">Выкл. Включите, если используете внешний эквалайзер вроде Wavelet</string>
+    <string name="gradient_background">Градиентный фон</string>
+    <string name="gradient_bg_on">Градиент из цветов обложки</string>
+    <string name="gradient_bg_off">Плавающая обложка</string>
+    <string name="lossless_on_flac">FLAC</string>
+    <string name="region_nearest">Ближайший (авто)</string>
+    <string name="eternal_jukebox">Eternal Jukebox</string>
+
+    <!-- Snackbars -->
+    <string name="following_artist">Вы подписались на исполнителя</string>
+    <string name="saved_to_library">Добавлено в медиатеку</string>
+    <string name="save_to_library">Добавить в медиатеку</string>
+    <string name="added_to_playlist">Добавлено в плейлист</string>
+    <string name="added_tracks_to_playlist">Добавлено в плейлист треков: %1$d</string>
+    <string name="added_to_queue_msg">Добавлено в очередь</string>
+    <string name="added_tracks_to_queue">Добавлено в очередь треков: %1$d</string>
+
+    <!-- Notification channels -->
+    <string name="notif_channel_playback">Воспроизведение музыки</string>
+    <string name="notif_channel_playback_desc">Показывает текущий трек</string>
+    <string name="notif_channel_alerts">Предупреждения</string>
+    <string name="notif_channel_alerts_desc">Проблемы с подключением и входом, требующие внимания</string>
+
+    <!-- Connection errors -->
+    <string name="auth_lost">Сессия Spotify потеряна. Войдите снова, чтобы продолжить</string>
+    <string name="connect_failed">Не удалось подключиться после 5 попыток. Повторите попытку позже.</string>
+    <string name="notif_connection_lost_title">Snepilatch: соединение потеряно</string>
+    <string name="notif_connection_lost_text">Нажмите, чтобы переподключиться к Spotify</string>
 </resources>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -60,8 +60,8 @@
     <string name="lossless_on_flac">FLAC</string>
     <string name="lossless_off">Standard quality</string>
     <string name="lossless_provider">Lossless Provider</string>
-    <string name="tidal_desc">Tidal — FLAC up to 1411kbps</string>
-    <string name="qobuz_desc">Qobuz — FLAC up to 9216kbps</string>
+    <string name="tidal_desc">Tidal · FLAC up to 1411kbps</string>
+    <string name="qobuz_desc">Qobuz · FLAC up to 9216kbps</string>
     <string name="canvas_background">Canvas Background</string>
     <string name="canvas_on">Looping video behind album art</string>
     <string name="canvas_off">Off</string>
@@ -253,4 +253,42 @@
     <string name="account_section_playback">Playback</string>
     <string name="account_section_appearance">Appearance</string>
     <string name="account_section_notifications">Notifications</string>
+
+    <!-- Equalizer -->
+    <string name="state_on">On</string>
+    <string name="state_off">Off</string>
+    <string name="eq_in_app">In-app equalizer</string>
+    <string name="eq_in_app_desc">Takes over from external EQs like Wavelet</string>
+    <string name="eq_requires_p">Requires Android 9 or newer.</string>
+    <string name="eq_preamp">Preamp %1$s dB</string>
+    <string name="eq_preamp_auto">Automatic</string>
+    <string name="eq_flat">Flat</string>
+    <string name="eq_headroom">EQ headroom</string>
+    <string name="eq_headroom_handled">Handled by the in-app equalizer</string>
+    <string name="eq_headroom_on">Playback lowered %1$d dB. Set this to match your largest EQ boost</string>
+    <string name="eq_headroom_off">Off. Enable if you use an external equalizer like Wavelet</string>
+    <string name="gradient_background">Gradient background</string>
+    <string name="gradient_bg_on">Album colour gradient</string>
+    <string name="gradient_bg_off">Flowing album art</string>
+
+    <!-- Snackbars -->
+    <string name="following_artist">Following artist</string>
+    <string name="saved_to_library">Saved to Library</string>
+    <string name="save_to_library">Save to Library</string>
+    <string name="added_to_playlist">Added to playlist</string>
+    <string name="added_tracks_to_playlist">Added %1$d tracks to playlist</string>
+    <string name="added_to_queue_msg">Added to queue</string>
+    <string name="added_tracks_to_queue">Added %1$d tracks to queue</string>
+
+    <!-- Notification channels -->
+    <string name="notif_channel_playback">Music Playback</string>
+    <string name="notif_channel_playback_desc">Shows current playing track</string>
+    <string name="notif_channel_alerts">Alerts</string>
+    <string name="notif_channel_alerts_desc">Connection and sign-in problems that need your attention</string>
+
+    <!-- Connection errors -->
+    <string name="auth_lost">Lost Spotify session. Sign in again to continue</string>
+    <string name="connect_failed">Connection failed after 5 attempts. Please try again later.</string>
+    <string name="notif_connection_lost_title">Snepilatch: connection lost</string>
+    <string name="notif_connection_lost_text">Tap to reconnect to Spotify</string>
 </resources>

--- a/src/app/src/test/java/ch/snepilatch/app/playback/EqualizerHeadroomTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/playback/EqualizerHeadroomTest.kt
@@ -1,0 +1,51 @@
+package ch.snepilatch.app.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.max
+
+class EqualizerHeadroomTest {
+
+    private fun flat() = FloatArray(EqualizerHeadroom.BANDS)
+
+    @Test
+    fun `input gain cancels the largest boost`() {
+        val curve = flat().also {
+            it[3] = 9f
+            it[7] = 4f
+        }
+        assertEquals(-9f, EqualizerHeadroom.inputGainDb(curve), 1e-6f)
+    }
+
+    @Test
+    fun `flat and cut-only curves need no headroom`() {
+        assertEquals(0f, EqualizerHeadroom.inputGainDb(flat()), 1e-6f)
+        assertEquals(0f, EqualizerHeadroom.inputGainDb(FloatArray(EqualizerHeadroom.BANDS) { -6f }), 1e-6f)
+    }
+
+    @Test
+    fun `never above minus the largest positive gain, for any curve`() {
+        val curves = listOf(
+            flat(),
+            FloatArray(EqualizerHeadroom.BANDS) { -12f },
+            FloatArray(EqualizerHeadroom.BANDS) { 12f },
+            FloatArray(EqualizerHeadroom.BANDS) { if (it % 2 == 0) 12f else -12f },
+            FloatArray(EqualizerHeadroom.BANDS) { it - 5f },
+            flat().also { it[0] = 0.5f }
+        )
+        for (curve in curves) {
+            val peak = max(0f, curve.max())
+            assertTrue(
+                "curve ${curve.toList()}",
+                EqualizerHeadroom.inputGainDb(curve) <= -peak + 1e-6f
+            )
+        }
+    }
+
+    @Test
+    fun `band layout matches the ten sliders`() {
+        assertEquals(10, EqualizerHeadroom.BANDS)
+        assertEquals(EqualizerHeadroom.BANDS, EqualizerHeadroom.FREQUENCIES.size)
+    }
+}

--- a/src/app/src/test/java/ch/snepilatch/app/playback/GainAudioProcessorTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/playback/GainAudioProcessorTest.kt
@@ -1,0 +1,88 @@
+package ch.snepilatch.app.playback
+
+import androidx.media3.common.C
+import androidx.media3.common.audio.AudioProcessor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.math.abs
+
+class GainAudioProcessorTest {
+
+    private val stereo16 = AudioProcessor.AudioFormat(44100, 2, C.ENCODING_PCM_16BIT)
+
+    private fun buffer(samples: ShortArray): ByteBuffer =
+        ByteBuffer.allocate(samples.size * 2).order(ByteOrder.LITTLE_ENDIAN).apply {
+            samples.forEach { putShort(it) }
+            flip()
+        }
+
+    private fun shorts(buf: ByteBuffer): ShortArray {
+        val out = ShortArray(buf.remaining() / 2)
+        buf.order(ByteOrder.LITTLE_ENDIAN).asShortBuffer().get(out)
+        return out
+    }
+
+    /** Push [samples] through a processor already settled at its gain (configure starts at target). */
+    private fun process(processor: GainAudioProcessor, samples: ShortArray): ShortArray {
+        processor.configure(stereo16)
+        processor.flush(AudioProcessor.StreamMetadata.DEFAULT)
+        processor.queueInput(buffer(samples))
+        return shorts(processor.output)
+    }
+
+    @Test
+    fun `applies gain to 16 bit samples`() {
+        val p = GainAudioProcessor()
+        p.setGain(0.5f)
+        val out = process(p, shortArrayOf(1000, -1000, 32767, -32768))
+        assertTrue(out.contentEquals(shortArrayOf(500, -500, 16383, -16384)))
+    }
+
+    @Test
+    fun `unity gain is inactive and leaves the buffer untouched`() {
+        val p = GainAudioProcessor()
+        assertFalse(p.isActive())
+        // configure() reports NOT_SET for an inactive processor — the sink then bypasses it entirely.
+        assertEquals(AudioProcessor.AudioFormat.NOT_SET, p.configure(stereo16))
+
+        // Even if it is in the chain (gain returned to 1.0 while configured), audio passes unchanged.
+        p.setGain(0.5f)
+        val input = shortArrayOf(1000, -1000, 500, -500)
+        p.setGain(1f)
+        assertTrue(process(p, input).contentEquals(input))
+    }
+
+    @Test
+    fun `unsupported encoding is bypassed via NOT_SET`() {
+        val p = GainAudioProcessor()
+        p.setGain(0.5f)
+        val float32 = AudioProcessor.AudioFormat(44100, 2, C.ENCODING_PCM_FLOAT)
+        assertEquals(AudioProcessor.AudioFormat.NOT_SET, p.configure(float32))
+    }
+
+    @Test
+    fun `gain change ramps without a discontinuity`() {
+        val p = GainAudioProcessor()
+        p.setGain(1f)
+        p.configure(stereo16)
+        p.flush(AudioProcessor.StreamMetadata.DEFAULT)
+        // Full-scale DC: every output sample is the gain curve itself, so a jump would show up directly.
+        val dc = ShortArray(8000) { 20000 }
+        p.setGain(0.25f)
+        p.queueInput(buffer(dc))
+        val out = shorts(p.output)
+
+        var maxStep = 0
+        for (i in 2 until out.size) {
+            // Compare across a frame (2 channels): within a frame the gain is constant by design.
+            maxStep = maxOf(maxStep, abs(out[i] - out[i - 2]))
+        }
+        // 30 ms ramp at 44.1 kHz => ~0.00076 gain per frame => ~16 counts at 20000 full scale.
+        assertTrue("max step was $maxStep", maxStep <= 32)
+        assertEquals(5000, out.last().toInt())
+    }
+}

--- a/src/app/src/test/java/ch/snepilatch/app/playback/LoudnessNormalizationTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/playback/LoudnessNormalizationTest.kt
@@ -1,0 +1,34 @@
+package ch.snepilatch.app.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LoudnessNormalizationTest {
+
+    @Test
+    fun `dB to linear`() {
+        assertEquals(1f, LoudnessNormalization.dbToLinear(0.0), 1e-6f)
+        assertEquals(0.5012f, LoudnessNormalization.dbToLinear(-6.0), 1e-4f)
+        assertEquals(0.1f, LoudnessNormalization.dbToLinear(-20.0), 1e-6f)
+    }
+
+    @Test
+    fun `louder than target is attenuated to the target`() {
+        // -8 dB track, -14 target => -6 dB of attenuation.
+        assertEquals(LoudnessNormalization.dbToLinear(-6.0), LoudnessNormalization.gainFor(-8.0), 1e-6f)
+    }
+
+    @Test
+    fun `quieter than target is never boosted`() {
+        assertEquals(1f, LoudnessNormalization.gainFor(-20.0), 1e-6f)
+        assertEquals(1f, LoudnessNormalization.gainFor(-14.0), 1e-6f)
+    }
+
+    @Test
+    fun `missing loudness falls back to the configured attenuation`() {
+        assertEquals(LoudnessNormalization.dbToLinear(-6.0), LoudnessNormalization.gainFor(null), 1e-6f)
+        assertEquals(LoudnessNormalization.dbToLinear(-12.0), LoudnessNormalization.gainFor(null, -12.0), 1e-6f)
+        // A positive fallback would boost — clamped away.
+        assertEquals(1f, LoudnessNormalization.gainFor(null, 3.0), 1e-6f)
+    }
+}


### PR DESCRIPTION
Adds a 10-band equalizer on the player's audio session that computes its own preamp from the curve, plus an opt-in flat attenuation ("EQ headroom") for people running an external equalizer. While the in-app EQ is on the session is no longer advertised to external effect apps, and the effect attaches at maximum priority because AudioFlinger rejects every write from a non-controlling client.

Closes #460