### PR TITLE
Model the equalizer as one three-way choice and regroup the Account tab

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -460,13 +460,14 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
      * metadata), so every track takes the flat user-set attenuation.
      */
     fun applyHeadroomGain(trackLoudnessDb: Double? = null) {
-        val gain = if (AppSettings.eqHeadroomEnabled.value) {
+        // Only an external equalizer needs this: our own computes its input gain from the curve.
+        val gain = if (AppSettings.eqExternal) {
             LoudnessNormalization.gainFor(trackLoudnessDb, AppSettings.eqHeadroomDb.value.toDouble())
         } else {
             1f
         }
         val branch = if (trackLoudnessDb != null) "loudness=${trackLoudnessDb}dB" else "flat"
-        LokiLogger.i(TAG, "Headroom gain=$gain ($branch, enabled=${AppSettings.eqHeadroomEnabled.value})")
+        LokiLogger.i(TAG, "Headroom gain=$gain ($branch, eqMode=${AppSettings.eqMode.value})")
         gainProcessor.setGain(gain)
     }
 
@@ -490,7 +491,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
     fun syncEqualizer() {
         equalizer.debugLowPriority = lowPriorityDebug
-        if (AppSettings.eqEnabled.value) {
+        if (AppSettings.eqInApp) {
             // Evict external effect apps first — see broadcastAudioEffectAction for why sharing fails.
             if (openAudioEffectSession) {
                 broadcastAudioEffectAction(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION)
@@ -498,11 +499,12 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             }
             equalizer.attach(currentAudioSessionId, AppSettings.eqBands.value)
             // The effect refused to be created on a live session (some Samsung firmware does this).
-            // Turn the feature off rather than leave the user with neither our EQ nor their external
-            // one: this flips the toggle, releases, and re-advertises the session on the way back in.
+            // Drop to Off rather than leave the user with neither our EQ nor their external one: the
+            // else branch below then releases and re-advertises the session for external effect apps.
+            // Off rather than External, so nobody gets silent attenuation with no equalizer attached.
             if (equalizer.supported && currentAudioSessionId != 0 && !equalizer.attached) {
                 LokiLogger.e(TAG, "EQ unavailable on this device — falling back to external effects")
-                AppSettings.setEqEnabled(false, this)
+                AppSettings.setEqMode(AppSettings.EQ_OFF, this)
             }
         } else {
             equalizer.release()
@@ -518,7 +520,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     fun setEqCurve(bands: FloatArray) {
         if (!equalizer.applyCurve(bands)) {
             LokiLogger.e(TAG, "EQ curve could not be applied — disabling in-app EQ")
-            AppSettings.setEqEnabled(false, this)
+            AppSettings.setEqMode(AppSettings.EQ_OFF, this)
         }
     }
 
@@ -1258,7 +1260,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         // a Galaxy (Android 16): once Samsung's SoundAlive attaches after this broadcast, every
         // DynamicsProcessing write on the same session fails with "invalid parameter operation" — and
         // two EQs in one chain would double-process anyway. CLOSE always goes out, so they detach.
-        if (action == AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION && AppSettings.eqEnabled.value) {
+        if (action == AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION && AppSettings.eqInApp) {
             LokiLogger.i(TAG, "Not advertising session $currentAudioSessionId — in-app EQ owns it")
             return
         }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ExitToApp
-import androidx.compose.material.icons.automirrored.rounded.VolumeUp
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -139,9 +138,150 @@ fun AccountScreen(vm: PlaybackViewModel) {
         )
 
         Spacer(Modifier.height(24.dp))
-        AccountSectionHeader(stringResource(R.string.account_section_appearance))
+        AccountSectionHeader(stringResource(R.string.account_section_playback))
 
         val audioContext = androidx.compose.ui.platform.LocalContext.current
+
+        // Audio settings
+        val audioSource by AppSettings.preferredAudioSource.collectAsState()
+        val isLossless = audioSource != null
+        val losslessSubtitle = if (isLossless) {
+            stringResource(R.string.lossless_on_flac)
+        } else {
+            stringResource(R.string.lossless_off_spfy)
+        }
+
+        // Lossless toggle — when on, the resolver picks the best source
+        // (Qobuz, then Deezer) autonomously; no provider choice.
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.lossless_audio), color = SpfyWhite) },
+            supportingContent = { Text(losslessSubtitle, color = SpfyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.MusicNote, null, tint = SpfyLightGray) },
+            trailingContent = {
+                Switch(
+                    checked = isLossless,
+                    onCheckedChange = { enabled ->
+                        AppSettings.setPreferredAudioSource(if (enabled) "lossless" else null, audioContext)
+                    },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = animatedPrimary,
+                        checkedTrackColor = animatedPrimary.copy(alpha = 0.5f),
+                        uncheckedThumbColor = SpfyLightGray,
+                        uncheckedTrackColor = SpfyLightGray.copy(alpha = 0.3f)
+                    )
+                )
+            },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+        )
+
+        // Content region picker
+        val currentRegion by AppSettings.contentRegion.collectAsState()
+        var showRegionPicker by remember { mutableStateOf(false) }
+        val regionLabel = if (currentRegion == "nearest") {
+            stringResource(R.string.region_nearest)
+        } else {
+            currentRegion
+        }
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.content_region), color = SpfyWhite) },
+            supportingContent = { Text(regionLabel, color = SpfyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.Language, null, tint = SpfyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showRegionPicker = true }
+        )
+        if (showRegionPicker) {
+            val regionOptions = listOf(
+                "nearest" to stringResource(R.string.region_nearest),
+                "US" to stringResource(R.string.region_us),
+                "GB" to stringResource(R.string.region_gb),
+                "DE" to stringResource(R.string.region_de),
+                "CH" to stringResource(R.string.region_ch),
+                "FR" to stringResource(R.string.region_fr),
+                "JP" to stringResource(R.string.region_jp),
+                "KR" to stringResource(R.string.region_kr),
+                "AU" to stringResource(R.string.region_au),
+                "BR" to stringResource(R.string.region_br),
+                "CA" to stringResource(R.string.region_ca),
+                "SE" to stringResource(R.string.region_se)
+            )
+            RadioPickerDialog(
+                title = stringResource(R.string.content_region),
+                options = regionOptions.map { RadioOption(it.first, it.second, it.first) },
+                selected = currentRegion,
+                selectedColor = animatedPrimary,
+                onSelect = {
+                    AppSettings.setContentRegion(it, audioContext)
+                    showRegionPicker = false
+                },
+                onDismiss = { showRegionPicker = false }
+            )
+        }
+
+        // Connect to device (Playback)
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.connect_to_device), color = SpfyWhite) },
+            leadingContent = { Icon(Icons.Rounded.Devices, null, tint = SpfyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { vm.loadDevices(); vm.showDevices.value = true }
+        )
+
+        Spacer(Modifier.height(24.dp))
+        AccountSectionHeader(stringResource(R.string.account_section_sound))
+
+        // Equalizer: one choice, because the options exclude each other. Our EQ computes its own
+        // input gain from the curve; the headroom attenuation exists only to give an external EQ room
+        // to boost into. See AppSettings.eqMode.
+        val eqMode by AppSettings.eqMode.collectAsState()
+        val headroomDb by AppSettings.eqHeadroomDb.collectAsState()
+        var showEqPicker by remember { mutableStateOf(false) }
+        val eqModeLabel = when (eqMode) {
+            AppSettings.EQ_IN_APP -> stringResource(R.string.eq_in_app)
+            AppSettings.EQ_EXTERNAL -> stringResource(R.string.eq_mode_external_at, headroomDb.toInt())
+            else -> stringResource(R.string.state_off)
+        }
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.equalizer), color = SpfyWhite) },
+            supportingContent = { Text(eqModeLabel, color = SpfyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.GraphicEq, null, tint = SpfyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showEqPicker = true }
+        )
+        if (showEqPicker) {
+            RadioPickerDialog(
+                title = stringResource(R.string.equalizer),
+                options = listOf(
+                    RadioOption(AppSettings.EQ_OFF, stringResource(R.string.state_off), stringResource(R.string.eq_mode_off_desc)),
+                    RadioOption(AppSettings.EQ_IN_APP, stringResource(R.string.eq_in_app), stringResource(R.string.eq_mode_in_app_desc)),
+                    RadioOption(AppSettings.EQ_EXTERNAL, stringResource(R.string.eq_mode_external), stringResource(R.string.eq_mode_external_desc))
+                ),
+                selected = eqMode,
+                selectedColor = animatedPrimary,
+                onSelect = { picked ->
+                    AppSettings.setEqMode(picked, audioContext)
+                    showEqPicker = false
+                    // Straight into the curve editor: picking In-app is a request to shape it.
+                    if (picked == AppSettings.EQ_IN_APP) vm.navigateTo(ch.snepilatch.app.data.Screen.EQUALIZER)
+                },
+                onDismiss = { showEqPicker = false }
+            )
+        }
+        // Only External uses this attenuation; the in-app EQ stages its own gain.
+        if (eqMode == AppSettings.EQ_EXTERNAL) {
+            Slider(
+                value = headroomDb,
+                onValueChange = { AppSettings.setEqHeadroomDb(it.toInt().toFloat(), audioContext) },
+                valueRange = -18f..0f,
+                steps = 17,
+                colors = SliderDefaults.colors(thumbColor = animatedPrimary, activeTrackColor = animatedPrimary),
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+        }
+
+        Spacer(Modifier.height(24.dp))
+        AccountSectionHeader(stringResource(R.string.account_section_appearance))
 
         // Language picker
         val appLanguage by AppSettings.appLanguage.collectAsState()
@@ -209,98 +349,6 @@ fun AccountScreen(vm: PlaybackViewModel) {
             )
         }
 
