### PR TITLE
Add YouTube Music as a selectable audio source

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - Plays locally on your phone as its own Connect device, so transport actions are never skip-capped
 - Ad-free listening
-- Optional lossless audio alongside the standard stream
+- Choose your audio source: the standard stream, optional lossless, or YouTube Music
 - Full Connect control: transfer to and from other devices
 
 **Sound**
@@ -64,6 +64,12 @@ Download the latest APK from the [Releases](https://github.com/PianoNic/Snepilat
 ## Community
 
 [Discord](https://discord.gg/NJxKMSNYRG)
+
+## Credits
+
+The YouTube Music audio source follows the approach shown by [Meld](https://github.com/FrancescoGrazioso/Meld) and its [Metrolist](https://github.com/MetrolistGroup/Metrolist) / [OuterTune](https://github.com/DD3Boh/OuterTune) / [InnerTune](https://github.com/z-huang/InnerTune) lineage.
+
+No code of theirs is used; this is an independent implementation.
 
 ## License
 

--- a/src/app/src/main/java/ch/snepilatch/app/playback/AudioSourceResolver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/AudioSourceResolver.kt
@@ -1,0 +1,71 @@
+package ch.snepilatch.app.playback
+
+import ch.snepilatch.app.viewmodel.AppSettings
+import kotify.api.playerstatus.TrackChangeEvent
+import kotify.cdn.CdnPlayback
+import kotify.cdn.StreamInfo
+import kotify.cdn.StreamResult
+
+/**
+ * Resolves a track to a playable stream for whichever audio source is selected, so callers never
+ * branch on [AppSettings.preferredAudioSource] themselves. YouTube Music resolves in-app via
+ * [YouTubeMusicSource]; everything else goes to KotifyClient's Qobuz/Deezer chain.
+ *
+ * The Spfy CDN path is not here: it is Widevine DRM and needs a different player call, so
+ * PlaybackViewModel keeps it.
+ */
+object AudioSourceResolver {
+
+    private val cdn = CdnPlayback()
+
+    /** Resolve from a track-change event, which already carries title, artist and duration. */
+    suspend fun fromTrack(event: TrackChangeEvent): StreamResult {
+        val current = event.current
+        return youTubeMusic(current?.name, current?.artistName, current?.durationMs ?: 0L)
+            ?: cdn.resolveFromTrack(
+                event,
+                region = AppSettings.effectiveRegion(),
+                preferredSource = AppSettings.preferredAudioSource.value,
+            )
+    }
+
+    /** Resolve from metadata, for the cold-start, initial-track and pre-resolve paths. */
+    suspend fun byQuery(
+        trackId: String,
+        searchQuery: String?,
+        title: String?,
+        artist: String?,
+        durationMs: Long,
+    ): StreamResult = youTubeMusic(title, artist, durationMs)
+        ?: cdn.resolveStreamUrl(
+            trackId,
+            region = AppSettings.effectiveRegion(),
+            searchQuery = searchQuery,
+            preferredSource = AppSettings.preferredAudioSource.value,
+        )
+
+    /**
+     * Null unless YouTube Music is the selected source, so callers fall through to the chain. A miss
+     * is a [StreamResult.Failure] rather than null: null would hand the track to Qobuz/Deezer, and
+     * silently swapping the source the user picked is what #480 removed.
+     */
+    private suspend fun youTubeMusic(title: String?, artist: String?, durationMs: Long): StreamResult? {
+        if (AppSettings.preferredAudioSource.value != AppSettings.SOURCE_YTM) return null
+        val stream = YouTubeMusicSource.resolve(
+            title = title.orEmpty(),
+            artist = artist.orEmpty(),
+            region = AppSettings.effectiveRegion(),
+            durationMs = durationMs,
+        ) ?: return StreamResult.Failure(
+            "No YouTube Music match for ${listOfNotNull(artist, title).joinToString(" ")}"
+        )
+        return StreamResult.Success(
+            StreamInfo(
+                url = stream.url,
+                provider = "YouTube Music",
+                mimeType = stream.mimeType,
+                headers = stream.headers,
+            )
+        )
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/YouTubeMusicSource.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/YouTubeMusicSource.kt
@@ -1,0 +1,304 @@
+package ch.snepilatch.app.playback
+
+import ch.snepilatch.app.util.LokiLogger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.util.concurrent.TimeUnit
+import kotlin.math.abs
+
+/**
+ * Audio from YouTube Music over the InnerTube JSON API. No account, no PO token, no signature
+ * cipher. Search runs on WEB_REMIX, the player call on ANDROID_VR.
+ *
+ * Two things here are load-bearing and cost a long afternoon to find. The player client version must
+ * be [VR_VERSION]: 1.61.47 and 1.62.27 both answer LOGIN_REQUIRED ("Sign in to confirm you're not a
+ * bot"). And every request needs [visitorData]; without it the same client is refused, and clients
+ * that do answer without it (IOS) hand back a URL that only serves its first megabyte before
+ * returning 403 forever. With both in place the URL is plain and the whole file is readable.
+ */
+object YouTubeMusicSource {
+
+    private const val TAG = "YtmSource"
+
+    private const val SEARCH_URL = "https://music.youtube.com/youtubei/v1/search"
+    private const val PLAYER_URL = "https://youtubei.googleapis.com/youtubei/v1/player"
+
+    /**
+     * Search filters. Songs is the catalog proper and is tried first because its durations match
+     * Spotify's masters. Plenty of tracks only exist as uploads though (German YouTuber rap, for
+     * one), and for those the songs shelf silently returns other work by the same artist, so a miss
+     * retries against videos.
+     */
+    private const val SONGS_PARAMS = "EgWKAQIIAWoKEAoQAxAEEAkQBQ%3D%3D"
+    private const val VIDEOS_PARAMS = "EgWKAQIQAWoKEAoQAxAEEAkQBQ%3D%3D"
+
+    private const val WEB_REMIX_VERSION = "1.20240101.01.00"
+    private const val WEB_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+    private const val VR_VERSION = "1.65.10"
+    private const val VR_UA =
+        "com.google.android.apps.youtube.vr.oculus/$VR_VERSION (Linux; U; Android 12; GB) gzip"
+
+    /**
+     * A catalog master matches Spotify's within a second or two, but a music-video upload of the
+     * same track carries an intro or outro, so the window has to allow for that. Combined with the
+     * title score below it is still tight enough to reject a different song of similar length.
+     */
+    internal const val DURATION_TOLERANCE_SEC = 30L
+
+    /**
+     * Share of the wanted title's words a candidate must carry. High on purpose: at 0.5 the shared
+     * filler in "Rappe nur das Gleiche" and "Es ist immer das Gleiche" was enough to match, and a
+     * confidently wrong track is worse than none.
+     */
+    internal const val MIN_TITLE_SCORE = 0.8
+
+    private const val MAX_CANDIDATES = 10
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val jsonMedia = "application/json".toMediaType()
+
+    private val http: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(8, TimeUnit.SECONDS)
+            .build()
+    }
+
+    @Volatile private var visitorData: String? = null
+
+    data class Stream(val url: String, val mimeType: String?, val headers: Map<String, String>)
+
+    internal data class Candidate(
+        val videoId: String,
+        val title: String,
+        val artist: String?,
+        val durationSec: Long,
+    )
+
+    /**
+     * Resolves a Spotify track to a YouTube Music stream, or null when there is no confident match.
+     * [durationMs] is the Spotify length and is what rejects a same-titled radio edit or live take;
+     * pass 0 when it isn't known and matching falls back to the title alone.
+     */
+    suspend fun resolve(
+        title: String,
+        artist: String,
+        region: String?,
+        durationMs: Long,
+    ): Stream? = withContext(Dispatchers.IO) {
+        val query = listOf(artist, title).filter { it.isNotBlank() }.joinToString(" ").trim()
+        if (query.isBlank()) return@withContext null
+
+        val visitor = visitorData ?: fetchVisitorData(region)?.also { visitorData = it }
+        if (visitor == null) {
+            LokiLogger.w(TAG, "no visitorData, cannot resolve '$query'")
+            return@withContext null
+        }
+
+        var seen = 0
+        val match = listOf(SONGS_PARAMS, VIDEOS_PARAMS).firstNotNullOfOrNull { params ->
+            val body = post(SEARCH_URL, searchBody(query, region, visitor, params), WEB_UA, visitor)
+            val candidates = body?.let { runCatching { parseCandidates(it) }.getOrNull() }.orEmpty()
+            seen += candidates.size
+            bestMatch(candidates, title, durationMs)
+        }
+        if (match == null) {
+            LokiLogger.i(TAG, "no match for '$query' ($seen candidates, ${durationMs / 1000}s)")
+            return@withContext null
+        }
+        LokiLogger.i(TAG, "'$query' -> ${match.videoId} '${match.title}' ${match.durationSec}s")
+
+        streamFor(match.videoId, region, visitor)
+    }
+
+    /** Any InnerTube response carries one; a throwaway search is the cheapest way to get it. */
+    private fun fetchVisitorData(region: String?): String? {
+        val gl = (region ?: "US").uppercase()
+        val body = """{"context":{"client":{"clientName":"WEB_REMIX",""" +
+            """"clientVersion":"$WEB_REMIX_VERSION","hl":"en","gl":"$gl"}},"query":"a"}"""
+        val raw = post(SEARCH_URL, body, WEB_UA, visitor = null) ?: return null
+        return runCatching {
+            json.parseToJsonElement(raw).jsonObject["responseContext"]?.jsonObject
+                ?.get("visitorData")?.jsonPrimitive?.content
+        }.getOrNull()
+    }
+
+    private fun post(url: String, body: String, userAgent: String, visitor: String?): String? = runCatching {
+        val request = Request.Builder()
+            .url(url)
+            .post(body.toRequestBody(jsonMedia))
+            .header("User-Agent", userAgent)
+            .header("Accept", "*/*")
+            .apply { if (visitor != null) header("X-Goog-Visitor-Id", visitor) }
+            .build()
+        http.newCall(request).execute().use { if (it.isSuccessful) it.body?.string() else null }
+    }.getOrNull()
+
+    private fun searchBody(query: String, region: String?, visitor: String, params: String): String {
+        val gl = (region ?: "US").uppercase()
+        return """{"context":{"client":{"clientName":"WEB_REMIX","clientVersion":"$WEB_REMIX_VERSION",""" +
+            """"hl":"en","gl":"$gl","visitorData":"$visitor"}},""" +
+            """"query":"${escapeJson(query)}","params":"$params"}"""
+    }
+
+    private fun playerBody(videoId: String, region: String?, visitor: String): String {
+        val gl = (region ?: "US").uppercase()
+        return """{"context":{"client":{"clientName":"ANDROID_VR","clientVersion":"$VR_VERSION",""" +
+            """"deviceMake":"Oculus","deviceModel":"Quest 3","osName":"Android","osVersion":"12",""" +
+            """"androidSdkVersion":32,"hl":"en","gl":"$gl","visitorData":"$visitor"}},""" +
+            """"videoId":"$videoId","contentCheckOk":true,"racyCheckOk":true}"""
+    }
+
+    private fun streamFor(videoId: String, region: String?, visitor: String): Stream? {
+        val raw = post(PLAYER_URL, playerBody(videoId, region, visitor), VR_UA, visitor)
+        if (raw == null) {
+            LokiLogger.w(TAG, "player request failed for $videoId")
+            return null
+        }
+        return runCatching { pickAudio(raw) }.getOrNull()
+    }
+
+    /**
+     * contents -> tabbedSearchResultsRenderer -> tabs -> sectionListRenderer -> musicShelfRenderer
+     * -> musicResponsiveListItemRenderer. Rows without a videoId or title are shelf furniture.
+     */
+    internal fun parseCandidates(rawJson: String): List<Candidate> {
+        val rows = json.parseToJsonElement(rawJson).jsonObject["contents"]?.jsonObject
+            ?.get("tabbedSearchResultsRenderer")?.jsonObject
+            ?.get("tabs")?.jsonArray
+            ?.flatMap { tab ->
+                tab.jsonObject["tabRenderer"]?.jsonObject
+                    ?.get("content")?.jsonObject
+                    ?.get("sectionListRenderer")?.jsonObject
+                    ?.get("contents")?.jsonArray
+                    ?.mapNotNull { it.jsonObject["musicShelfRenderer"]?.jsonObject }
+                    ?.flatMap { shelf -> shelf["contents"]?.jsonArray?.toList() ?: emptyList() }
+                    ?: emptyList()
+            }
+            ?: return emptyList()
+        return rows.mapNotNull { candidateFrom(it) }.take(MAX_CANDIDATES)
+    }
+
+    private fun candidateFrom(row: JsonElement): Candidate? {
+        val item = row.jsonObject["musicResponsiveListItemRenderer"]?.jsonObject ?: return null
+        val videoId = item["playlistItemData"]?.jsonObject?.get("videoId")?.jsonPrimitive?.content
+            ?: return null
+        val texts = item["flexColumns"]?.jsonArray?.flatMap { column ->
+            column.jsonObject["musicResponsiveListItemFlexColumnRenderer"]?.jsonObject
+                ?.get("text")?.jsonObject
+                ?.get("runs")?.jsonArray
+                ?.mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.content }
+                ?: emptyList()
+        } ?: return null
+        val title = texts.firstOrNull()?.takeIf { it.isNotBlank() } ?: return null
+        return Candidate(
+            videoId = videoId,
+            title = title,
+            artist = texts.drop(1).firstOrNull { it.trim().length > 1 },
+            durationSec = texts.firstNotNullOfOrNull { parseDuration(it) } ?: 0L,
+        )
+    }
+
+    /** "3:59" / "1:02:33" -> seconds; null for any run that isn't a timestamp. */
+    internal fun parseDuration(text: String): Long? {
+        val parts = text.trim().split(":")
+        if (parts.size !in 2..3 || parts.any { it.isEmpty() || !it.all(Char::isDigit) }) return null
+        return parts.fold(0L) { acc, part -> acc * 60 + part.toLong() }
+    }
+
+    /**
+     * Returning null rather than guessing is deliberate: the wrong recording is worse than none, and
+     * the caller already skips a track it cannot resolve.
+     */
+    internal fun bestMatch(candidates: List<Candidate>, wantTitle: String, durationMs: Long): Candidate? {
+        val want = words(wantTitle)
+        val titled = candidates.filter { want.isEmpty() || titleScore(it.title, want) >= MIN_TITLE_SCORE }
+        if (durationMs <= 0L) return titled.firstOrNull()
+        val wantSec = durationMs / 1000
+        return titled
+            .filter { it.durationSec > 0 && abs(it.durationSec - wantSec) <= DURATION_TOLERANCE_SEC }
+            .minByOrNull { abs(it.durationSec - wantSec) }
+    }
+
+    /**
+     * Share of the wanted title's words the candidate carries. Word overlap rather than substring
+     * containment, because YouTube and Spotify disagree on spelling often enough to matter and one
+     * differing word should not throw the match away.
+     */
+    internal fun titleScore(candidateTitle: String, want: Set<String>): Double {
+        if (want.isEmpty()) return 0.0
+        val have = words(candidateTitle)
+        return want.count { w -> have.any { nearlyEqual(it, w) } }.toDouble() / want.size
+    }
+
+    /**
+     * Equal, or one edit apart for words long enough that a single differing character is a spelling
+     * variant rather than a different word. Spotify's "Tobbss" and YouTube's "Tobbs" are the same
+     * track, and exact comparison threw it away.
+     */
+    private fun nearlyEqual(a: String, b: String): Boolean {
+        if (a == b) return true
+        if (minOf(a.length, b.length) < 4 || abs(a.length - b.length) > 1) return false
+        val (long, short) = if (a.length >= b.length) a to b else b to a
+        var i = 0
+        var j = 0
+        var edits = 0
+        while (i < long.length && j < short.length) {
+            if (long[i] == short[j]) {
+                i++
+                j++
+            } else {
+                if (++edits > 1) return false
+                i++
+                if (long.length == short.length) j++
+            }
+        }
+        return edits + (long.length - i) + (short.length - j) <= 1
+    }
+
+    private fun words(s: String): Set<String> =
+        normalize(s).split(' ').filter { it.isNotBlank() }.toSet()
+
+    internal fun normalize(s: String): String = s.lowercase()
+        .replace(Regex("\\(.*?\\)|\\[.*?]"), " ")
+        .replace(Regex("[^\\p{L}\\p{N} ]"), " ")
+        .replace(Regex("\\s+"), " ")
+        .trim()
+
+    /** Highest-bitrate audio-only format. Formats with `signatureCipher` instead of `url` are skipped. */
+    internal fun pickAudio(rawJson: String): Stream? {
+        val root = json.parseToJsonElement(rawJson).jsonObject
+        val status = root["playabilityStatus"]?.jsonObject?.get("status")?.jsonPrimitive?.content
+        if (status != "OK") {
+            LokiLogger.w(TAG, "playabilityStatus=$status")
+            return null
+        }
+        val best = root["streamingData"]?.jsonObject?.get("adaptiveFormats")?.jsonArray
+            ?.map { it.jsonObject }
+            ?.filter {
+                it["mimeType"]?.jsonPrimitive?.content.orEmpty().startsWith("audio") && it["url"] != null
+            }
+            ?.maxByOrNull { it["bitrate"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L }
+            ?: return null
+        val url = best["url"]?.jsonPrimitive?.content ?: return null
+        return Stream(
+            url = url,
+            mimeType = best["mimeType"]?.jsonPrimitive?.content?.substringBefore(';'),
+            headers = mapOf("User-Agent" to VR_UA),
+        )
+    }
+
+    private fun escapeJson(s: String): String =
+        s.replace("\\", "\\\\").replace("\"", "\\\"")
+}

--- a/src/app/src/main/java/ch/snepilatch/app/playback/YouTubeMusicSource.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/YouTubeMusicSource.kt
@@ -19,11 +19,9 @@ import kotlin.math.abs
  * Audio from YouTube Music over the InnerTube JSON API. No account, no PO token, no signature
  * cipher. Search runs on WEB_REMIX, the player call on ANDROID_VR.
  *
- * Two things here are load-bearing and cost a long afternoon to find. The player client version must
- * be [VR_VERSION]: 1.61.47 and 1.62.27 both answer LOGIN_REQUIRED ("Sign in to confirm you're not a
- * bot"). And every request needs [visitorData]; without it the same client is refused, and clients
- * that do answer without it (IOS) hand back a URL that only serves its first megabyte before
- * returning 403 forever. With both in place the URL is plain and the whole file is readable.
+ * Two things are load-bearing. [VR_VERSION] must stay current: 1.61.47 and 1.62.27 answer
+ * LOGIN_REQUIRED. And every request needs visitorData; without it the client is refused, and clients
+ * that answer anyway (IOS) return a URL that serves one megabyte and then 403s.
  */
 object YouTubeMusicSource {
 
@@ -32,12 +30,8 @@ object YouTubeMusicSource {
     private const val SEARCH_URL = "https://music.youtube.com/youtubei/v1/search"
     private const val PLAYER_URL = "https://youtubei.googleapis.com/youtubei/v1/player"
 
-    /**
-     * Search filters. Songs is the catalog proper and is tried first because its durations match
-     * Spotify's masters. Plenty of tracks only exist as uploads though (German YouTuber rap, for
-     * one), and for those the songs shelf silently returns other work by the same artist, so a miss
-     * retries against videos.
-     */
+    // Songs first (durations match Spotify's masters). Tracks that only exist as uploads are absent
+    // from that shelf, which returns other work by the same artist instead, so a miss retries videos.
     private const val SONGS_PARAMS = "EgWKAQIIAWoKEAoQAxAEEAkQBQ%3D%3D"
     private const val VIDEOS_PARAMS = "EgWKAQIQAWoKEAoQAxAEEAkQBQ%3D%3D"
 
@@ -49,18 +43,10 @@ object YouTubeMusicSource {
     private const val VR_UA =
         "com.google.android.apps.youtube.vr.oculus/$VR_VERSION (Linux; U; Android 12; GB) gzip"
 
-    /**
-     * A catalog master matches Spotify's within a second or two, but a music-video upload of the
-     * same track carries an intro or outro, so the window has to allow for that. Combined with the
-     * title score below it is still tight enough to reject a different song of similar length.
-     */
+    /** Wide because a music-video upload of the same track carries an intro or outro. */
     internal const val DURATION_TOLERANCE_SEC = 30L
 
-    /**
-     * Share of the wanted title's words a candidate must carry. High on purpose: at 0.5 the shared
-     * filler in "Rappe nur das Gleiche" and "Es ist immer das Gleiche" was enough to match, and a
-     * confidently wrong track is worse than none.
-     */
+    /** Share of the wanted title's words a candidate must carry. At 0.5 shared filler words matched. */
     internal const val MIN_TITLE_SCORE = 0.8
 
     private const val MAX_CANDIDATES = 10
@@ -217,10 +203,7 @@ object YouTubeMusicSource {
         return parts.fold(0L) { acc, part -> acc * 60 + part.toLong() }
     }
 
-    /**
-     * Returning null rather than guessing is deliberate: the wrong recording is worse than none, and
-     * the caller already skips a track it cannot resolve.
-     */
+    /** Null rather than a guess: the wrong recording is worse than none, and the caller skips. */
     internal fun bestMatch(candidates: List<Candidate>, wantTitle: String, durationMs: Long): Candidate? {
         val want = words(wantTitle)
         val titled = candidates.filter { want.isEmpty() || titleScore(it.title, want) >= MIN_TITLE_SCORE }
@@ -231,22 +214,14 @@ object YouTubeMusicSource {
             .minByOrNull { abs(it.durationSec - wantSec) }
     }
 
-    /**
-     * Share of the wanted title's words the candidate carries. Word overlap rather than substring
-     * containment, because YouTube and Spotify disagree on spelling often enough to matter and one
-     * differing word should not throw the match away.
-     */
+    /** Share of the wanted title's words the candidate carries. */
     internal fun titleScore(candidateTitle: String, want: Set<String>): Double {
         if (want.isEmpty()) return 0.0
         val have = words(candidateTitle)
         return want.count { w -> have.any { nearlyEqual(it, w) } }.toDouble() / want.size
     }
 
-    /**
-     * Equal, or one edit apart for words long enough that a single differing character is a spelling
-     * variant rather than a different word. Spotify's "Tobbss" and YouTube's "Tobbs" are the same
-     * track, and exact comparison threw it away.
-     */
+    /** Equal, or one edit apart, so a spelling variant like "Tobbs" / "Tobbss" still matches. */
     private fun nearlyEqual(a: String, b: String): Boolean {
         if (a == b) return true
         if (minOf(a.length, b.length) < 4 || abs(a.length - b.length) > 1) return false

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -142,37 +142,52 @@ fun AccountScreen(vm: PlaybackViewModel) {
 
         val audioContext = androidx.compose.ui.platform.LocalContext.current
 
-        // Audio settings
+        // One choice of three: the sources exclude each other and a chosen one is never silently
+        // swapped (#480). The setting stores null for Spfy, so the dialog stands in SOURCE_SPOTIFY_UI.
         val audioSource by AppSettings.preferredAudioSource.collectAsState()
-        val isLossless = audioSource != null
-        val losslessSubtitle = if (isLossless) {
-            stringResource(R.string.lossless_on_flac)
-        } else {
-            stringResource(R.string.lossless_off_spfy)
+        var showSourcePicker by remember { mutableStateOf(false) }
+        val sourceLabel = when (audioSource) {
+            AppSettings.SOURCE_LOSSLESS -> stringResource(R.string.lossless_on_flac)
+            AppSettings.SOURCE_YTM -> stringResource(R.string.audio_source_ytm)
+            else -> stringResource(R.string.lossless_off_spfy)
         }
-
-        // Lossless toggle — when on, the resolver picks the best source
-        // (Qobuz, then Deezer) autonomously; no provider choice.
         ListItem(
-            headlineContent = { Text(stringResource(R.string.lossless_audio), color = SpfyWhite) },
-            supportingContent = { Text(losslessSubtitle, color = SpfyLightGray) },
+            headlineContent = { Text(stringResource(R.string.audio_source), color = SpfyWhite) },
+            supportingContent = { Text(sourceLabel, color = SpfyLightGray) },
             leadingContent = { Icon(Icons.Rounded.MusicNote, null, tint = SpfyLightGray) },
-            trailingContent = {
-                Switch(
-                    checked = isLossless,
-                    onCheckedChange = { enabled ->
-                        AppSettings.setPreferredAudioSource(if (enabled) "lossless" else null, audioContext)
-                    },
-                    colors = SwitchDefaults.colors(
-                        checkedThumbColor = animatedPrimary,
-                        checkedTrackColor = animatedPrimary.copy(alpha = 0.5f),
-                        uncheckedThumbColor = SpfyLightGray,
-                        uncheckedTrackColor = SpfyLightGray.copy(alpha = 0.3f)
-                    )
-                )
-            },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showSourcePicker = true }
         )
+        if (showSourcePicker) {
+            RadioPickerDialog(
+                title = stringResource(R.string.audio_source),
+                options = listOf(
+                    RadioOption(
+                        SOURCE_SPOTIFY_UI,
+                        stringResource(R.string.audio_source_spotify),
+                        stringResource(R.string.audio_source_spotify_desc)
+                    ),
+                    RadioOption(
+                        AppSettings.SOURCE_LOSSLESS,
+                        stringResource(R.string.lossless_audio),
+                        stringResource(R.string.audio_source_lossless_desc)
+                    ),
+                    RadioOption(
+                        AppSettings.SOURCE_YTM,
+                        stringResource(R.string.audio_source_ytm),
+                        stringResource(R.string.audio_source_ytm_desc)
+                    )
+                ),
+                selected = audioSource ?: SOURCE_SPOTIFY_UI,
+                selectedColor = animatedPrimary,
+                onSelect = { picked ->
+                    AppSettings.setPreferredAudioSource(picked.takeIf { it != SOURCE_SPOTIFY_UI }, audioContext)
+                    showSourcePicker = false
+                },
+                onDismiss = { showSourcePicker = false }
+            )
+        }
 
         // Content region picker
         val currentRegion by AppSettings.contentRegion.collectAsState()
@@ -614,6 +629,9 @@ private fun AccountSectionHeader(title: String) {
         modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
     )
 }
+
+/** Stands in for Spfy in the audio-source dialog, which selects on a String while the setting is null. */
+private const val SOURCE_SPOTIFY_UI = "spotify"
 
 private data class RadioOption(val value: String, val label: String, val supportingText: String? = null)
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
@@ -25,9 +25,14 @@ object AppSettings {
     const val EQ_IN_APP = "inapp"
     const val EQ_EXTERNAL = "external"
 
+    // Audio source ids for [preferredAudioSource]; null means Spfy's own CDN.
+    const val SOURCE_LOSSLESS = "lossless"
+    const val SOURCE_YTM = "ytm"
+
     @Volatile private var appContext: Context? = null
 
-    // Audio source preference: null = Spfy (default), "lossless" = third-party FLAC chain.
+    // Audio source: null = Spfy (default), [SOURCE_LOSSLESS] = third-party FLAC chain,
+    // [SOURCE_YTM] = YouTube Music (ch.snepilatch.app.playback.YouTubeMusicSource).
     val preferredAudioSource = MutableStateFlow<String?>(null)
 
     // Lyrics animation direction for line-synced (non word-synced): "vertical" or "horizontal"

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -15,7 +15,7 @@ import ch.snepilatch.app.playback.InfiniPlayViz
 import ch.snepilatch.app.playback.MusicPlaybackService
 import ch.snepilatch.app.playback.PositionInterpolator
 import ch.snepilatch.app.playback.SessionHolder
-import ch.snepilatch.app.playback.YouTubeMusicSource
+import ch.snepilatch.app.playback.AudioSourceResolver
 import ch.snepilatch.app.playback.engine.SpfyCdnResolver
 import ch.snepilatch.app.playback.engine.SpfyStream
 import ch.snepilatch.app.data.*
@@ -28,9 +28,7 @@ import kotify.api.playerstatus.PlayerTrack
 import kotify.api.song.Song
 import kotify.api.user.User
 import kotify.api.canvas.Canvas
-import kotify.cdn.CdnPlayback
 import kotify.cdn.SpfyPlayback
-import kotify.cdn.StreamInfo
 import kotify.cdn.StreamResult
 import kotify.session.Session
 import kotify.session.SessionConfig
@@ -79,7 +77,6 @@ class PlaybackViewModel : ViewModel() {
     private var initRetryCount = 0
 
     // Streaming
-    private val cdn = CdnPlayback()
     private var spfyPlayback: SpfyPlayback?
         get() = SessionHolder.spfyPlayback
         set(value) { SessionHolder.spfyPlayback = value }
@@ -1314,11 +1311,7 @@ class PlaybackViewModel : ViewModel() {
                 val query = listOf(artist, title)
                     .filter { it.isNotBlank() && it != "Unknown" }
                     .joinToString(" ")
-                val result = resolveYtmOrNull(title, artist, track.durationMs)
-                    ?: cdn.resolveStreamUrl(
-                        trackId, region = AppSettings.effectiveRegion(),
-                        searchQuery = query, preferredSource = AppSettings.preferredAudioSource.value
-                    )
+                val result = AudioSourceResolver.byQuery(trackId, query, title, artist, track.durationMs)
                 if (result is StreamResult.Success) {
                     val info = result.info
                     playUrlAt = System.currentTimeMillis()
@@ -2512,8 +2505,7 @@ class PlaybackViewModel : ViewModel() {
         }
 
         try {
-            val result = resolveYtmOrNull(title, artist, current.durationMs)
-                ?: cdn.resolveFromTrack(event, region = AppSettings.effectiveRegion(), preferredSource = AppSettings.preferredAudioSource.value)
+            val result = AudioSourceResolver.fromTrack(event)
             when (result) {
                 is StreamResult.Success -> {
                     // Don't resume Spfy yet — onReady callback will sync after ExoPlayer buffers
@@ -2550,38 +2542,10 @@ class PlaybackViewModel : ViewModel() {
         preResolveNextTrack()
     }
 
-    /**
-     * YouTube Music resolves in-app; every other non-Spfy source goes through KotifyClient's relay
-     * chain. Returns null when YouTube Music isn't the chosen source, so callers fall through to
-     * their existing `cdn.*` call unchanged.
-     *
-     * A miss is a [StreamResult.Failure], never null: falling through would hand the track to
-     * Qobuz/Deezer, and silently swapping the source the user picked is what #480 removed.
-     */
-    private suspend fun resolveYtmOrNull(title: String?, artist: String?, durationMs: Long): StreamResult? {
-        if (AppSettings.preferredAudioSource.value != AppSettings.SOURCE_YTM) return null
-        val stream = YouTubeMusicSource.resolve(
-            title = title.orEmpty(),
-            artist = artist.orEmpty(),
-            region = AppSettings.effectiveRegion(),
-            durationMs = durationMs,
-        ) ?: return StreamResult.Failure(
-            "No YouTube Music match for ${listOfNotNull(artist, title).joinToString(" ")}"
-        )
-        return StreamResult.Success(
-            StreamInfo(
-                url = stream.url,
-                provider = "YouTube Music",
-                mimeType = stream.mimeType,
-                headers = stream.headers,
-            )
-        )
-    }
 
     /**
-     * No YouTube Music match, so there is no audio for this track. Skip forward rather than sitting
-     * in silence, bounded by the existing playback-error budget so a run of unmatched tracks cannot
-     * race through the queue. The budget resets on the next successful onReady.
+     * Skip rather than sit in silence, bounded by the playback-error budget so a run of unmatched
+     * tracks cannot race through the queue. The budget resets on the next successful onReady.
      */
     private suspend fun skipUnmatchedYtmTrack(trackUri: String) {
         if (playbackErrorRetries >= MAX_PLAYBACK_ERROR_RETRIES) {
@@ -2773,11 +2737,7 @@ class PlaybackViewModel : ViewModel() {
             try {
                 val art = normalizeSpfyImageUrl(track.imageLargeUrl ?: track.imageUrl)
 
-                val result = resolveYtmOrNull(title, artist, track.durationMs)
-                    ?: cdn.resolveStreamUrl(
-                        trackId, region = AppSettings.effectiveRegion(),
-                        searchQuery = searchQuery, preferredSource = AppSettings.preferredAudioSource.value
-                    )
+                val result = AudioSourceResolver.byQuery(trackId, searchQuery, title, artist, track.durationMs)
                 when (result) {
                     is StreamResult.Success -> {
                         playUrlAt = System.currentTimeMillis()
@@ -2833,13 +2793,7 @@ class PlaybackViewModel : ViewModel() {
                 .joinToString(" ").takeIf { it.isNotBlank() }
 
             LokiLogger.i(TAG, "Pre-resolving next: $title by $artist")
-            val result = resolveYtmOrNull(title, artist, nextTrack.durationMs)
-                ?: cdn.resolveStreamUrl(
-                    nextId,
-                    region = AppSettings.effectiveRegion(),
-                    searchQuery = searchQuery,
-                    preferredSource = AppSettings.preferredAudioSource.value
-                )
+            val result = AudioSourceResolver.byQuery(nextId, searchQuery, title, artist, nextTrack.durationMs)
             if (result is StreamResult.Success) {
                 val info = result.info
                 val key = info.decryptionKey

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -15,6 +15,7 @@ import ch.snepilatch.app.playback.InfiniPlayViz
 import ch.snepilatch.app.playback.MusicPlaybackService
 import ch.snepilatch.app.playback.PositionInterpolator
 import ch.snepilatch.app.playback.SessionHolder
+import ch.snepilatch.app.playback.YouTubeMusicSource
 import ch.snepilatch.app.playback.engine.SpfyCdnResolver
 import ch.snepilatch.app.playback.engine.SpfyStream
 import ch.snepilatch.app.data.*
@@ -29,6 +30,7 @@ import kotify.api.user.User
 import kotify.api.canvas.Canvas
 import kotify.cdn.CdnPlayback
 import kotify.cdn.SpfyPlayback
+import kotify.cdn.StreamInfo
 import kotify.cdn.StreamResult
 import kotify.session.Session
 import kotify.session.SessionConfig
@@ -1312,10 +1314,11 @@ class PlaybackViewModel : ViewModel() {
                 val query = listOf(artist, title)
                     .filter { it.isNotBlank() && it != "Unknown" }
                     .joinToString(" ")
-                val result = cdn.resolveStreamUrl(
-                    trackId, region = AppSettings.effectiveRegion(),
-                    searchQuery = query, preferredSource = AppSettings.preferredAudioSource.value
-                )
+                val result = resolveYtmOrNull(title, artist, track.durationMs)
+                    ?: cdn.resolveStreamUrl(
+                        trackId, region = AppSettings.effectiveRegion(),
+                        searchQuery = query, preferredSource = AppSettings.preferredAudioSource.value
+                    )
                 if (result is StreamResult.Success) {
                     val info = result.info
                     playUrlAt = System.currentTimeMillis()
@@ -2509,7 +2512,8 @@ class PlaybackViewModel : ViewModel() {
         }
 
         try {
-            val result = cdn.resolveFromTrack(event, region = AppSettings.effectiveRegion(), preferredSource = AppSettings.preferredAudioSource.value)
+            val result = resolveYtmOrNull(title, artist, current.durationMs)
+                ?: cdn.resolveFromTrack(event, region = AppSettings.effectiveRegion(), preferredSource = AppSettings.preferredAudioSource.value)
             when (result) {
                 is StreamResult.Success -> {
                     // Don't resume Spfy yet — onReady callback will sync after ExoPlayer buffers
@@ -2532,6 +2536,9 @@ class PlaybackViewModel : ViewModel() {
                     MusicPlaybackService.instance?.stop()
                     isStreaming.value = false
                     streamProvider.value = null
+                    if (AppSettings.preferredAudioSource.value == AppSettings.SOURCE_YTM) {
+                        skipUnmatchedYtmTrack(trackUri)
+                    }
                 }
             }
         } catch (e: Exception) {
@@ -2541,6 +2548,57 @@ class PlaybackViewModel : ViewModel() {
         }
 
         preResolveNextTrack()
+    }
+
+    /**
+     * YouTube Music resolves in-app; every other non-Spfy source goes through KotifyClient's relay
+     * chain. Returns null when YouTube Music isn't the chosen source, so callers fall through to
+     * their existing `cdn.*` call unchanged.
+     *
+     * A miss is a [StreamResult.Failure], never null: falling through would hand the track to
+     * Qobuz/Deezer, and silently swapping the source the user picked is what #480 removed.
+     */
+    private suspend fun resolveYtmOrNull(title: String?, artist: String?, durationMs: Long): StreamResult? {
+        if (AppSettings.preferredAudioSource.value != AppSettings.SOURCE_YTM) return null
+        val stream = YouTubeMusicSource.resolve(
+            title = title.orEmpty(),
+            artist = artist.orEmpty(),
+            region = AppSettings.effectiveRegion(),
+            durationMs = durationMs,
+        ) ?: return StreamResult.Failure(
+            "No YouTube Music match for ${listOfNotNull(artist, title).joinToString(" ")}"
+        )
+        return StreamResult.Success(
+            StreamInfo(
+                url = stream.url,
+                provider = "YouTube Music",
+                mimeType = stream.mimeType,
+                headers = stream.headers,
+            )
+        )
+    }
+
+    /**
+     * No YouTube Music match, so there is no audio for this track. Skip forward rather than sitting
+     * in silence, bounded by the existing playback-error budget so a run of unmatched tracks cannot
+     * race through the queue. The budget resets on the next successful onReady.
+     */
+    private suspend fun skipUnmatchedYtmTrack(trackUri: String) {
+        if (playbackErrorRetries >= MAX_PLAYBACK_ERROR_RETRIES) {
+            LokiLogger.w(TAG, "[Ytm] $MAX_PLAYBACK_ERROR_RETRIES unmatched in a row, stopping")
+            playbackErrorRetries = 0
+            return
+        }
+        playbackErrorRetries++
+        val pc = player ?: return
+        LokiLogger.w(TAG, "[Ytm] no match for $trackUri, skipping ($playbackErrorRetries/$MAX_PLAYBACK_ERROR_RETRIES)")
+        try {
+            pc.localNext()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LokiLogger.e(TAG, "[Ytm] skip failed: ${e.message}")
+        }
     }
 
     /**
@@ -2715,10 +2773,11 @@ class PlaybackViewModel : ViewModel() {
             try {
                 val art = normalizeSpfyImageUrl(track.imageLargeUrl ?: track.imageUrl)
 
-                val result = cdn.resolveStreamUrl(
-                    trackId, region = AppSettings.effectiveRegion(),
-                    searchQuery = searchQuery, preferredSource = AppSettings.preferredAudioSource.value
-                )
+                val result = resolveYtmOrNull(title, artist, track.durationMs)
+                    ?: cdn.resolveStreamUrl(
+                        trackId, region = AppSettings.effectiveRegion(),
+                        searchQuery = searchQuery, preferredSource = AppSettings.preferredAudioSource.value
+                    )
                 when (result) {
                     is StreamResult.Success -> {
                         playUrlAt = System.currentTimeMillis()
@@ -2774,12 +2833,13 @@ class PlaybackViewModel : ViewModel() {
                 .joinToString(" ").takeIf { it.isNotBlank() }
 
             LokiLogger.i(TAG, "Pre-resolving next: $title by $artist")
-            val result = cdn.resolveStreamUrl(
-                nextId,
-                region = AppSettings.effectiveRegion(),
-                searchQuery = searchQuery,
-                preferredSource = AppSettings.preferredAudioSource.value
-            )
+            val result = resolveYtmOrNull(title, artist, nextTrack.durationMs)
+                ?: cdn.resolveStreamUrl(
+                    nextId,
+                    region = AppSettings.effectiveRegion(),
+                    searchQuery = searchQuery,
+                    preferredSource = AppSettings.preferredAudioSource.value
+                )
             if (result is StreamResult.Success) {
                 val info = result.info
                 val key = info.decryptionKey

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -53,6 +53,12 @@
     <string name="log_out">Abmelde</string>
 
     <!-- Settings -->
+    <string name="audio_source">Audioquälle</string>
+    <string name="audio_source_spotify">Spotify</string>
+    <string name="audio_source_spotify_desc">Standardqualität, direkt vo Spotify</string>
+    <string name="audio_source_lossless_desc">FLAC, wänn en Drittaabieter de Track het</string>
+    <string name="audio_source_ytm">YouTube Music</string>
+    <string name="audio_source_ytm_desc">Zuegordnet über Titel und Längi. Bruucht kes Konto. Es paar Tracks git s nöd.</string>
     <string name="lossless_audio">Verlustfreii Audio (Beta)</string>
     <string name="lossless_on">FLAC über %s</string>
     <string name="lossless_off">Standardqualität</string>

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -57,8 +57,8 @@
     <string name="audio_source_spotify">Spotify</string>
     <string name="audio_source_spotify_desc">Standardqualität, direkt vo Spotify</string>
     <string name="audio_source_lossless_desc">FLAC, wänn en Drittaabieter de Track het</string>
-    <string name="audio_source_ytm">YouTube Music</string>
-    <string name="audio_source_ytm_desc">Zuegordnet über Titel und Längi. Bruucht kes Konto. Es paar Tracks git s nöd.</string>
+    <string name="audio_source_ytm">YouTube Music (Beta)</string>
+    <string name="audio_source_ytm_desc">Es paar Tracks sind nöd verfüegbar</string>
     <string name="lossless_audio">Verlustfreii Audio (Beta)</string>
     <string name="lossless_on">FLAC über %s</string>
     <string name="lossless_off">Standardqualität</string>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -53,6 +53,12 @@
     <string name="log_out">Abmelden</string>
 
     <!-- Settings -->
+    <string name="audio_source">Audioquelle</string>
+    <string name="audio_source_spotify">Spotify</string>
+    <string name="audio_source_spotify_desc">Standardqualität, direkt von Spotify</string>
+    <string name="audio_source_lossless_desc">FLAC, wenn ein Drittanbieter den Titel hat</string>
+    <string name="audio_source_ytm">YouTube Music</string>
+    <string name="audio_source_ytm_desc">Zuordnung über Titel und Länge. Kein Konto nötig. Manche Titel sind nicht verfügbar.</string>
     <string name="lossless_audio">Verlustfreies Audio (Beta)</string>
     <string name="lossless_on">FLAC über %s</string>
     <string name="lossless_off">Standardqualität</string>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -57,8 +57,8 @@
     <string name="audio_source_spotify">Spotify</string>
     <string name="audio_source_spotify_desc">Standardqualität, direkt von Spotify</string>
     <string name="audio_source_lossless_desc">FLAC, wenn ein Drittanbieter den Titel hat</string>
-    <string name="audio_source_ytm">YouTube Music</string>
-    <string name="audio_source_ytm_desc">Zuordnung über Titel und Länge. Kein Konto nötig. Manche Titel sind nicht verfügbar.</string>
+    <string name="audio_source_ytm">YouTube Music (Beta)</string>
+    <string name="audio_source_ytm_desc">Manche Titel sind nicht verfügbar</string>
     <string name="lossless_audio">Verlustfreies Audio (Beta)</string>
     <string name="lossless_on">FLAC über %s</string>
     <string name="lossless_off">Standardqualität</string>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -57,8 +57,8 @@
     <string name="audio_source_spotify">Spotify</string>
     <string name="audio_source_spotify_desc">Стандартное качество, поток из Spotify</string>
     <string name="audio_source_lossless_desc">FLAC, если трек есть у стороннего сервиса</string>
-    <string name="audio_source_ytm">YouTube Music</string>
-    <string name="audio_source_ytm_desc">Подбор по названию и длительности. Аккаунт не нужен. Некоторые треки недоступны.</string>
+    <string name="audio_source_ytm">YouTube Music (Beta)</string>
+    <string name="audio_source_ytm_desc">Некоторые треки недоступны</string>
     <string name="lossless_audio">Без потерь (Beta)</string>
     <string name="lossless_on">FLAC через %s</string>
     <string name="lossless_off">Стандартное качество</string>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -53,6 +53,12 @@
     <string name="log_out">Выйти</string>
 
     <!-- Settings -->
+    <string name="audio_source">Источник звука</string>
+    <string name="audio_source_spotify">Spotify</string>
+    <string name="audio_source_spotify_desc">Стандартное качество, поток из Spotify</string>
+    <string name="audio_source_lossless_desc">FLAC, если трек есть у стороннего сервиса</string>
+    <string name="audio_source_ytm">YouTube Music</string>
+    <string name="audio_source_ytm_desc">Подбор по названию и длительности. Аккаунт не нужен. Некоторые треки недоступны.</string>
     <string name="lossless_audio">Без потерь (Beta)</string>
     <string name="lossless_on">FLAC через %s</string>
     <string name="lossless_off">Стандартное качество</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -55,6 +55,12 @@
     <string name="log_out">Log out</string>
 
     <!-- Settings -->
+    <string name="audio_source">Audio source</string>
+    <string name="audio_source_spotify">Spotify</string>
+    <string name="audio_source_spotify_desc">Standard quality, streamed from Spotify</string>
+    <string name="audio_source_lossless_desc">FLAC where a third party relay has the track</string>
+    <string name="audio_source_ytm">YouTube Music</string>
+    <string name="audio_source_ytm_desc">Matched by title and length. No account needed. Some tracks are unavailable.</string>
     <string name="lossless_audio">Lossless Audio (Beta)</string>
     <string name="lossless_on">FLAC via %s</string>
     <string name="lossless_on_flac">FLAC</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -59,8 +59,8 @@
     <string name="audio_source_spotify">Spotify</string>
     <string name="audio_source_spotify_desc">Standard quality, streamed from Spotify</string>
     <string name="audio_source_lossless_desc">FLAC where a third party relay has the track</string>
-    <string name="audio_source_ytm">YouTube Music</string>
-    <string name="audio_source_ytm_desc">Matched by title and length. No account needed. Some tracks are unavailable.</string>
+    <string name="audio_source_ytm">YouTube Music (Beta)</string>
+    <string name="audio_source_ytm_desc">Some tracks are unavailable</string>
     <string name="lossless_audio">Lossless Audio (Beta)</string>
     <string name="lossless_on">FLAC via %s</string>
     <string name="lossless_on_flac">FLAC</string>

--- a/src/app/src/test/java/ch/snepilatch/app/playback/YouTubeMusicSourceTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/playback/YouTubeMusicSourceTest.kt
@@ -142,6 +142,7 @@ class YouTubeMusicSourceTest {
     @Test
     fun refusesAPlayerResponseThatDemandsALogin() {
         // What the older ANDROID_VR versions return; the pinned one must keep working.
-        assertNull(YouTubeMusicSource.pickAudio(fixture("player_login_required.json")))
+        val denied = """{"playabilityStatus":{"status":"LOGIN_REQUIRED","reason":"Sign in"}}"""
+        assertNull(YouTubeMusicSource.pickAudio(denied))
     }
 }

--- a/src/app/src/test/java/ch/snepilatch/app/playback/YouTubeMusicSourceTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/playback/YouTubeMusicSourceTest.kt
@@ -1,0 +1,147 @@
+package ch.snepilatch.app.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The saved search response is a real capture for "Daft Punk Get Lucky", whose songs shelf returns
+ * the 6:10 album cut next to a 4:09 radio edit and a 4:08 re-upload. Taking the top-ranked hit is
+ * right there by luck and wrong the moment the user's track is the radio edit, so the duration
+ * matcher is what these tests pin.
+ */
+class YouTubeMusicSourceTest {
+
+    private fun fixture(name: String): String =
+        requireNotNull(javaClass.getResourceAsStream("/fixtures/youtubemusic/$name")) {
+            "missing fixture $name"
+        }.bufferedReader().use { it.readText() }
+
+    private val candidates by lazy {
+        YouTubeMusicSource.parseCandidates(fixture("search_songs.json"))
+    }
+
+    @Test
+    fun parsesVideoIdTitleArtistAndDurationFromTheSongsShelf() {
+        assertEquals(5, candidates.size)
+        val first = candidates.first()
+        assertEquals("4D7u5KF7SP8", first.videoId)
+        assertTrue("got '${first.title}'", first.title.startsWith("Get Lucky"))
+        assertEquals("Daft Punk", first.artist)
+        assertEquals(370L, first.durationSec)
+        assertTrue("every candidate needs a videoId", candidates.all { it.videoId.isNotBlank() })
+    }
+
+    @Test
+    fun picksTheAlbumCutWhenTheSpotifyTrackIsTheAlbumCut() {
+        val match = YouTubeMusicSource.bestMatch(candidates, "Get Lucky", durationMs = 369_000)
+        assertNotNull(match)
+        assertEquals("4D7u5KF7SP8", match!!.videoId)
+        assertEquals(370L, match.durationSec)
+    }
+
+    @Test
+    fun picksTheRadioEditWhenThatIsWhatTheDurationSays() {
+        // Same query, same shelf, different Spotify track. Search rank alone would return the 6:10 cut.
+        val match = YouTubeMusicSource.bestMatch(candidates, "Get Lucky", durationMs = 249_000)
+        assertNotNull(match)
+        assertEquals(249L, match!!.durationSec)
+        assertTrue("got '${match.title}'", match.title.contains("Radio Edit"))
+    }
+
+    @Test
+    fun refusesToGuessWhenNoCandidateIsCloseEnough() {
+        assertNull(YouTubeMusicSource.bestMatch(candidates, "Get Lucky", durationMs = 480_000))
+    }
+
+    @Test
+    fun matchesOnTitleAloneWhenTheDurationIsUnknown() {
+        val match = YouTubeMusicSource.bestMatch(candidates, "Get Lucky", durationMs = 0)
+        assertNotNull(match)
+        assertEquals("4D7u5KF7SP8", match!!.videoId)
+    }
+
+    @Test
+    fun neverPicksADifferentSongOnDurationAlone() {
+        // "Lose Yourself to Dance" (5:54) sits in this shelf and is the closest thing by length to a
+        // 5:54 request. The title score has to keep it out no matter how well the duration lines up.
+        val match = YouTubeMusicSource.bestMatch(candidates, "Get Lucky", durationMs = 354_000)
+        assertTrue(
+            "picked '${match?.title}', which is not Get Lucky",
+            match == null || match.title.contains("Get Lucky")
+        )
+    }
+
+    @Test
+    fun matchesDespiteASpellingDifferenceAndAVideoIntro() {
+        // Real miss from the device: Spotify has "Tobbss stinkt" at 2:48, YouTube has it spelled
+        // "Tobbs stinkt" in a 3:08 music video. Substring matching failed on the extra s and the
+        // 20s intro blew a tight duration window, so the track resolved to nothing.
+        val yt = listOf(
+            YouTubeMusicSource.Candidate("aaa", "Team Melone (Hardstyle Remix)", "Chaosflo44", 152),
+            YouTubeMusicSource.Candidate("bbb", "Tobbs stinkt | Chaosflo44", "Chaosflo44", 188),
+        )
+        val match = YouTubeMusicSource.bestMatch(yt, "Tobbss stinkt", durationMs = 168_000)
+        assertNotNull(match)
+        assertEquals("bbb", match!!.videoId)
+    }
+
+    @Test
+    fun titleScoreCountsSharedWordsNotSubstrings() {
+        val want = setOf("rappe", "nur", "das", "gleiche")
+        assertEquals(1.0, YouTubeMusicSource.titleScore("RAPPE NUR DAS GLEICHE feat. LarsOderSo", want), 0.001)
+        assertEquals(0.0, YouTubeMusicSource.titleScore("Fortnite 31er Song", want), 0.001)
+        // Filler words alone must not carry a match; this one scored 0.5 and was picked at 3:30
+        // against a 3:11 request, which is a different song entirely.
+        assertTrue(YouTubeMusicSource.titleScore("Es ist immer das Gleiche", want) < YouTubeMusicSource.MIN_TITLE_SCORE)
+    }
+
+    @Test
+    fun aDifferentGermanTitleSharingFillerWordsIsRejected() {
+        val yt = listOf(
+            YouTubeMusicSource.Candidate("wrong", "Es ist immer das Gleiche", "Someone", 210),
+            YouTubeMusicSource.Candidate("right", "RAPPE NUR DAS GLEICHE feat. LarsOderSo", "Arazhul", 190),
+        )
+        val match = YouTubeMusicSource.bestMatch(yt, "Rappe nur das Gleiche", durationMs = 191_000)
+        assertNotNull(match)
+        assertEquals("right", match!!.videoId)
+    }
+
+    @Test
+    fun titleMatchToleratesYouTubesLongerSpelling() {
+        assertEquals(
+            "get lucky",
+            YouTubeMusicSource.normalize("Get Lucky (feat. Pharrell Williams and Nile Rodgers)")
+        )
+        assertEquals("get lucky radio edit", YouTubeMusicSource.normalize("Get Lucky - Radio Edit"))
+        // Non-latin titles must survive normalisation or every J-pop and K-pop track stops matching.
+        assertEquals("勇者", YouTubeMusicSource.normalize("勇者"))
+    }
+
+    @Test
+    fun parsesBothTimestampShapesAndIgnoresOtherRuns() {
+        assertEquals(239L, YouTubeMusicSource.parseDuration("3:59"))
+        assertEquals(3753L, YouTubeMusicSource.parseDuration("1:02:33"))
+        assertNull(YouTubeMusicSource.parseDuration("1.8B plays"))
+        assertNull(YouTubeMusicSource.parseDuration("Daft Punk"))
+        assertNull(YouTubeMusicSource.parseDuration(""))
+    }
+
+    @Test
+    fun takesTheHighestBitrateAudioOnlyFormat() {
+        val stream = YouTubeMusicSource.pickAudio(fixture("player_android_vr.json"))
+        assertNotNull(stream)
+        assertEquals("audio/webm", stream!!.mimeType)
+        assertTrue("got ${stream.url.take(40)}", stream.url.startsWith("https://"))
+        // googlevideo matches the request identity against the client the player call claimed.
+        assertTrue(stream.headers.getValue("User-Agent").contains("youtube.vr.oculus"))
+    }
+
+    @Test
+    fun refusesAPlayerResponseThatDemandsALogin() {
+        // What the older ANDROID_VR versions return; the pinned one must keep working.
+        assertNull(YouTubeMusicSource.pickAudio(fixture("player_login_required.json")))
+    }
+}

--- a/src/app/src/test/resources/fixtures/youtubemusic/player_android_vr.json
+++ b/src/app/src/test/resources/fixtures/youtubemusic/player_android_vr.json
@@ -1,0 +1,169 @@
+{
+ "playabilityStatus": {
+  "status": "OK"
+ },
+ "videoDetails": {
+  "videoId": "4D7u5KF7SP8",
+  "title": "Get Lucky (feat. Pharrell Williams and Nile Rodgers)",
+  "lengthSeconds": "370",
+  "author": "Daft Punk - Topic"
+ },
+ "streamingData": {
+  "adaptiveFormats": [
+   {
+    "itag": 137,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=137&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=1932332&dur=369.600&lmt=1665111733891416&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAJ0_DKGdfpTJ0ZuLVmjWDXG4VIXL7zGKZRDjgfoYbF9SAiBLZ45jhccLeEeRjodEufzcghqysc1Sh6SUN09RGyxiNw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"avc1.640020\"",
+    "bitrate": 49042,
+    "contentLength": "1932332"
+   },
+   {
+    "itag": 248,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=248&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=4972433&dur=369.600&lmt=1665112362815501&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRgIhALLg72cUCNp16bhKZzUombvTWwAwfuVQ8atpFEQXzen8AiEA5AD6qoNcKqp3VG8LPpqWl-D3DIs8RqAPHHesRaU-Ros%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/webm; codecs=\"vp9\"",
+    "bitrate": 132265,
+    "contentLength": "4972433"
+   },
+   {
+    "itag": 399,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=399&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=4239508&dur=369.600&lmt=1665113405110455&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAMiW7MkX05a1aFFmZq4vOLXernEKgAJ8OS2yKWGCp5jlAiBWZ46oiTY0IGcptPKc5pcoAiGA7EjGnNwVsgX7VtvpHw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"av01.0.08M.08\"",
+    "bitrate": 111907,
+    "contentLength": "4239508"
+   },
+   {
+    "itag": 136,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=136&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=928236&dur=369.600&lmt=1665113921765196&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgbeTJe9NSiduEPx2MI1KN3MKFeI5Q8cRJuFrLiZZ_VbYCIAz5FYwy5-LoPQ6L8fLjEVUzMZq9stONsy7NWEEg3dNe&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"avc1.4d401f\"",
+    "bitrate": 22897,
+    "contentLength": "928236"
+   },
+   {
+    "itag": 247,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=247&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=2992517&dur=369.600&lmt=1665113473587279&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgS6-8Uj_z8hTnAT2LPryZMSGo11OkonJyZ80uIWnncxsCIDJRl6luhrfIbj-GKaCDeyfV3OOOlAbu4PAhA5jhb8ie&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/webm; codecs=\"vp9\"",
+    "bitrate": 78880,
+    "contentLength": "2992517"
+   },
+   {
+    "itag": 398,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=398&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=2453746&dur=369.600&lmt=1665112468174144&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgWrulIX0iXco7nkJvt70wpT1t5UXgHFbwTPBO6trZoUUCIF8vo8_kKOpb3p45O16VXcJpZ8PIko9Xec-YqFFgT7UO&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"av01.0.04M.08\"",
+    "bitrate": 64410,
+    "contentLength": "2453746"
+   },
+   {
+    "itag": 135,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=135&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=689141&dur=369.600&lmt=1665112917974977&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgB2z7AkALESv2ZEMr3ybyJ06NQ7mT-GrSEHB5Lrw1uI8CIQD6_aFtEfvdXj51eheeFlXEnD2HZk6puSednwsFlNFyUw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"avc1.4d401e\"",
+    "bitrate": 17047,
+    "contentLength": "689141"
+   },
+   {
+    "itag": 244,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=244&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=1649005&dur=369.600&lmt=1665111653620236&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAMjijfZKf2ybIRxI3zGOnUe6vAF5AepmRYQecGD-IL6vAiA4ezb8x5_e9OEOOkbA1tyHKf-dGbh9Np6YRVNViuk5Pg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/webm; codecs=\"vp9\"",
+    "bitrate": 43295,
+    "contentLength": "1649005"
+   },
+   {
+    "itag": 397,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=397&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=1373338&dur=369.600&lmt=1665111704867593&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgCBT1_qvTHRL5a2iz67ZPvGZ-NWLmx7n9UIG9l4duyjkCIEpv7xeP1Ff6SrWKgoesQsiIqXIHTQtwzZvuATjuDSe8&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"av01.0.01M.08\"",
+    "bitrate": 35508,
+    "contentLength": "1373338"
+   },
+   {
+    "itag": 134,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=134&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=557170&dur=369.600&lmt=1665112830646276&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgF09kvazGmecafPKqJOS9idKwGInCcahQtMkEGFr2VMMCIQDZFshKFlyR56llAMe6Unysu_i0xGug8z2gKRVht5IVWg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"avc1.4d4015\"",
+    "bitrate": 13529,
+    "contentLength": "557170"
+   },
+   {
+    "itag": 243,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=243&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=1145668&dur=369.600&lmt=1665111971679932&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAMs0Fv4SZlIytvLWA1EfLoo4TmVKrbp7Xp11sbX04WOkAiAKAUXysra9fni2XdDQcdhpz4QLDISvZ3APG28zftJCkg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/webm; codecs=\"vp9\"",
+    "bitrate": 29682,
+    "contentLength": "1145668"
+   },
+   {
+    "itag": 396,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=396&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=951772&dur=369.600&lmt=1665111866473991&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgCGGhgF_12ELvSLXew9kZGm8tAS2NncWWDt_-4eGQ2i4CIC229pvYmdsPEXpmhBhz6pP24wWFAzSODemyneCpX5So&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+    "bitrate": 24320,
+    "contentLength": "951772"
+   },
+   {
+    "itag": 133,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=133&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=417501&dur=369.600&lmt=1665113142169220&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRgIhAIncfXng5ACyRFz8fmxncb1RQ9ClTaje8K8AdurcE3xXAiEA1DY7UDSSxhQ9-BDTyWSXRpYvBw9UKfr1j91FczPdyBE%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"avc1.4d400c\"",
+    "bitrate": 10669,
+    "contentLength": "417501"
+   },
+   {
+    "itag": 242,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=242&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=789031&dur=369.600&lmt=1665111733740323&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgHogDqymSTXBFDMVOEbyNs_DYsAtw8TU7vlX1Z6pEtu0CIQDOOxYr96difq02a6xFlRQMzJabp64qUe5nLCDXAJj0gg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/webm; codecs=\"vp9\"",
+    "bitrate": 20218,
+    "contentLength": "789031"
+   },
+   {
+    "itag": 395,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=395&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=739162&dur=369.600&lmt=1665111726439139&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgNTWUA0PTYzoOidC41LHoPNgguwzBqMEIvmy6bXveQawCIQCqWeoSsqjpRihmt9ZOoR7BqradhuRtX1vXb6JFpYgt2Q%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+    "bitrate": 18424,
+    "contentLength": "739162"
+   },
+   {
+    "itag": 160,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=160&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=324136&dur=369.600&lmt=1665112846823714&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgFBIsPGG3zY9a2ijVFrXiPUTIm3I1pLizMR23HWsFiW4CIFsZmGU4d4ZS-ZwWpBtehU1GDowCde3mRr4xZrbg4zMr&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"avc1.4d400b\"",
+    "bitrate": 8769,
+    "contentLength": "324136"
+   },
+   {
+    "itag": 278,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=278&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=517076&dur=369.600&lmt=1665111658580849&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgEc82BwXzvYLMMNTVMbmBFP-XY3jwJWK0NlkZqL1KG3UCIFuWeCas0veFT1MXnaKtEwqifL33dYVCujTrwULeFpVn&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/webm; codecs=\"vp9\"",
+    "bitrate": 12828,
+    "contentLength": "517076"
+   },
+   {
+    "itag": 394,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=394&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=564188&dur=369.600&lmt=1665111572239903&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAPiOkkKXOmQ-bifc1TLbozbCHuS9o49OTVX2ozcz6QiBAiBDouJGTTP2wpSBOoyHOTvHbervxEa9rfM6dL69Q6UpNg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+    "bitrate": 13697,
+    "contentLength": "564188"
+   },
+   {
+    "itag": 139,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=139&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=audio%2Fmp4&rqh=1&gir=yes&clen=2255955&dur=369.668&lmt=1665106604157144&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgbiwVzBVYFKzitbshnhZ7QRuY_xF0cb3aoYvMuIuZvPUCIQCZQIEqS4qnam2lYs91BzZ_2GUo_RGtwSTDHxbtdofl_A%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+    "bitrate": 50609,
+    "contentLength": "2255955"
+   },
+   {
+    "itag": 140,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=140&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=audio%2Fmp4&rqh=1&gir=yes&clen=5983790&dur=369.626&lmt=1665106603576375&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAIn2bwPwUolnQiZV4HrZlLlPvz9uBNhUjYCgp4ue7YIEAiB5BiE5IPGYB4kIDKAUNIl-pGuH5yAQG8bRoZvLn6LYjw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+    "bitrate": 137064,
+    "contentLength": "5983790"
+   },
+   {
+    "itag": 249,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=249&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=audio%2Fwebm&rqh=1&gir=yes&clen=2367546&dur=369.641&lmt=1714447227183010&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgEwxkyYjaTYAHqj9S5CWhbsnBBtfiize3G_Z4-T_XpZMCIQDl-OMgRYENb7oc22jjrfgS1TAJL75lv_TAZdL_I0iy3A%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "audio/webm; codecs=\"opus\"",
+    "bitrate": 54853,
+    "contentLength": "2367546"
+   },
+   {
+    "itag": 251,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=251&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=audio%2Fwebm&rqh=1&gir=yes&clen=6214188&dur=369.641&lmt=1714447227166300&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgIVIMbg6-U_W8RB0iMd9fpgh30lsTdtnbUafUEXxAwzECIQDpYVF6LRiZoULelMd2ng_bZCB2fzV-LFIWvPzifErLwQ%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "audio/webm; codecs=\"opus\"",
+    "bitrate": 146453,
+    "contentLength": "6214188"
+   }
+  ]
+ }
+}

--- a/src/app/src/test/resources/fixtures/youtubemusic/player_android_vr.json
+++ b/src/app/src/test/resources/fixtures/youtubemusic/player_android_vr.json
@@ -11,132 +11,6 @@
  "streamingData": {
   "adaptiveFormats": [
    {
-    "itag": 137,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=137&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=1932332&dur=369.600&lmt=1665111733891416&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAJ0_DKGdfpTJ0ZuLVmjWDXG4VIXL7zGKZRDjgfoYbF9SAiBLZ45jhccLeEeRjodEufzcghqysc1Sh6SUN09RGyxiNw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"avc1.640020\"",
-    "bitrate": 49042,
-    "contentLength": "1932332"
-   },
-   {
-    "itag": 248,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=248&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=4972433&dur=369.600&lmt=1665112362815501&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRgIhALLg72cUCNp16bhKZzUombvTWwAwfuVQ8atpFEQXzen8AiEA5AD6qoNcKqp3VG8LPpqWl-D3DIs8RqAPHHesRaU-Ros%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/webm; codecs=\"vp9\"",
-    "bitrate": 132265,
-    "contentLength": "4972433"
-   },
-   {
-    "itag": 399,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=399&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=4239508&dur=369.600&lmt=1665113405110455&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAMiW7MkX05a1aFFmZq4vOLXernEKgAJ8OS2yKWGCp5jlAiBWZ46oiTY0IGcptPKc5pcoAiGA7EjGnNwVsgX7VtvpHw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"av01.0.08M.08\"",
-    "bitrate": 111907,
-    "contentLength": "4239508"
-   },
-   {
-    "itag": 136,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=136&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=928236&dur=369.600&lmt=1665113921765196&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgbeTJe9NSiduEPx2MI1KN3MKFeI5Q8cRJuFrLiZZ_VbYCIAz5FYwy5-LoPQ6L8fLjEVUzMZq9stONsy7NWEEg3dNe&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"avc1.4d401f\"",
-    "bitrate": 22897,
-    "contentLength": "928236"
-   },
-   {
-    "itag": 247,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=247&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=2992517&dur=369.600&lmt=1665113473587279&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgS6-8Uj_z8hTnAT2LPryZMSGo11OkonJyZ80uIWnncxsCIDJRl6luhrfIbj-GKaCDeyfV3OOOlAbu4PAhA5jhb8ie&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/webm; codecs=\"vp9\"",
-    "bitrate": 78880,
-    "contentLength": "2992517"
-   },
-   {
-    "itag": 398,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=398&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=2453746&dur=369.600&lmt=1665112468174144&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgWrulIX0iXco7nkJvt70wpT1t5UXgHFbwTPBO6trZoUUCIF8vo8_kKOpb3p45O16VXcJpZ8PIko9Xec-YqFFgT7UO&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"av01.0.04M.08\"",
-    "bitrate": 64410,
-    "contentLength": "2453746"
-   },
-   {
-    "itag": 135,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=135&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=689141&dur=369.600&lmt=1665112917974977&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgB2z7AkALESv2ZEMr3ybyJ06NQ7mT-GrSEHB5Lrw1uI8CIQD6_aFtEfvdXj51eheeFlXEnD2HZk6puSednwsFlNFyUw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"avc1.4d401e\"",
-    "bitrate": 17047,
-    "contentLength": "689141"
-   },
-   {
-    "itag": 244,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=244&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=1649005&dur=369.600&lmt=1665111653620236&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAMjijfZKf2ybIRxI3zGOnUe6vAF5AepmRYQecGD-IL6vAiA4ezb8x5_e9OEOOkbA1tyHKf-dGbh9Np6YRVNViuk5Pg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/webm; codecs=\"vp9\"",
-    "bitrate": 43295,
-    "contentLength": "1649005"
-   },
-   {
-    "itag": 397,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=397&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=1373338&dur=369.600&lmt=1665111704867593&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgCBT1_qvTHRL5a2iz67ZPvGZ-NWLmx7n9UIG9l4duyjkCIEpv7xeP1Ff6SrWKgoesQsiIqXIHTQtwzZvuATjuDSe8&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"av01.0.01M.08\"",
-    "bitrate": 35508,
-    "contentLength": "1373338"
-   },
-   {
-    "itag": 134,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=134&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=557170&dur=369.600&lmt=1665112830646276&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgF09kvazGmecafPKqJOS9idKwGInCcahQtMkEGFr2VMMCIQDZFshKFlyR56llAMe6Unysu_i0xGug8z2gKRVht5IVWg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"avc1.4d4015\"",
-    "bitrate": 13529,
-    "contentLength": "557170"
-   },
-   {
-    "itag": 243,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=243&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=1145668&dur=369.600&lmt=1665111971679932&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAMs0Fv4SZlIytvLWA1EfLoo4TmVKrbp7Xp11sbX04WOkAiAKAUXysra9fni2XdDQcdhpz4QLDISvZ3APG28zftJCkg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/webm; codecs=\"vp9\"",
-    "bitrate": 29682,
-    "contentLength": "1145668"
-   },
-   {
-    "itag": 396,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=396&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=951772&dur=369.600&lmt=1665111866473991&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgCGGhgF_12ELvSLXew9kZGm8tAS2NncWWDt_-4eGQ2i4CIC229pvYmdsPEXpmhBhz6pP24wWFAzSODemyneCpX5So&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
-    "bitrate": 24320,
-    "contentLength": "951772"
-   },
-   {
-    "itag": 133,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=133&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=417501&dur=369.600&lmt=1665113142169220&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRgIhAIncfXng5ACyRFz8fmxncb1RQ9ClTaje8K8AdurcE3xXAiEA1DY7UDSSxhQ9-BDTyWSXRpYvBw9UKfr1j91FczPdyBE%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"avc1.4d400c\"",
-    "bitrate": 10669,
-    "contentLength": "417501"
-   },
-   {
-    "itag": 242,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=242&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=789031&dur=369.600&lmt=1665111733740323&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgHogDqymSTXBFDMVOEbyNs_DYsAtw8TU7vlX1Z6pEtu0CIQDOOxYr96difq02a6xFlRQMzJabp64qUe5nLCDXAJj0gg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/webm; codecs=\"vp9\"",
-    "bitrate": 20218,
-    "contentLength": "789031"
-   },
-   {
-    "itag": 395,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=395&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=739162&dur=369.600&lmt=1665111726439139&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgNTWUA0PTYzoOidC41LHoPNgguwzBqMEIvmy6bXveQawCIQCqWeoSsqjpRihmt9ZOoR7BqradhuRtX1vXb6JFpYgt2Q%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
-    "bitrate": 18424,
-    "contentLength": "739162"
-   },
-   {
-    "itag": 160,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=160&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=324136&dur=369.600&lmt=1665112846823714&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgFBIsPGG3zY9a2ijVFrXiPUTIm3I1pLizMR23HWsFiW4CIFsZmGU4d4ZS-ZwWpBtehU1GDowCde3mRr4xZrbg4zMr&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"avc1.4d400b\"",
-    "bitrate": 8769,
-    "contentLength": "324136"
-   },
-   {
-    "itag": 278,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=278&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fwebm&rqh=1&gir=yes&clen=517076&dur=369.600&lmt=1665111658580849&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4537434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRAIgEc82BwXzvYLMMNTVMbmBFP-XY3jwJWK0NlkZqL1KG3UCIFuWeCas0veFT1MXnaKtEwqifL33dYVCujTrwULeFpVn&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/webm; codecs=\"vp9\"",
-    "bitrate": 12828,
-    "contentLength": "517076"
-   },
-   {
-    "itag": 394,
-    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=394&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=564188&dur=369.600&lmt=1665111572239903&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAPiOkkKXOmQ-bifc1TLbozbCHuS9o49OTVX2ozcz6QiBAiBDouJGTTP2wpSBOoyHOTvHbervxEa9rfM6dL69Q6UpNg%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
-    "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
-    "bitrate": 13697,
-    "contentLength": "564188"
-   },
-   {
     "itag": 139,
     "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=139&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=audio%2Fmp4&rqh=1&gir=yes&clen=2255955&dur=369.668&lmt=1665106604157144&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIgbiwVzBVYFKzitbshnhZ7QRuY_xF0cb3aoYvMuIuZvPUCIQCZQIEqS4qnam2lYs91BzZ_2GUo_RGtwSTDHxbtdofl_A%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
     "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
@@ -163,6 +37,13 @@
     "mimeType": "audio/webm; codecs=\"opus\"",
     "bitrate": 146453,
     "contentLength": "6214188"
+   },
+   {
+    "itag": 137,
+    "url": "https://rr3---sn-1gi7znes.googlevideo.com/videoplayback?expire=1785417231&ei=r_lqas3ULKfT6dsP4arOgAQ&ip=141.195.95.82&id=o-ACMC9-FZ0N1dAr4WOWZhVVYmdvZWiYiFS-tLEW6n4Pyc&itag=137&source=youtube&requiressl=yes&xpc=EgVo2aDSNQ%3D%3D&cps=737&met=1785395631%2C&mh=V0&mm=31%2C26&mn=sn-1gi7znes%2Csn-h0jelnez&ms=au%2Conr&mv=m&mvi=3&pl=23&rms=au%2Cau&gcr=ch&initcwndbps=4426250&bui=AZFlqhOWl3leUajU_qSt0Mb6WZo45MokzOkH1IwEWJphuc86szYFuG-TRT5Fc3L69w-hGNEk9eSgKSXG&spc=KBGBcuyuD9WgrVEXgG4gGfqb6fMSnUMC-mtNntr8uWxv&vprv=1&svpuc=1&mime=video%2Fmp4&rqh=1&gir=yes&clen=1932332&dur=369.600&lmt=1665111733891416&mt=1785395374&fvip=5&keepalive=yes&fexp=51565116&c=ANDROID_VR&txp=4532434&sparams=expire%2Cei%2Cip%2Cid%2Citag%2Csource%2Crequiressl%2Cxpc%2Cgcr%2Cbui%2Cspc%2Cvprv%2Csvpuc%2Cmime%2Crqh%2Cgir%2Cclen%2Cdur%2Clmt&sig=AE0s2JYwRQIhAJ0_DKGdfpTJ0ZuLVmjWDXG4VIXL7zGKZRDjgfoYbF9SAiBLZ45jhccLeEeRjodEufzcghqysc1Sh6SUN09RGyxiNw%3D%3D&lsparams=cps%2Cmet%2Cmh%2Cmm%2Cmn%2Cms%2Cmv%2Cmvi%2Cpl%2Crms%2Cinitcwndbps&lsig=APaTxxMwRAIgFUetj2ypgKjVmidirR_n-Vqv5hwpIHM6exFJxEa1RocCIBoxywbEzqM5yKZBRIrFd1qtRD9d_rJKWho_Ns2giLsY",
+    "mimeType": "video/mp4; codecs=\"avc1.640020\"",
+    "bitrate": 49042,
+    "contentLength": "1932332"
    }
   ]
  }

--- a/src/app/src/test/resources/fixtures/youtubemusic/player_login_required.json
+++ b/src/app/src/test/resources/fixtures/youtubemusic/player_login_required.json
@@ -1,6 +1,0 @@
-{
- "playabilityStatus": {
-  "status": "LOGIN_REQUIRED",
-  "reason": "Sign in to confirm you're not a bot"
- }
-}

--- a/src/app/src/test/resources/fixtures/youtubemusic/player_login_required.json
+++ b/src/app/src/test/resources/fixtures/youtubemusic/player_login_required.json
@@ -1,0 +1,6 @@
+{
+ "playabilityStatus": {
+  "status": "LOGIN_REQUIRED",
+  "reason": "Sign in to confirm you're not a bot"
+ }
+}

--- a/src/app/src/test/resources/fixtures/youtubemusic/search_songs.json
+++ b/src/app/src/test/resources/fixtures/youtubemusic/search_songs.json
@@ -1,0 +1,676 @@
+{
+ "contents": {
+  "tabbedSearchResultsRenderer": {
+   "tabs": [
+    {
+     "tabRenderer": {
+      "title": "YT Music",
+      "selected": true,
+      "content": {
+       "sectionListRenderer": {
+        "contents": [
+         {
+          "musicShelfRenderer": {
+           "title": {
+            "runs": [
+             {
+              "text": "Songs"
+             }
+            ]
+           },
+           "contents": [
+            {
+             "musicResponsiveListItemRenderer": {
+              "flexColumns": [
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Get Lucky (feat. Pharrell Williams and Nile Rodgers)",
+                    "navigationEndpoint": {
+                     "watchEndpoint": {
+                      "videoId": "4D7u5KF7SP8",
+                      "playerParams": "0gcJCeEB0OBS9m0t"
+                     }
+                    }
+                   }
+                  ]
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Daft Punk",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCRr1xG_2WIDs18a6cIiCxeA"
+                     }
+                    }
+                   },
+                   {
+                    "text": ", "
+                   },
+                   {
+                    "text": "Pharrell Williams",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCJw8VyO6e3v6S0327AsgwcQ"
+                     }
+                    }
+                   },
+                   {
+                    "text": " & "
+                   },
+                   {
+                    "text": "Nile Rodgers",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCThde8ccpEr6sP8dIHZ-ceQ"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "Random Access Memories",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "MPREb_K8qWMWVqXGi"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "6:10"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "Daft Punk, Pharrell Williams & Nile Rodgers • Random Access Memories • 6 minutes, 10 seconds"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "1.8B plays"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "1.8 billion plays"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               }
+              ],
+              "playlistItemData": {
+               "videoId": "4D7u5KF7SP8"
+              }
+             }
+            },
+            {
+             "musicResponsiveListItemRenderer": {
+              "flexColumns": [
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Get Lucky (Radio Edit - feat. Pharrell Williams and Nile Rodgers)",
+                    "navigationEndpoint": {
+                     "watchEndpoint": {
+                      "videoId": "Rgrt_8mXrK8"
+                     }
+                    }
+                   }
+                  ]
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Daft Punk",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCRr1xG_2WIDs18a6cIiCxeA"
+                     }
+                    }
+                   },
+                   {
+                    "text": ", "
+                   },
+                   {
+                    "text": "Pharrell Williams",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCJw8VyO6e3v6S0327AsgwcQ"
+                     }
+                    }
+                   },
+                   {
+                    "text": " & "
+                   },
+                   {
+                    "text": "Nile Rodgers",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCThde8ccpEr6sP8dIHZ-ceQ"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "Get Lucky (Radio Edit - feat. Pharrell Williams and Nile Rodgers)",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "MPREb_yw4jv9byKCr"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "4:09"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "Daft Punk, Pharrell Williams & Nile Rodgers • Get Lucky (Radio Edit - feat. Pharrell Williams and Nile Rodgers) • 4 minutes, 9 seconds"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "1.8B plays"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "1.8 billion plays"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               }
+              ],
+              "playlistItemData": {
+               "videoId": "Rgrt_8mXrK8"
+              }
+             }
+            },
+            {
+             "musicResponsiveListItemRenderer": {
+              "flexColumns": [
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Lose Yourself to Dance (feat. Pharrell Williams)",
+                    "navigationEndpoint": {
+                     "watchEndpoint": {
+                      "videoId": "iU7oF4OXZSE"
+                     }
+                    }
+                   }
+                  ]
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Daft Punk",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCRr1xG_2WIDs18a6cIiCxeA"
+                     }
+                    }
+                   },
+                   {
+                    "text": " & "
+                   },
+                   {
+                    "text": "Pharrell Williams",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCJw8VyO6e3v6S0327AsgwcQ"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "Random Access Memories",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "MPREb_K8qWMWVqXGi"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "5:54"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "Daft Punk & Pharrell Williams • Random Access Memories • 5 minutes, 54 seconds"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "382M plays"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "382 million plays"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               }
+              ],
+              "playlistItemData": {
+               "videoId": "iU7oF4OXZSE"
+              }
+             }
+            },
+            {
+             "musicResponsiveListItemRenderer": {
+              "flexColumns": [
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Instant Crush (feat. Julian Casablancas)",
+                    "navigationEndpoint": {
+                     "watchEndpoint": {
+                      "videoId": "khnokW3Mw24"
+                     }
+                    }
+                   }
+                  ]
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Daft Punk",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCRr1xG_2WIDs18a6cIiCxeA"
+                     }
+                    }
+                   },
+                   {
+                    "text": " & "
+                   },
+                   {
+                    "text": "Julian Casablancas",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCWhpbdGLnR8XtXLr0yl2nYA"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "Random Access Memories",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "MPREb_K8qWMWVqXGi"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "5:38"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "Daft Punk & Julian Casablancas • Random Access Memories • 5 minutes, 38 seconds"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "1.2B plays"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "1.2 billion plays"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               }
+              ],
+              "playlistItemData": {
+               "videoId": "khnokW3Mw24"
+              }
+             }
+            },
+            {
+             "musicResponsiveListItemRenderer": {
+              "flexColumns": [
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Get Lucky (feat. Pharrell & Nile rodgers)",
+                    "navigationEndpoint": {
+                     "watchEndpoint": {
+                      "videoId": "C6CYfFhlwkc"
+                     }
+                    }
+                   }
+                  ]
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "Daft punk",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "UCRr1xG_2WIDs18a6cIiCxeA"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "Rare RnB & New Jack 71",
+                    "navigationEndpoint": {
+                     "browseEndpoint": {
+                      "browseId": "MPREb_GPKU10x0HR4"
+                     }
+                    }
+                   },
+                   {
+                    "text": " • "
+                   },
+                   {
+                    "text": "4:08"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "Daft punk • Rare RnB & New Jack 71 • 4 minutes, 8 seconds"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               },
+               {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                 "text": {
+                  "runs": [
+                   {
+                    "text": "1.8B plays"
+                   }
+                  ],
+                  "accessibility": {
+                   "accessibilityData": {
+                    "label": "1.8 billion plays"
+                   }
+                  }
+                 },
+                 "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                }
+               }
+              ],
+              "playlistItemData": {
+               "videoId": "C6CYfFhlwkc"
+              }
+             }
+            }
+           ]
+          }
+         }
+        ],
+        "header": {
+         "chipCloudRenderer": {
+          "chips": [
+           {
+            "chipCloudChipRenderer": {
+             "style": {
+              "styleType": "STYLE_SECONDARY"
+             },
+             "navigationEndpoint": {
+              "searchEndpoint": {
+               "query": "Daft Punk Get Lucky"
+              }
+             },
+             "icon": {
+              "iconType": "CLOSE"
+             },
+             "accessibilityData": {
+              "accessibilityData": {
+               "label": "Clear filters"
+              }
+             },
+             "isSelected": false,
+             "uniqueId": "Clear filters"
+            }
+           },
+           {
+            "chipCloudChipRenderer": {
+             "style": {
+              "styleType": "STYLE_DEFAULT"
+             },
+             "text": {
+              "runs": [
+               {
+                "text": "Community playlists"
+               }
+              ]
+             },
+             "navigationEndpoint": {
+              "searchEndpoint": {
+               "query": "Daft Punk Get Lucky",
+               "params": "EgeKAQQoAEABagoQChADEAQQCRAF"
+              }
+             },
+             "accessibilityData": {
+              "accessibilityData": {
+               "label": "Show community playlist results"
+              }
+             },
+             "isSelected": false,
+             "uniqueId": "Community playlists"
+            }
+           },
+           {
+            "chipCloudChipRenderer": {
+             "style": {
+              "styleType": "STYLE_PRIMARY"
+             },
+             "text": {
+              "runs": [
+               {
+                "text": "Songs"
+               }
+              ]
+             },
+             "navigationEndpoint": {
+              "searchEndpoint": {
+               "query": "Daft Punk Get Lucky",
+               "params": "EgWKAQIIAWoKEAoQAxAEEAkQBQ%3D%3D"
+              }
+             },
+             "accessibilityData": {
+              "accessibilityData": {
+               "label": "Show song results selected"
+              }
+             },
+             "isSelected": true,
+             "uniqueId": "Songs"
+            }
+           },
+           {
+            "chipCloudChipRenderer": {
+             "style": {
+              "styleType": "STYLE_DEFAULT"
+             },
+             "text": {
+              "runs": [
+               {
+                "text": "Videos"
+               }
+              ]
+             },
+             "navigationEndpoint": {
+              "searchEndpoint": {
+               "query": "Daft Punk Get Lucky",
+               "params": "EgWKAQIQAWoKEAoQAxAEEAkQBQ%3D%3D"
+              }
+             },
+             "accessibilityData": {
+              "accessibilityData": {
+               "label": "Show video results"
+              }
+             },
+             "isSelected": false,
+             "uniqueId": "Videos"
+            }
+           },
+           {
+            "chipCloudChipRenderer": {
+             "style": {
+              "styleType": "STYLE_DEFAULT"
+             },
+             "text": {
+              "runs": [
+               {
+                "text": "Albums"
+               }
+              ]
+             },
+             "navigationEndpoint": {
+              "searchEndpoint": {
+               "query": "Daft Punk Get Lucky",
+               "params": "EgWKAQIYAWoKEAoQAxAEEAkQBQ%3D%3D"
+              }
+             },
+             "accessibilityData": {
+              "accessibilityData": {
+               "label": "Show album results"
+              }
+             },
+             "isSelected": false,
+             "uniqueId": "Albums"
+            }
+           },
+           {
+            "chipCloudChipRenderer": {
+             "style": {
+              "styleType": "STYLE_DEFAULT"
+             },
+             "text": {
+              "runs": [
+               {
+                "text": "Artists"
+               }
+              ]
+             },
+             "navigationEndpoint": {
+              "searchEndpoint": {
+               "query": "Daft Punk Get Lucky",
+               "params": "EgWKAQIgAWoKEAoQAxAEEAkQBQ%3D%3D"
+              }
+             },
+             "accessibilityData": {
+              "accessibilityData": {
+               "label": "Show artist results"
+              }
+             },
+             "isSelected": false,
+             "uniqueId": "Artists"
+            }
+           }
+          ],
+          "collapsedRowCount": 1,
+          "horizontalScrollable": true
+         }
+        }
+       }
+      },
+      "tabIdentifier": "music_search_catalog"
+     }
+    }
+   ]
+  }
+ }
+}


### PR DESCRIPTION
Adds YouTube Music alongside the Spfy stream and the lossless chain, so the audio-source setting becomes an explicit three-way choice. Resolution runs over InnerTube with no account, and a track that cannot be confidently matched is skipped rather than served from a different source.

Closes #490