### PR TITLE
Replace the action snackbars with failure-only toasts

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpfyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpfyApp.kt
@@ -112,7 +112,6 @@ fun SpfyApp(vm: PlaybackViewModel) {
     val currentTrackUri by vm.currentTrackUri.collectAsState()
     val showDevices by vm.showDevices.collectAsState()
     val hazeState = remember { HazeState() }
-    val snackbarHostState = remember { SnackbarHostState() }
     val bottomOverlayHeight = remember { mutableStateOf(0.dp) }
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
@@ -139,13 +138,14 @@ fun SpfyApp(vm: PlaybackViewModel) {
         if (screen != Screen.NOW_PLAYING && screen != Screen.LYRICS) contentScreen = screen
     }
 
-    val snackbarContext = androidx.compose.ui.platform.LocalContext.current
+    val toastContext = androidx.compose.ui.platform.LocalContext.current
     LaunchedEffect(Unit) {
-        vm.snackbarMessage.collect { message ->
-            snackbarHostState.showSnackbar(
-                snackbarContext.getString(message.id, *message.args.toTypedArray()),
-                duration = SnackbarDuration.Short
-            )
+        vm.errorMessage.collect { message ->
+            android.widget.Toast.makeText(
+                toastContext,
+                message.resolve(toastContext),
+                android.widget.Toast.LENGTH_SHORT
+            ).show()
         }
     }
 
@@ -236,19 +236,6 @@ fun SpfyApp(vm: PlaybackViewModel) {
             ) {
                 BottomNav(screen, vm, hazeState)
             }
-        }
-
-        // Snackbar
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 140.dp)
-        ) { data ->
-            Snackbar(
-                snackbarData = data,
-                containerColor = SpfyGray,
-                contentColor = SpfyWhite,
-                shape = RoundedCornerShape(8.dp)
-            )
         }
 
         // Expanding player: lerps from the mini bar's bounds to fullscreen,

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.annotation.StringRes
 import ch.snepilatch.app.R
 import ch.snepilatch.app.data.UiMessage
 import ch.snepilatch.app.util.LokiLogger