-        Spacer(Modifier.height(24.dp))
-        AccountSectionHeader(stringResource(R.string.account_section_playback))
-
-        // Audio settings
-        val audioSource by AppSettings.preferredAudioSource.collectAsState()
-        val isLossless = audioSource != null
-        val losslessSubtitle = if (isLossless) {
-            stringResource(R.string.lossless_on_flac)
-        } else {
-            stringResource(R.string.lossless_off_spfy)
-        }
-
-        // Lossless toggle — when on, the resolver picks the best source
-        // (Qobuz, then Deezer) autonomously; no provider choice.
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.lossless_audio), color = SpfyWhite) },
-            supportingContent = { Text(losslessSubtitle, color = SpfyLightGray) },
-            leadingContent = { Icon(Icons.Rounded.MusicNote, null, tint = SpfyLightGray) },
-            trailingContent = {
-                Switch(
-                    checked = isLossless,
-                    onCheckedChange = { enabled ->
-                        AppSettings.setPreferredAudioSource(if (enabled) "lossless" else null, audioContext)
-                    },
-                    colors = SwitchDefaults.colors(
-                        checkedThumbColor = animatedPrimary,
-                        checkedTrackColor = animatedPrimary.copy(alpha = 0.5f),
-                        uncheckedThumbColor = SpfyLightGray,
-                        uncheckedTrackColor = SpfyLightGray.copy(alpha = 0.3f)
-                    )
-                )
-            },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-        )
-
-        // EQ headroom — a flat attenuation for people running an EXTERNAL equalizer. Off by default:
-        // with no EQ attached it is pure level loss, and the in-app EQ makes its own headroom.
-        val headroomOn by AppSettings.eqHeadroomEnabled.collectAsState()
-        val headroomDb by AppSettings.eqHeadroomDb.collectAsState()
-        // The in-app EQ owns its own gain staging, so stacking this on top would double-attenuate.
-        val inAppEqOn by AppSettings.eqEnabled.collectAsState()
-
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.equalizer), color = SpfyWhite) },
-            supportingContent = {
-                Text(stringResource(if (inAppEqOn) R.string.state_on else R.string.state_off), color = SpfyLightGray)
-            },
-            leadingContent = { Icon(Icons.Rounded.GraphicEq, null, tint = SpfyLightGray) },
-            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-            modifier = Modifier.clickable { vm.navigateTo(ch.snepilatch.app.data.Screen.EQUALIZER) }
-        )
-
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.eq_headroom), color = SpfyWhite) },
-            supportingContent = {
-                Text(
-                    when {
-                        inAppEqOn -> stringResource(R.string.eq_headroom_handled)
-                        headroomOn -> stringResource(R.string.eq_headroom_on, headroomDb.toInt())
-                        else -> stringResource(R.string.eq_headroom_off)
-                    },
-                    color = SpfyLightGray
-                )
-            },
-            leadingContent = { Icon(Icons.AutoMirrored.Rounded.VolumeUp, null, tint = SpfyLightGray) },
-            trailingContent = {
-                Switch(
-                    checked = headroomOn && !inAppEqOn,
-                    enabled = !inAppEqOn,
-                    onCheckedChange = { AppSettings.setEqHeadroomEnabled(it, audioContext) },
-                    colors = SwitchDefaults.colors(
-                        checkedThumbColor = animatedPrimary,
-                        checkedTrackColor = animatedPrimary.copy(alpha = 0.5f),
-                        uncheckedThumbColor = SpfyLightGray,
-                        uncheckedTrackColor = SpfyLightGray.copy(alpha = 0.3f)
-                    )
-                )
-            },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-        )
-        if (headroomOn && !inAppEqOn) {
-            Slider(
-                value = headroomDb,
-                onValueChange = { AppSettings.setEqHeadroomDb(it.toInt().toFloat(), audioContext) },
-                valueRange = -18f..0f,
-                steps = 17,
-                colors = SliderDefaults.colors(thumbColor = animatedPrimary, activeTrackColor = animatedPrimary),
-                modifier = Modifier.padding(horizontal = 24.dp)
-            )
-        }
-
         // Canvas background
         val canvasOn by AppSettings.canvasEnabled.collectAsState()
         ListItem(
@@ -349,59 +397,6 @@ fun AccountScreen(vm: PlaybackViewModel) {
                 )
             },
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-        )
-
-        // Content region picker
-        val currentRegion by AppSettings.contentRegion.collectAsState()
-        var showRegionPicker by remember { mutableStateOf(false) }
-        val regionLabel = if (currentRegion == "nearest") {
-            stringResource(R.string.region_nearest)
-        } else {
-            currentRegion
-        }
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.content_region), color = SpfyWhite) },
-            supportingContent = { Text(regionLabel, color = SpfyLightGray) },
-            leadingContent = { Icon(Icons.Rounded.Language, null, tint = SpfyLightGray) },
-            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-            modifier = Modifier.clickable { showRegionPicker = true }
-        )
-        if (showRegionPicker) {
-            val regionOptions = listOf(
-                "nearest" to stringResource(R.string.region_nearest),
-                "US" to stringResource(R.string.region_us),
-                "GB" to stringResource(R.string.region_gb),
-                "DE" to stringResource(R.string.region_de),
-                "CH" to stringResource(R.string.region_ch),
-                "FR" to stringResource(R.string.region_fr),
-                "JP" to stringResource(R.string.region_jp),
-                "KR" to stringResource(R.string.region_kr),
-                "AU" to stringResource(R.string.region_au),
-                "BR" to stringResource(R.string.region_br),
-                "CA" to stringResource(R.string.region_ca),
-                "SE" to stringResource(R.string.region_se)
-            )
-            RadioPickerDialog(
-                title = stringResource(R.string.content_region),
-                options = regionOptions.map { RadioOption(it.first, it.second, it.first) },
-                selected = currentRegion,
-                selectedColor = animatedPrimary,
-                onSelect = {
-                    AppSettings.setContentRegion(it, audioContext)
-                    showRegionPicker = false
-                },
-                onDismiss = { showRegionPicker = false }
-            )
-        }
-
-        // Connect to device (Playback)
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.connect_to_device), color = SpfyWhite) },
-            leadingContent = { Icon(Icons.Rounded.Devices, null, tint = SpfyLightGray) },
-            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-            modifier = Modifier.clickable { vm.loadDevices(); vm.showDevices.value = true }
         )
 
         Spacer(Modifier.height(24.dp))

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/EqualizerScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/EqualizerScreen.kt
@@ -39,7 +39,8 @@ private const val GRID_STEP_DB = 6f
 @Composable
 fun EqualizerScreen(vm: PlaybackViewModel) {
     val context = LocalContext.current
-    val enabled by AppSettings.eqEnabled.collectAsState()
+    val eqMode by AppSettings.eqMode.collectAsState()
+    val enabled = eqMode == AppSettings.EQ_IN_APP
     val bands by AppSettings.eqBands.collectAsState()
     val theme by ThemeController.themeColors.collectAsState()
     // Reported by the service; on API 26–27 DynamicsProcessing doesn't exist and the EQ stays inert.
@@ -76,7 +77,10 @@ fun EqualizerScreen(vm: PlaybackViewModel) {
             supported = supported,
             preamp = preamp,
             accent = theme.primary,
-            onEnabledChange = { AppSettings.setEqEnabled(it, context) },
+            // The header switch only toggles our own EQ; External is chosen from the Account tab.
+            onEnabledChange = {
+                AppSettings.setEqMode(if (it) AppSettings.EQ_IN_APP else AppSettings.EQ_OFF, context)
+            },
             onFlat = { AppSettings.setEqBands(FloatArray(EqualizerHeadroom.BANDS), context) }
         )
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
@@ -20,6 +20,11 @@ object AppSettings {
     const val PREFS = "kotify_prefs"
     private const val TAG = "AppSettings"
 
+    // Equalizer modes; see [eqMode].
+    const val EQ_OFF = "off"
+    const val EQ_IN_APP = "inapp"
+    const val EQ_EXTERNAL = "external"
+
     @Volatile private var appContext: Context? = null
 
     // Audio source preference: null = Spfy (default), "lossless" = third-party FLAC chain.
@@ -44,15 +49,23 @@ object AppSettings {
     // Canvas background toggle (the URL itself is playback state on PlaybackViewModel).
     val canvasEnabled = MutableStateFlow(false)
 
-    // EQ headroom: a flat attenuation before the audio session, so an EXTERNAL equalizer (Wavelet &
-    // co.) has room to boost into instead of clipping. Off by default — with no EQ attached it is pure
-    // level loss. The in-app EQ doesn't need it; that one computes its own input gain from the curve.
-    val eqHeadroomEnabled = MutableStateFlow(false)
+    // How the equalizer is handled. One choice, because the options exclude each other: the in-app EQ
+    // computes its own input gain from the curve, while the headroom attenuation exists only to give an
+    // EXTERNAL equalizer (Wavelet & co.) room to boost into. Running both would attenuate twice.
+    //   [EQ_OFF]      no EQ, no attenuation
+    //   [EQ_IN_APP]   our 10-band EQ, which makes its own headroom
+    //   [EQ_EXTERNAL] no in-app EQ, just [eqHeadroomDb] of attenuation for the external one
+    val eqMode = MutableStateFlow(EQ_OFF)
     val eqHeadroomDb = MutableStateFlow(-6f)
 
-    // In-app 10-band EQ: on/off plus the per-band gains in dB (see EqualizerHeadroom.FREQUENCIES).
-    val eqEnabled = MutableStateFlow(false)
+    // Per-band gains in dB for the in-app EQ (see EqualizerHeadroom.FREQUENCIES).
     val eqBands = MutableStateFlow(FloatArray(ch.snepilatch.app.playback.EqualizerHeadroom.BANDS))
+
+    /** True when our own equalizer should be attached. */
+    val eqInApp: Boolean get() = eqMode.value == EQ_IN_APP
+
+    /** True when we should attenuate for someone else's equalizer. */
+    val eqExternal: Boolean get() = eqMode.value == EQ_EXTERNAL
 
     private fun prefs(ctx: Context) = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
 
@@ -77,9 +90,8 @@ object AppSettings {
             context.resources.updateConfiguration(config, context.resources.displayMetrics)
         }
         canvasEnabled.value = prefs.getBoolean("canvas_enabled", true)
-        eqHeadroomEnabled.value = prefs.getBoolean("eq_headroom_enabled", false)
         eqHeadroomDb.value = prefs.getFloat("eq_headroom_db", -6f)
-        eqEnabled.value = prefs.getBoolean("eq_enabled", false)
+        eqMode.value = prefs.getString("eq_mode", null) ?: migratedEqMode(prefs)
         eqBands.value = parseBands(prefs.getString("eq_bands", null))
         playerGradientBg.value = prefs.getBoolean("player_gradient_bg", true)
         contentRegion.value = prefs.getString("content_region", "nearest") ?: "nearest"
@@ -187,9 +199,21 @@ object AppSettings {
      * Persist the headroom toggle / attenuation and push the new gain to the service. It lands on the
      * next configure (track change or seek), so the level doesn't jump mid-track.
      */
-    fun setEqHeadroomEnabled(enabled: Boolean, context: Context) {
-        eqHeadroomEnabled.value = enabled
-        prefs(context).edit().putBoolean("eq_headroom_enabled", enabled).apply()
+    /**
+     * The two booleans this replaced could both be set, which the UI had to paper over. Carry the old
+     * state across once: the in-app EQ wins if it was on, otherwise headroom means an external one.
+     */
+    internal fun migratedEqMode(prefs: android.content.SharedPreferences): String = when {
+        prefs.getBoolean("eq_enabled", false) -> EQ_IN_APP
+        prefs.getBoolean("eq_headroom_enabled", false) -> EQ_EXTERNAL
+        else -> EQ_OFF
+    }
+
+    /** Switch equalizer mode: re-attach or drop our EQ, and re-stage the gain for the new mode. */
+    fun setEqMode(mode: String, context: Context) {
+        eqMode.value = mode
+        prefs(context).edit().putString("eq_mode", mode).apply()
+        MusicPlaybackService.instance?.syncEqualizer()
         MusicPlaybackService.instance?.applyHeadroomGain()
     }
 
@@ -198,12 +222,6 @@ object AppSettings {
         val bands = ch.snepilatch.app.playback.EqualizerHeadroom.BANDS
         val parsed = raw?.split(",")?.mapNotNull { it.trim().toFloatOrNull() } ?: emptyList()
         return if (parsed.size == bands) parsed.toFloatArray() else FloatArray(bands)
-    }
-
-    fun setEqEnabled(enabled: Boolean, context: Context) {
-        eqEnabled.value = enabled
-        prefs(context).edit().putBoolean("eq_enabled", enabled).apply()
-        MusicPlaybackService.instance?.syncEqualizer()
     }
 
     fun setEqBands(bands: FloatArray, context: Context) {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -1796,7 +1796,7 @@ class PlaybackViewModel : ViewModel() {
 
     /** In-app EQ on: our screen owns the curve. Off: hand the user to their external EQ app. */
     fun openEqualizer(context: android.content.Context) {
-        if (AppSettings.eqEnabled.value) {
+        if (AppSettings.eqInApp) {
             navigateTo(Screen.EQUALIZER)
             return
         }

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -261,6 +261,12 @@
     <string name="eq_preamp">Preamp %1$s dB</string>
     <string name="eq_preamp_auto">Automatic</string>
     <string name="eq_flat">Flat</string>
+    <string name="account_section_sound">Sound</string>
+    <string name="eq_mode_off_desc">No equalizer, no attenuation</string>
+    <string name="eq_mode_in_app_desc">10 bands, automatic headroom</string>
+    <string name="eq_mode_external">External equalizer</string>
+    <string name="eq_mode_external_desc">Lower playback so an app like Wavelet can boost</string>
+    <string name="eq_mode_external_at">External, lowered %1$d dB</string>
     <string name="eq_headroom">EQ headroom</string>
     <string name="eq_headroom_handled">Handled by the in-app equalizer</string>
     <string name="eq_headroom_on">Playback lowered %1$d dB. Set this to match your largest EQ boost</string>

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/EqModeMigrationTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/EqModeMigrationTest.kt
@@ -1,0 +1,42 @@
+package ch.snepilatch.app.viewmodel
+
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The equalizer used to persist two independent booleans that could both be set, which is exactly the
+ * state the single [AppSettings.eqMode] replaces. Anyone upgrading must land on the mode that matches
+ * what they were hearing, so this pins the one-time carry-over.
+ */
+class EqModeMigrationTest {
+
+    private fun prefs(inApp: Boolean, headroom: Boolean): SharedPreferences = mockk {
+        every { getBoolean("eq_enabled", false) } returns inApp
+        every { getBoolean("eq_headroom_enabled", false) } returns headroom
+    }
+
+    @Test
+    fun inAppEqualizerBecomesInApp() {
+        assertEquals(AppSettings.EQ_IN_APP, AppSettings.migratedEqMode(prefs(inApp = true, headroom = false)))
+    }
+
+    @Test
+    fun headroomAloneBecomesExternal() {
+        assertEquals(AppSettings.EQ_EXTERNAL, AppSettings.migratedEqMode(prefs(inApp = false, headroom = true)))
+    }
+
+    @Test
+    fun neitherBecomesOff() {
+        assertEquals(AppSettings.EQ_OFF, AppSettings.migratedEqMode(prefs(inApp = false, headroom = false)))
+    }
+
+    @Test
+    fun theImpossibleBothOnStateFavoursTheInAppEqualizer() {
+        // The old UI allowed this and showed "handled by the equalizer", so the in-app EQ was what
+        // actually ran. Resolving it the other way would silently attenuate and drop their curve.
+        assertEquals(AppSettings.EQ_IN_APP, AppSettings.migratedEqMode(prefs(inApp = true, headroom = true)))
+    }
+}


### PR DESCRIPTION
Replaces the two independent equalizer switches with a single Off / In-app / External choice, since the in-app EQ stages its own gain and the headroom attenuation only exists for an external one. Playback now holds audio and routing, a new Sound section holds the equalizer, and both background toggles move to Appearance.

Closes #484