### PR TITLE
Remove em dashes from documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,7 @@ src/app/src/main/java/ch/snepilatch/app/
 - **`util/`** is pure. No Compose, no ViewModel, no service. Top-level functions, easy to test.
 - **`data/`** is types + mappers. No business logic. The mappers translate KotifyClient DTOs into the UI models defined here.
 - **`playback/`** owns everything Android about playback: the foreground service, ExoPlayer, the media buttons, the session holder. Code here can use Android APIs but should not reach into the ViewModel.
-- **`ui/`** is Compose only. Screens take a `PlaybackViewModel` and read its state flows. No direct API calls, no service references — go through the ViewModel.
+- **`ui/`** is Compose only. Screens take a `PlaybackViewModel` and read its state flows. No direct API calls, no service references; go through the ViewModel.
 - **`viewmodel/`** holds the single `PlaybackViewModel`. It owns the UI state, dispatches user actions, and bridges between the UI layer and the playback / data layers.
 
 ## Session ownership
@@ -47,7 +47,7 @@ There is exactly one Kotify `Session`, `PlayerConnect`, `SpotifyPlayback`, and `
 
 **Do not** create `Session` or `PlayerConnect` in any other place. **Do not** store them on Activity-scoped objects. The whole point of `SessionHolder` is that headphone-cold-launch and similar non-Activity entry points need them.
 
-## Playback rules — read before touching
+## Playback rules (read before touching)
 
 The playback path has subtle ordering invariants between `onState`, `onTrackChange`, `onPlay`, `onPause`, and `onPlaybackId`. Refactoring it without tests is dangerous; we have a graveyard of regressions to prove it.
 
@@ -87,11 +87,11 @@ When you fix a playback bug, **add a test that would have caught it.** The "brow
 
 ## Build
 
-- Two product flavors on the `environment` dimension: **prod** (`ch.snepilatch.app`, "Snepilatch") and **dev** (`ch.snepilatch.app.dev`, "Snepilatch Dev", `-dev` versionName). They differ only in identity — same code — so a dev build installs alongside the shipped app. Variants are `{prod,dev}{Debug,Release}`.
-- `./gradlew :app:assembleDebug` — both debug APKs (`assembleProdDebug` / `assembleDevDebug` for one)
-- `./gradlew :app:testProdDebugUnitTest` — unit tests (`:app:test` for every variant)
+- Two product flavors on the `environment` dimension: **prod** (`ch.snepilatch.app`, "Snepilatch") and **dev** (`ch.snepilatch.app.dev`, "Snepilatch Dev", `-dev` versionName). They differ only in identity (same code), so a dev build installs alongside the shipped app. Variants are `{prod,dev}{Debug,Release}`.
+- `./gradlew :app:assembleDebug`: both debug APKs (`assembleProdDebug` / `assembleDevDebug` for one)
+- `./gradlew :app:testProdDebugUnitTest`: unit tests (`:app:test` for every variant)
 - KotifyClient is consumed as a local jar: `app/libs/KotifyClient.jar`. Rebuild with `cd ../KotifyClient && ./gradlew obfuscate` and copy `build/libs/KotifyClient-obfuscated.jar` over.
-- Two `.so` files per ABI in `app/src/main/jniLibs/<abi>/` are required at runtime: `libtls_client_go.so` (the Go TLS engine) and `libjnidispatch.so` (JNA's native dispatcher — JNA can't extract its own `.so` at runtime on Android due to W^X). CI re-fetches both on every release build; for local dev, the committed copies are fine unless KotifyClient bumps its kotlin-tls-client or JNA version. See `CLAUDE.md` for the bump procedure.
+- Two `.so` files per ABI in `app/src/main/jniLibs/<abi>/` are required at runtime: `libtls_client_go.so` (the Go TLS engine) and `libjnidispatch.so` (JNA's native dispatcher; JNA can't extract its own `.so` at runtime on Android due to W^X). CI re-fetches both on every release build; for local dev, the committed copies are fine unless KotifyClient bumps its kotlin-tls-client or JNA version. See `CLAUDE.md` for the bump procedure.
 - Local logs go to Loki when `loki.endpoint` is set in `local.properties` (gitignored). Otherwise logs are local.
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ Living notes about non-obvious things in this repo. Keep this short and only add
 
 ## Native TLS binary lives in `jniLibs/` and must match KotifyClient
 
-KotifyClient's JAR is code only — the JNA-loaded `libtls_client_go.so` ships separately from [`PianoNic/kotlin-tls-client-natives`](https://github.com/PianoNic/kotlin-tls-client-natives/releases/latest). We commit one `.so` per ABI under `src/app/src/main/jniLibs/<abi>/` so local debug builds work without a network step.
+KotifyClient's JAR is code only; the JNA-loaded `libtls_client_go.so` ships separately from [`PianoNic/kotlin-tls-client-natives`](https://github.com/PianoNic/kotlin-tls-client-natives/releases/latest). We commit one `.so` per ABI under `src/app/src/main/jniLibs/<abi>/` so local debug builds work without a network step.
 
 CI (`.github/workflows/build-and-release.yml`) re-fetches the latest natives release on every release build, overwriting whatever is in the tree, so production APKs always ship matching binaries even if the committed copies have drifted.
 
 **When you bump KotifyClient locally**, refresh the four ABIs (`arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`) from the natives release matching the kotlin-tls-client version your new KotifyClient depends on. Otherwise you'll get `UnsatisfiedLinkError` for any FFI symbol added since your last refresh (e.g. `wsOpen` after the WebSocket migration).
 
-`libjnidispatch.so` (JNA's own dispatcher) sits next to `libtls_client_go.so` in each ABI directory. KotifyClient's shadow jar bundles JNA's Java classes but not its per-ABI native — Android's W^X rules forbid extracting `.so` files from inside a jar at runtime, so the file must be on disk in `jniLibs/`. CI re-extracts the latest from the JNA AAR alongside the natives step; locally, the committed copies are fine unless KotifyClient bumps its JNA dependency.
+`libjnidispatch.so` (JNA's own dispatcher) sits next to `libtls_client_go.so` in each ABI directory. KotifyClient's shadow jar bundles JNA's Java classes but not its per-ABI native; Android's W^X rules forbid extracting `.so` files from inside a jar at runtime, so the file must be on disk in `jniLibs/`. CI re-extracts the latest from the JNA AAR alongside the natives step; locally, the committed copies are fine unless KotifyClient bumps its JNA dependency.
 
 ## Verification before merging anything
 
@@ -25,9 +25,9 @@ All three must be green. The test rig + detekt baseline catch most regressions b
 
 ## Build flavors
 
-There are two product flavors on the `environment` dimension: **prod** (`ch.snepilatch.app`, "Snepilatch" — what ships) and **dev** (`ch.snepilatch.app.dev`, "Snepilatch Dev", `-dev` versionName suffix). They differ only in identity, not behaviour, so a dev build installs side-by-side with the production app.
+There are two product flavors on the `environment` dimension: **prod** (`ch.snepilatch.app`, "Snepilatch", the one that ships) and **dev** (`ch.snepilatch.app.dev`, "Snepilatch Dev", `-dev` versionName suffix). They differ only in identity, not behaviour, so a dev build installs side-by-side with the production app.
 
-Variant task names are flavor-qualified: `assembleProdDebug` / `assembleDevDebug`, `testProdDebugUnitTest` / `testDevDebugUnitTest`. The umbrella `assembleDebug` still builds both; there is no `testDebugUnitTest` anymore — use `:app:testProdDebugUnitTest` or `:app:test`. The dev `app_name` override lives in `app/src/dev/res/values/strings.xml`. The release pipeline builds `assembleProdRelease`.
+Variant task names are flavor-qualified: `assembleProdDebug` / `assembleDevDebug`, `testProdDebugUnitTest` / `testDevDebugUnitTest`. The umbrella `assembleDebug` still builds both; there is no `testDebugUnitTest` anymore; use `:app:testProdDebugUnitTest` or `:app:test`. The dev `app_name` override lives in `app/src/dev/res/values/strings.xml`. The release pipeline builds `assembleProdRelease`.
 
 ## Test rig
 
@@ -39,8 +39,8 @@ When fixing a playback bug, add a test that would have caught it.
 
 Two helpers in `PlaybackViewModel` cover most IO launches:
 
-- **`launchWithSession("tag") { sess -> ... }`** — null-checks the session, runs on `Dispatchers.IO`, catches and logs against the tag.
-- **`launchWithPlayer("tag") { pc -> ... }`** — same shape, but for transport commands that need `PlayerConnect`.
+- **`launchWithSession("tag") { sess -> ... }`**: null-checks the session, runs on `Dispatchers.IO`, catches and logs against the tag.
+- **`launchWithPlayer("tag") { pc -> ... }`**: same shape, but for transport commands that need `PlayerConnect`.
 
 Prefer these over hand-rolled `viewModelScope.launch(Dispatchers.IO) { try { val s = session ?: return@launch ... } catch ... }` blocks.
 
@@ -58,24 +58,24 @@ The pre-resolved cache (`nextCdnUrl` + `nextCdnFileId` from `onNextPlaybackId`) 
 
 ## ViewModel split strategy
 
-`PlaybackViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`, `LibraryViewModel`, `HomeViewModel`** (Detail/Library built on the shared `Navigator`; Home/Library load their feed in `init`). Each lands with its own tests. That's the clean feature set — what's left on `PlaybackViewModel` is playback, the playback-coupled features (Queue/Account/Devices), and cross-cutting settings/theme.
+`PlaybackViewModel` is large (~3k lines). We extract feature-scoped ViewModels incrementally. **Extracted so far: `SearchViewModel`, `LyricsViewModel`, `DetailViewModel`, `LibraryViewModel`, `HomeViewModel`** (Detail/Library built on the shared `Navigator`; Home/Library load their feed in `init`). Each lands with its own tests. That's the clean feature set; what's left on `PlaybackViewModel` is playback, the playback-coupled features (Queue/Account/Devices), and cross-cutting settings/theme.
 
-**Persisted user settings live in the process-scoped `AppSettings` store** (like `SessionHolder`/`Navigator`): audio source, content region, language, lyrics-anim direction, notification buttons, player gradient, canvas toggle — plus `load(context)`, `effectiveRegion()`, and the setters (incl. side effects: notification push to the service, locale change). `PlaybackViewModel` reads `AppSettings` in the stream-resolution path (`preferredAudioSource`, `effectiveRegion()`); the UI reads/writes it directly. `canvasUrl` (the current track's video URL — playback state, not persisted) stays on `PlaybackViewModel`, whose thin `setCanvasEnabled` wraps `AppSettings.setCanvasEnabled` to also clear it.
+**Persisted user settings live in the process-scoped `AppSettings` store** (like `SessionHolder`/`Navigator`): audio source, content region, language, lyrics-anim direction, notification buttons, player gradient, canvas toggle, plus `load(context)`, `effectiveRegion()`, and the setters (incl. side effects: notification push to the service, locale change). `PlaybackViewModel` reads `AppSettings` in the stream-resolution path (`preferredAudioSource`, `effectiveRegion()`); the UI reads/writes it directly. `canvasUrl` (the current track's video URL: playback state, not persisted) stays on `PlaybackViewModel`, whose thin `setCanvasEnabled` wraps `AppSettings.setCanvasEnabled` to also clear it.
 
 **The album-art accent palette lives in the process-scoped `ThemeController`** (`themeColors` + `updateFromArt`, fed by PlaybackViewModel on track change; read by the ~12 screens that tint themselves).
 
-**Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `PlaybackViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly — that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `PlaybackViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
+**Navigation is a process-scoped `Navigator`** (like `SessionHolder`): it owns `currentScreen` + the back stack + `navigateTo`/`navigateToTab`/`goBack`. `PlaybackViewModel` delegates to it and `reset()`s it on construction. Feature VMs navigate through `Navigator` directly; that's what unblocked the Detail extraction. For a feature VM whose openers must also be reachable from `PlaybackViewModel`'s own code (deep links, playback-context bridges) or from non-composable UI builders, add a tiny process-scoped router object next to the VM (see `DetailRoutes`): the live VM registers itself in `init` and the callers hop through it, so no one holds a cross-VM reference. A screen (normally Home) is always composed before any deep link is processed, so a VM is always registered in time.
 
 Pattern (proven by `SearchViewModel`/`LyricsViewModel`):
 1. Move the feature's state + methods into a new `<Feature>ViewModel : SessionViewModel("<Tag>")`.
-2. `SessionViewModel` (the base for all five feature VMs) provides `launchWithSession(op) { sess -> }` and `launchWithSessionLoading(op, loadingFlag) { sess -> }` — both null-check `SessionHolder.session`, rethrow cancellation, and log against the tag. Don't re-roll these. `PlaybackViewModel` is NOT a `SessionViewModel` (it owns the session lifecycle and needs player-scoped launches too).
-3. A screen can hold **both** ViewModels at once — obtain the feature VM in the body with `val featureVm: <Feature>ViewModel = viewModel()`. `LyricsScreen` reads playback/transport/theme from `PlaybackViewModel` and lyrics content from `LyricsViewModel` side by side. The feature VM doesn't need to own the whole screen.
+2. `SessionViewModel` (the base for all five feature VMs) provides `launchWithSession(op) { sess -> }` and `launchWithSessionLoading(op, loadingFlag) { sess -> }`; both null-check `SessionHolder.session`, rethrow cancellation, and log against the tag. Don't re-roll these. `PlaybackViewModel` is NOT a `SessionViewModel` (it owns the session lifecycle and needs player-scoped launches too).
+3. A screen can hold **both** ViewModels at once: obtain the feature VM in the body with `val featureVm: <Feature>ViewModel = viewModel()`. `LyricsScreen` reads playback/transport/theme from `PlaybackViewModel` and lyrics content from `LyricsViewModel` side by side. The feature VM doesn't need to own the whole screen.
 4. Pass the inputs the feature needs down from the screen (e.g. `lyricsVm.fetch(track.uri)`), rather than having the feature VM reach back into `PlaybackViewModel` state.
 
 **What makes a feature safe to extract now vs. what's blocked:**
 - Clean = the feature reads the session, writes its own state, and navigates through `Navigator`. `Lyrics` needed no navigation at all; `Detail` navigates via `Navigator` and exposes `DetailRoutes` for the `PlaybackViewModel`/non-composable callers.
-- **`Account` and `Devices` are NOT clean extractions — leave them on `PlaybackViewModel`.** They're playback-coupled: `AccountInfo.isPremium` gates audio-source logic inside the VM, and `activeDeviceName` is written from the playback state handler (`updatePlaybackFromState`) while `loadDevices`/`transferPlayback` need `PlayerConnect`. Extracting them would drag playback state across a VM boundary — the same reason we don't extract playback itself.
-- **`LibraryViewModel`** took the clean part: the library list + pagination + `createPlaylist`/`removeFromLibrary`. It loads in `init` (the old eager load lived in `PlaybackViewModel.initialize`, which runs before any composable exists) and reads `username` from `SessionHolder`. The snackbar-emitting `followArtist`/`savePlaylist` and the add-to-playlist picker stayed on `PlaybackViewModel` (they'd have needed the snackbar channel + a router for non-composable callers) — "add external content to the library" is a separable concern from browsing it.
+- **`Account` and `Devices` are NOT clean extractions; leave them on `PlaybackViewModel`.** They're playback-coupled: `AccountInfo.isPremium` gates audio-source logic inside the VM, and `activeDeviceName` is written from the playback state handler (`updatePlaybackFromState`) while `loadDevices`/`transferPlayback` need `PlayerConnect`. Extracting them would drag playback state across a VM boundary, the same reason we don't extract playback itself.
+- **`LibraryViewModel`** took the clean part: the library list + pagination + `createPlaylist`/`removeFromLibrary`. It loads in `init` (the old eager load lived in `PlaybackViewModel.initialize`, which runs before any composable exists) and reads `username` from `SessionHolder`. The snackbar-emitting `followArtist`/`savePlaylist` and the add-to-playlist picker stayed on `PlaybackViewModel` (they'd have needed the snackbar channel + a router for non-composable callers); "add external content to the library" is a separable concern from browsing it.
 
 Don't try to extract playback. The handler-extraction + test rig pattern (see `RemotePlayPauseHandlerTest`) is the safer route for that area.
 
@@ -89,7 +89,7 @@ cd ../KotifyClient
 cp build/libs/KotifyClient-obfuscated.jar ../Snepilatch/src/app/libs/KotifyClient.jar
 ```
 