@@ -275,11 +276,13 @@ class PlaybackViewModel : ViewModel() {
     // Loading (detail loading moved to DetailViewModel.isLoading)
     val isStreamLoading = MutableStateFlow(false)
 
-    // Snackbar messages. Carries a string resource, not a resolved String: the ViewModel has no
-    // Context, and resolving in the UI is what makes the message follow the picked app language.
-    private val _snackbarMessage =
+    // Failures the user should know about, shown as a system toast. Successful actions stay silent:
+    // the like button filling in or the track appearing in the queue is its own confirmation.
+    // Carries a string resource, not a resolved String — the ViewModel has no Context, and resolving
+    // in the UI is what makes the message follow the picked app language.
+    private val _errorMessage =
         kotlinx.coroutines.flow.MutableSharedFlow<UiMessage>(extraBufferCapacity = 1)
-    val snackbarMessage: kotlinx.coroutines.flow.SharedFlow<UiMessage> = _snackbarMessage
+    val errorMessage: kotlinx.coroutines.flow.SharedFlow<UiMessage> = _errorMessage
 
     // Like state
     val currentTrackLiked = MutableStateFlow(false)
@@ -753,7 +756,11 @@ class PlaybackViewModel : ViewModel() {
      * `viewModelScope.launch(Dispatchers.IO) { try { val s = session ?: return@launch ... } catch ... }`
      * that appeared throughout the ViewModel.
      */
-    private fun launchWithSession(tag: String, block: suspend (Session) -> Unit): Job =
+    private fun launchWithSession(
+        tag: String,
+        @StringRes errorMessage: Int? = null,
+        block: suspend (Session) -> Unit
+    ): Job =
         viewModelScope.launch(Dispatchers.IO) {
             val sess = session ?: return@launch
             try {
@@ -762,6 +769,7 @@ class PlaybackViewModel : ViewModel() {
                 throw e
             } catch (e: Exception) {
                 LokiLogger.e(TAG, tag, e)
+                errorMessage?.let { _errorMessage.tryEmit(UiMessage(it)) }
             }
         }
 
@@ -1705,16 +1713,9 @@ class PlaybackViewModel : ViewModel() {
      */
     fun addTracksToPlaylist(playlistId: String, trackUris: List<String>) {
         if (trackUris.isEmpty()) return
-        launchWithSession("addTracksToPlaylist") { sess ->
+        launchWithSession("addTracksToPlaylist", R.string.error_add_playlist) { sess ->
             kotify.api.playlist.Playlist(sess).addToPlaylist(playlistId, trackUris)
             LokiLogger.i(TAG, "Added ${trackUris.size} tracks to playlist $playlistId")
-            _snackbarMessage.tryEmit(
-                if (trackUris.size == 1) {
-                    UiMessage(R.string.added_to_playlist)
-                } else {
-                    UiMessage(R.string.added_tracks_to_playlist, listOf(trackUris.size))
-                }
-            )
         }
     }
 
@@ -1769,15 +1770,11 @@ class PlaybackViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 player?.addToQueue(trackUris)
-                _snackbarMessage.tryEmit(
-                    if (trackUris.size == 1) {
-                        UiMessage(R.string.added_to_queue_msg)
-                    } else {
-                        UiMessage(R.string.added_tracks_to_queue, listOf(trackUris.size))
-                    }
-                )
             }
-            catch (e: Exception) { LokiLogger.e(TAG, "addAllToQueue", e) }
+            catch (e: Exception) {
+                LokiLogger.e(TAG, "addAllToQueue", e)
+                _errorMessage.tryEmit(UiMessage(R.string.error_add_queue))
+            }
         }
     }
 
@@ -1911,20 +1908,18 @@ class PlaybackViewModel : ViewModel() {
     }
 
     fun likeSong(trackId: String) {
-        launchWithSession("likeSong") { sess ->
+        launchWithSession("likeSong", R.string.error_like) { sess ->
             Song(sess).likeSong(trackId)
             currentTrackLiked.value = true
             pushLikeToNotification(true)
-            _snackbarMessage.tryEmit(UiMessage(R.string.added_to_liked))
         }
     }
 
     fun unlikeSong(trackId: String) {
-        launchWithSession("unlikeSong") { sess ->
+        launchWithSession("unlikeSong", R.string.error_like) { sess ->
             Song(sess).unlikeSong(trackId)
             currentTrackLiked.value = false
             pushLikeToNotification(false)
-            _snackbarMessage.tryEmit(UiMessage(R.string.removed_from_liked))
         }
     }
 
@@ -2776,18 +2771,16 @@ class PlaybackViewModel : ViewModel() {
     // --- Playlist Management ---
 
     fun followArtist(artistId: String) {
-        launchWithSession("followArtist") { sess ->
+        launchWithSession("followArtist", R.string.error_follow) { sess ->
             Artist(sess).follow(artistId)
-            _snackbarMessage.tryEmit(UiMessage(R.string.following_artist))
         }
     }
 
     fun savePlaylist(playlistId: String) {
-        launchWithSession("savePlaylist") { sess ->
+        launchWithSession("savePlaylist", R.string.error_save_library) { sess ->
             // Playlists live in the rootlist, not the generic library (which rejects PLAYLIST uris),
             // so saveToLibrary needs the current username.
             kotify.api.playlist.Playlist(sess).saveToLibrary(playlistId, username)
-            _snackbarMessage.tryEmit(UiMessage(R.string.saved_to_library))
         }
     }
 

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -97,8 +97,6 @@
     <string name="searching_devices">Am Grät sueche…</string>
 
     <!-- Notification -->
-    <string name="added_to_liked">Zu de Lieblingssongs dezue</string>
-    <string name="removed_from_liked">Vo de Lieblingssongs weg</string>
 
     <!-- Playback -->
     <string name="playback_ended">Wiedergab fertig</string>
@@ -272,13 +270,7 @@
     <string name="eternal_jukebox">Eternal Jukebox</string>
 
     <!-- Snackbars -->
-    <string name="following_artist">Em Künstler folgsch jetz</string>
-    <string name="saved_to_library">Zur Bibliothek dezue</string>
     <string name="save_to_library">Zur Bibliothek dezuetue</string>
-    <string name="added_to_playlist">Zur Playlist dezue</string>
-    <string name="added_tracks_to_playlist">%1$d Lieder zur Playlist dezue</string>
-    <string name="added_to_queue_msg">Zur Warteschlange dezue</string>
-    <string name="added_tracks_to_queue">%1$d Lieder zur Warteschlange dezue</string>
 
     <!-- Notification channels -->
     <string name="notif_channel_playback">Musigwiedergab</string>
@@ -291,4 +283,11 @@
     <string name="connect_failed">Verbindig na 5 Versüech fehlgschlage. Bitte spöter nomal probiere.</string>
     <string name="notif_connection_lost_title">Snepilatch: Verbindig verlore</string>
     <string name="notif_connection_lost_text">Tippe, zum Spotify neu verbinde</string>
+
+    <!-- Action errors -->
+    <string name="error_like">Lieblingssongs händ nöd chöne aktualisiert werde</string>
+    <string name="error_follow">Em Künstler häsch nöd chöne folge</string>
+    <string name="error_save_library">Häts nöd i d Bibliothek gschafft</string>
+    <string name="error_add_playlist">Häts nöd i d Playlist gschafft</string>
+    <string name="error_add_queue">Häts nöd i d Warteschlange gschafft</string>
 </resources>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -97,8 +97,6 @@
     <string name="searching_devices">Suche nach Geräten…</string>
 
     <!-- Notification -->
-    <string name="added_to_liked">Zu Lieblingssongs hinzugefügt</string>
-    <string name="removed_from_liked">Aus Lieblingssongs entfernt</string>
 
     <!-- Playback -->
     <string name="playback_ended">Wiedergabe beendet</string>
@@ -272,13 +270,7 @@
     <string name="region_nearest">Nächstgelegen (automatisch)</string>
 
     <!-- Snackbars -->
-    <string name="following_artist">Künstler gefolgt</string>
-    <string name="saved_to_library">Zur Bibliothek hinzugefügt</string>
     <string name="save_to_library">Zur Bibliothek hinzufügen</string>
-    <string name="added_to_playlist">Zur Playlist hinzugefügt</string>
-    <string name="added_tracks_to_playlist">%1$d Titel zur Playlist hinzugefügt</string>
-    <string name="added_to_queue_msg">Zur Warteschlange hinzugefügt</string>
-    <string name="added_tracks_to_queue">%1$d Titel zur Warteschlange hinzugefügt</string>
 
     <!-- Notification channels -->
     <string name="notif_channel_playback">Musikwiedergabe</string>
@@ -291,4 +283,11 @@
     <string name="connect_failed">Verbindung nach 5 Versuchen fehlgeschlagen. Bitte später erneut versuchen.</string>
     <string name="notif_connection_lost_title">Snepilatch: Verbindung verloren</string>
     <string name="notif_connection_lost_text">Tippen, um Spotify neu zu verbinden</string>
+
+    <!-- Action errors -->
+    <string name="error_like">Lieblingssongs konnten nicht aktualisiert werden</string>
+    <string name="error_follow">Künstler konnte nicht gefolgt werden</string>
+    <string name="error_save_library">Konnte nicht zur Bibliothek hinzugefügt werden</string>
+    <string name="error_add_playlist">Konnte nicht zur Playlist hinzugefügt werden</string>
+    <string name="error_add_queue">Konnte nicht zur Warteschlange hinzugefügt werden</string>
 </resources>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -97,8 +97,6 @@
     <string name="searching_devices">Поиск устройств…</string>
 
     <!-- Notification -->
-    <string name="added_to_liked">Добавлено в любимые песни</string>
-    <string name="removed_from_liked">Удалено из любимых песен</string>
 
     <!-- Playback -->
     <string name="playback_ended">Воспроизведение завершено</string>
@@ -272,13 +270,7 @@
     <string name="eternal_jukebox">Eternal Jukebox</string>
 
     <!-- Snackbars -->
-    <string name="following_artist">Вы подписались на исполнителя</string>
-    <string name="saved_to_library">Добавлено в медиатеку</string>
     <string name="save_to_library">Добавить в медиатеку</string>
-    <string name="added_to_playlist">Добавлено в плейлист</string>
-    <string name="added_tracks_to_playlist">Добавлено в плейлист треков: %1$d</string>
-    <string name="added_to_queue_msg">Добавлено в очередь</string>
-    <string name="added_tracks_to_queue">Добавлено в очередь треков: %1$d</string>
 
     <!-- Notification channels -->
     <string name="notif_channel_playback">Воспроизведение музыки</string>
@@ -291,4 +283,11 @@
     <string name="connect_failed">Не удалось подключиться после 5 попыток. Повторите попытку позже.</string>
     <string name="notif_connection_lost_title">Snepilatch: соединение потеряно</string>
     <string name="notif_connection_lost_text">Нажмите, чтобы переподключиться к Spotify</string>
+
+    <!-- Action errors -->
+    <string name="error_like">Не удалось обновить любимые песни</string>
+    <string name="error_follow">Не удалось подписаться на исполнителя</string>
+    <string name="error_save_library">Не удалось добавить в медиатеку</string>
+    <string name="error_add_playlist">Не удалось добавить в плейлист</string>
+    <string name="error_add_queue">Не удалось добавить в очередь</string>
 </resources>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -102,8 +102,6 @@
     <string name="searching_devices">Searching for devices…</string>
 
     <!-- Notification -->
-    <string name="added_to_liked">Added to Liked Songs</string>
-    <string name="removed_from_liked">Removed from Liked Songs</string>
 
     <!-- Playback -->
     <string name="playback_ended">Playback ended</string>
@@ -272,13 +270,7 @@
     <string name="gradient_bg_off">Flowing album art</string>
 
     <!-- Snackbars -->
-    <string name="following_artist">Following artist</string>
-    <string name="saved_to_library">Saved to Library</string>
     <string name="save_to_library">Save to Library</string>
-    <string name="added_to_playlist">Added to playlist</string>
-    <string name="added_tracks_to_playlist">Added %1$d tracks to playlist</string>
-    <string name="added_to_queue_msg">Added to queue</string>
-    <string name="added_tracks_to_queue">Added %1$d tracks to queue</string>
 
     <!-- Notification channels -->
     <string name="notif_channel_playback">Music Playback</string>
@@ -291,4 +283,11 @@
     <string name="connect_failed">Connection failed after 5 attempts. Please try again later.</string>
     <string name="notif_connection_lost_title">Snepilatch: connection lost</string>
     <string name="notif_connection_lost_text">Tap to reconnect to Spotify</string>
+
+    <!-- Action errors -->
+    <string name="error_like">Could not update Liked Songs</string>
+    <string name="error_follow">Could not follow artist</string>
+    <string name="error_save_library">Could not save to library</string>
+    <string name="error_add_playlist">Could not add to playlist</string>
+    <string name="error_add_queue">Could not add to queue</string>
 </resources>


### PR DESCRIPTION
Successful actions no longer announce themselves; the five that used to show a snackbar now raise a system toast only when they fail. Removes the SnackbarHost and the confirmation strings.

Closes #464