### PR TITLE
Don't force an advance when an ad break spanned the end-of-track grace

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -2125,6 +2125,22 @@ class PlaybackViewModel : ViewModel() {
     internal fun currentAdEpoch(): Long = adEpoch
 
     /**
+     * Whether the end-of-track grace should force an advance. It must not when anything else already
+     * advanced: a new stream committed, audio is playing, or the ad epoch moved.
+     *
+     * That last test carries the weight. An ad break can span the whole grace window, and the other
+     * two miss it entirely, because the silent clip never sets [currentStreamUri] (so it still reads
+     * as the outgoing track) and the clip has already ended (so nothing is playing). The epoch moves
+     * on every ad and on every real track's audio, so a change means the advance happened without us.
+     * Observed live: a track ended at 15:01:42.5, two ads ran, the post-ad track's stream committed
+     * 16ms after the grace expired, and the forced advance ate it. Internal for tests.
+     */
+    internal fun graceAdvanceShouldFire(endedUri: String?, armedEpoch: Long, exoPlaying: Boolean): Boolean {
+        val newTrackLoaded = currentStreamUri != null && currentStreamUri != endedUri
+        return !newTrackLoaded && !exoPlaying && adEpoch == armedEpoch
+    }
+
+    /**
      * The ad context ended: bump the generation so any watchdog armed for it can no longer fire.
      * Called both when a new ad supersedes the old one and when a real track's audio is announced.
      * Internal for tests.
@@ -2182,16 +2198,17 @@ class PlaybackViewModel : ViewModel() {
             // headroom; the silent fallback only fires when Spfy Connect
             // genuinely fails to advance.
             val endedUri = currentStreamUri
+            val armedEpoch = adEpoch
             viewModelScope.launch(Dispatchers.IO) {
                 try {
                     LokiLogger.i(TAG, "ExoPlayer ended — waiting ${AUTO_ADVANCE_GRACE_MS}ms for auto-advance...")
                     delay(AUTO_ADVANCE_GRACE_MS)
-                    val newTrackLoaded = currentStreamUri != null && currentStreamUri != endedUri
                     val exoPlaying = withContext(Dispatchers.Main) {
                         MusicPlaybackService.instance?.isPlaying() == true
                     }
-                    if (newTrackLoaded || exoPlaying) {
-                        LokiLogger.d(TAG, "Auto-advance fired naturally (newTrackLoaded=$newTrackLoaded, exoPlaying=$exoPlaying)")
+                    if (!graceAdvanceShouldFire(endedUri, armedEpoch, exoPlaying)) {
+                        val why = "stream=$currentStreamUri exoPlaying=$exoPlaying adEpoch=$adEpoch/$armedEpoch"
+                        LokiLogger.d(TAG, "Auto-advance fired naturally ($why)")
                     } else {
                         // Advance locally (no skip command) so a slightly-late auto-advance (e.g. the
                         // post-ad track) resolves without burning a Free skip and hitting the cap.

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/GraceAdvanceAcrossAdBreakTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/GraceAdvanceAcrossAdBreakTest.kt
@@ -1,0 +1,84 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.playback.SessionHolder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression guard for a track eaten right after an ad break. The end-of-track grace was armed before
+ * the break, the break spanned the whole window, and neither of its tests noticed: the silent ad clip
+ * never sets currentStreamUri so it still read as the outgoing track, and the clip had ended so
+ * nothing was playing. It forced an advance 16ms before the post-ad stream committed, skipping it.
+ *
+ * Captured live at 15:01:47.561 as "Auto-advance didn't fire (still on spotify:track:53pILL...),
+ * forcing local advance", which ate 勇者 and jumped to Retry Now.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GraceAdvanceAcrossAdBreakTest {
+
+    private val rig = PlaybackTestRig()
+    private val ended = "spotify:track:theOneThatEnded"
+
+    @Before
+    fun setUp() {
+        rig.install()
+    }
+
+    @After
+    fun tearDown() {
+        SessionHolder.player = null
+        rig.uninstall()
+    }
+
+    @Test
+    fun doesNotForceAnAdvanceWhenAnAdBreakSpannedTheWindow() {
+        rig.seedStreaming()
+        rig.vm.currentStreamUri = ended
+        val armed = rig.vm.currentAdEpoch()
+
+        // The break: two ads, then the post-ad track's audio is announced. The stream has not
+        // committed yet, which is exactly the 16ms gap that lost the track.
+        rig.vm.handleAd(1000L)
+        rig.vm.handleAd(1000L)
+        rig.vm.handlePlaybackId("postAdFileId", "spotify:track:postad")
+
+        assertFalse(
+            "the ad break advanced us already, forcing again eats the post-ad track",
+            rig.vm.graceAdvanceShouldFire(ended, armed, exoPlaying = false)
+        )
+    }
+
+    @Test
+    fun stillForcesAnAdvanceWhenNothingHappenedAtAll() {
+        rig.seedStreaming()
+        rig.vm.currentStreamUri = ended
+        val armed = rig.vm.currentAdEpoch()
+
+        // No ad, no new stream, nothing playing: this is the stall the grace exists for.
+        assertTrue(rig.vm.graceAdvanceShouldFire(ended, armed, exoPlaying = false))
+    }
+
+    @Test
+    fun doesNotForceAnAdvanceOnceTheNextStreamCommitted() {
+        rig.seedStreaming()
+        rig.vm.currentStreamUri = ended
+        val armed = rig.vm.currentAdEpoch()
+
+        rig.vm.currentStreamUri = "spotify:track:next"
+
+        assertFalse(rig.vm.graceAdvanceShouldFire(ended, armed, exoPlaying = false))
+    }
+
+    @Test
+    fun doesNotForceAnAdvanceWhileAudioIsPlaying() {
+        rig.seedStreaming()
+        rig.vm.currentStreamUri = ended
+        val armed = rig.vm.currentAdEpoch()
+
+        assertFalse(rig.vm.graceAdvanceShouldFire(ended, armed, exoPlaying = true))
+    }
+}


### PR DESCRIPTION
The five second grace armed at the end of a track kept running through an ad break and forced an advance that skipped the post-ad track. Neither of its tests could see the break, since the silent clip never sets currentStreamUri and the clip had already ended, so it now also stands down when the ad epoch moved.

Closes #488