-**Symptom of a stale jar:** `:app:compileProdDebugKotlin` fails with a wall of unresolved references in `PlaybackViewModel.kt` (`onAd`, `onSeek`, `artistNames`, `passthroughUrl`, `saveToLibrary`, wrong `playTrack` arity). That is the committed jar lagging the app source — rebuild it with the recipe above. It is not a bug in whatever file you were editing.
+**Symptom of a stale jar:** `:app:compileProdDebugKotlin` fails with a wall of unresolved references in `PlaybackViewModel.kt` (`onAd`, `onSeek`, `artistNames`, `passthroughUrl`, `saveToLibrary`, wrong `playTrack` arity). That is the committed jar lagging the app source; rebuild it with the recipe above. It is not a bug in whatever file you were editing.
 
 ## Logging
 

--- a/docs/infiniplay.md
+++ b/docs/infiniplay.md
@@ -3,7 +3,7 @@
 Endless, ever-varying playback of a single track: the app captures the decoded PCM while the song
 plays, finds beats that sound alike, and then plays the captured audio out of order, splicing between
 matched beats with short crossfades. In the tradition of Paul Lamere's Infinite Jukebox and Pithaya's
-Spicetify Eternal Jukebox — but computed entirely from the waveform, since no per-track analysis API
+Spicetify Eternal Jukebox, but computed entirely from the waveform, since no per-track analysis API
 is available to us.
 
 Code lives in `app/src/main/java/ch/snepilatch/app/playback/`:
@@ -39,7 +39,7 @@ gain processor must come after the remix so EQ headroom applies to remixed audio
 playback.
 
 media3 detail: the sink re-reads a processor's `isActive()` only on a pipeline flush. The processor
-therefore joins the chain when the infiniplay session starts (`engaged` — the capture pass's seek
+therefore joins the chain when the infiniplay session starts (`engaged`; the capture pass's seek
 provides the flush) and passes audio through until a snapshot arrives. Activating it later would
 require a flush at takeover, and a seek to the current position is a no-op.
 
@@ -51,7 +51,7 @@ Constant tempo is assumed, which holds for the produced music this feature targe
 Two precision details, both introduced after audible failures:
 
 - **Fractional period.** The autocorrelation lag grid is one hop (~11.6 ms) coarse. Rounding the
-  period to a whole lag accumulates error beat by beat — by mid-track the grid sat hundreds of
+  period to a whole lag accumulates error beat by beat; by mid-track the grid sat hundreds of
   milliseconds beside the real beats and splices landed audibly "rushed". Parabolic interpolation of
   the autocorrelation peak gives a sub-sample period; beats are laid with per-beat rounding.
 - **Onset snapping.** Each nominal beat then snaps to the strongest onset within ±3 hops (~35 ms),
@@ -72,7 +72,7 @@ Candidates are beat pairs; each surviving pair becomes a branch the player may t
 | Onset level within 4 dB | The join replaces the source beat's opening with the destination's; beat averages can agree while the first 150 ms differ by 8 dB |
 | Spectral join continuity | Fine-resolution (8192-pt) spectra of the audio leading into the cut vs. the audio landing after it; the join must be nearly as continuous as the original transition at that boundary (absolute floor + relative slack). Coarse spectra blur adjacent harmonics and cannot see a wrong-chord landing |
 
-Scoring: `contextDistance` — the join judged across a window around the cut (offsets −1, 0, +1, +2
+Scoring: `contextDistance`, the join judged across a window around the cut (offsets −1, 0, +1, +2
 with weights 0.5, 1.0, 1.0, 0.75), because what the listener evaluates is whether the beats *after*
 the landing point continue what was playing. Features per beat: frame chroma/timbre averaged across
 the beat, plus z-scored loudness and a 4-slot kick pattern (the shape features are deliberately
@@ -80,26 +80,26 @@ level-blind, so dynamics must be added explicitly).
 
 Selection: **no branch-count target.** The vetoes gate quality; selection keeps the globally best
 edges up to n/4 by score. An earlier design loosened a similarity threshold until a target count of
-beats could branch — which meant every candidate a veto removed was replaced by a worse one that had
+beats could branch, which meant every candidate a veto removed was replaced by a worse one that had
 been over the line. Quality rules must reduce the graph, never degrade it.
 
 Post-processing, following the reference implementation:
 
-- **De-sequencing** — consecutive beats may not share a jump distance (the stutter-in-place artefact).
-- **Reachability → last branch point** — the last beat from which the song can still branch onward.
+- **De-sequencing**: consecutive beats may not share a jump distance (the stutter-in-place artefact).
+- **Reachability → last branch point**: the last beat from which the song can still branch onward.
   Branches past it are dropped; the player must never run into the outro, finish, and restart.
-- **Landing runway** — destinations within 2 bars of the last branch point are pruned (and the player
+- **Landing runway**: destinations within 2 bars of the last branch point are pruned (and the player
   enforces a 4 s guard). Landing just under the forced-branch zone chains two jumps back to back.
-- **End jump** — the best backward branch near the last branch point, pre-selected with the same
+- **End jump**: the best backward branch near the last branch point, pre-selected with the same
   scoring as every other edge, so the forced end-of-song jump is never a blind cut.
 
 ## Playback (`InfiniPlayRemixProcessor`)
 
-- A splice may only start when the playhead stands exactly on a matched source — the crossfade's
+- A splice may only start when the playhead stands exactly on a matched source; the crossfade's
   outgoing side has to *be* the matched audio. Linear runs stop precisely on the next source or the
   last branch point, whichever comes first.
 - Most sources are played through: 35 % take probability, 2.5 s cooldown.
-- Past the last branch point the coin flip no longer applies — a branch is forced. Forced jumps relax
+- Past the last branch point the coin flip no longer applies; a branch is forced. Forced jumps relax
   the freshness rule (a quality-checked edge that repeats beats the blind fallback) and fall back to
   the graph's end jump only when no legal edge exists.
 - **Anti-boredom:** destinations recently landed in are skipped; if every legal destination is recent,
@@ -108,12 +108,12 @@ Post-processing, following the reference implementation:
 
 The splice itself:
 
-1. **Waveform alignment** — the destination slides within ±12 ms to where its waveform correlates
+1. **Waveform alignment**: the destination slides within ±12 ms to where its waveform correlates
    best with the outgoing audio; beat detection is only accurate to a few ms and joining out of phase
    cancels bass and smears the attack.
-2. **Equal-power crossfade** (40 ms, √-weighted) — linear fades dip ~3 dB mid-fade on uncorrelated
+2. **Equal-power crossfade** (40 ms, √-weighted): linear fades dip ~3 dB mid-fade on uncorrelated
    material.
-3. **Bounded level match** — the destination's gain is nudged up to ±3 dB toward the outgoing level.
+3. **Bounded level match**: the destination's gain is nudged up to ±3 dB toward the outgoing level.
 
 The fade is longer than one sink buffer, so it runs as a small state machine across `queueInput`
 calls rather than assuming it fits in whatever the sink happens to pull.
@@ -128,7 +128,7 @@ graph cannot exist much earlier: the 10 s intro guard plus the 16-beat minimum j
 track with zero jumps keeps capturing and tries once more when capture stalls at the full track.
 There is deliberately no "play the first half normally" wait. After handoff, capture continues in
 the background and richer snapshots are swapped in every 15 s of new audio until the full track is
-held — the short cadence matters now that the first snapshot only spans ~20 s.
+held; the short cadence matters now that the first snapshot only spans ~20 s.
 
 Growth simulation in the offline lab (rendering while the capture "grows" at 1x, swapping snapshots
 on the controller's exact schedule) showed two properties of incremental analysis worth knowing:
@@ -139,7 +139,7 @@ on the controller's exact schedule) showed two properties of incremental analysi
   rather than jump references, and the ±12 ms splice alignment absorbs the residual offset. Seam
   jolts stayed below the track's own 99th percentile throughout.
 - At handoff the playhead sits at the capture edge, which is past the young snapshot's last branch
-  point — so the very first splice is a forced jump back. Expected, not a bug. Until the first
+  point, so the very first splice is a forced jump back. Expected, not a bug. Until the first
   growth pass lands, the remix lives in a small window and may revisit sections; the 15 s growth
   cadence bounds how long that lasts.
 
@@ -153,7 +153,7 @@ The authoritative values live in the code (`BeatGraph`, `InfiniPlayRemixProcesso
 | `JUMP_PROB = 0.35`, `COOLDOWN_MS = 2500` | Remix character: mostly linear, occasional branches |
 | `MIN_JUMP_BEATS = 16` | Nothing shorter than 4 bars reads as a real jump |
 | `LEVEL/KICK/ONSET vetoes (4/6/4 dB)` | Calibrated against seams the listening tests rejected |
-| `JOIN_COS_MIN = 0.55`, slack `0.10` | Same — the rejected seam measured 0.61, accepted ones ≥ 0.75 |
+| `JOIN_COS_MIN = 0.55`, slack `0.10` | Same: the rejected seam measured 0.61, accepted ones ≥ 0.75 |
 | `INTRO_GUARD_S = 10` | The song must establish itself; intro texture doesn't blend |
 | `XFADE_MS = 40` | Long enough to blend, short enough not to smear the attack |
 
@@ -162,9 +162,9 @@ The authoritative values live in the code (`BeatGraph`, `InfiniPlayRemixProcesso
 All of the above was developed and validated offline, without a phone in the loop:
 
 1. `yt-dlp` + `ffmpeg` fetch a track as 44.1 kHz/16-bit WAV.
-2. A JVM harness — the env-gated unit test `InfiniPlayLab` — uses the **actual app classes**
-   (analyzer, graph, processor) and drives the processor exactly as ExoPlayer's sink does —
-   fixed-size buffers in a loop — rendering minutes of remix to WAV in seconds, plus a `-seams.csv`
+2. A JVM harness (the env-gated unit test `InfiniPlayLab`) uses the **actual app classes**
+   (analyzer, graph, processor) and drives the processor exactly as ExoPlayer's sink does,
+   fixed-size buffers in a loop, rendering minutes of remix to WAV in seconds, plus a `-seams.csv`
    log of every splice (output position, from, to). `LAB_MODE=growth` replays the device's
    incremental capture timeline instead of analysing the full file once.
 3. A Python suite (`numpy`/`matplotlib`) computes per-seam health (RMS step, kick-band step, spectral
@@ -174,7 +174,7 @@ All of the above was developed and validated offline, without a phone in the loo
 Invariants the harness asserts on every run: all splices land on grid beats, no consecutive beats
 share a jump distance, and the playhead never passes the last branch point ("never ran into the
 outro"). When a listener reports a bad moment at a timestamp, the seam log identifies the exact
-branch, and the analysis panel usually identifies the failure class — that loop drove every rule in
+branch, and the analysis panel usually identifies the failure class; that loop drove every rule in
 the table above.
 
 The lab lives in the repo: the harness at `app/src/test/.../InfiniPlayLab.kt`, the analysis suite

--- a/tools/infiniplay-lab/README.md
+++ b/tools/infiniplay-lab/README.md
@@ -1,6 +1,6 @@
 # InfiniPlay offline lab
 
-Renders an InfiniPlay remix from a local audio file on the JVM — no phone in the loop — using the
+Renders an InfiniPlay remix from a local audio file on the JVM (no phone in the loop) using the
 **real** app classes (`BeatGrid`, `BeatGraph`, `InfiniPlayRemixProcessor`), then checks the result
 numerically and visually. Background and methodology: [docs/infiniplay.md](../../docs/infiniplay.md).
 
@@ -48,7 +48,7 @@ python tools/infiniplay-lab/analyze.py /path/to/remix.wav
 Writes `<name>-report.txt` (per-seam RMS/kick/spectral-cosine health, ranked worst first),
 `<name>-overview.png` (full-render spectrogram with seam markers) and `<name>-seam-<k>.png`
 (waveform zoom + band-energy panels per seam). Note: the pre-window of a seam includes the
-crossfade blend, so the reported cosine is systematically pessimistic — calibrate against the
+crossfade blend, so the reported cosine is systematically pessimistic; calibrate against the
 graph-side numbers and your ears, not this alone.
 
 ## 4. Listen
@@ -58,5 +58,5 @@ ffmpeg -i remix.wav -b:a 192k remix.mp3
 ```
 
 The numbers catch lurches and level jumps; whether a join makes *musical* sense is still decided
-by ear. Every veto in `BeatGraph` came from a seam that measured fine and sounded wrong — see the
+by ear. Every veto in `BeatGraph` came from a seam that measured fine and sounded wrong; see the
 tuning table in the docs.


### PR DESCRIPTION
Replaces every em dash in the docs with commas, colons, semicolons or parentheses.

Closes #468