### PR TITLE
Keep the playing track when trimming the queued next item

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -872,8 +872,8 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         }
 
         mainHandler.post {
-            if (player.mediaItemCount > 1) {
-                player.removeMediaItems(1, player.mediaItemCount)
+            staleQueueStart(player.currentMediaItemIndex, player.mediaItemCount)?.let { from ->
+                player.removeMediaItems(from, player.mediaItemCount)
             }
             // Header-gated sources (anandserver Qobuz) must be enqueued as a
             // header-injecting MediaSource, or the gapless advance hits a 401.
@@ -1340,3 +1340,13 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         super.onDestroy()
     }
 }
+
+/**
+ * Index to start dropping stale queued items from, or null when nothing follows the current one.
+ *
+ * A fixed index of 1 looks right only while the current track is the first item. After ExoPlayer
+ * advances gaplessly the played item stays in the playlist and the current index moves past it, so
+ * trimming from 1 removes the track that is playing and playback ends on the spot (#492).
+ */
+internal fun staleQueueStart(currentIndex: Int, itemCount: Int): Int? =
+    (currentIndex + 1).takeIf { it < itemCount }

--- a/src/app/src/test/java/ch/snepilatch/app/playback/StaleQueueStartTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/playback/StaleQueueStartTest.kt
@@ -1,0 +1,35 @@
+package ch.snepilatch.app.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression guard for a long gap between tracks. setNextUrl used to trim the queue from a fixed
+ * index 1, which is only the first stale slot while the current track is item 0. After a gapless
+ * auto-advance ExoPlayer leaves the played item in the playlist and moves the current index past it,
+ * so the next pre-resolve deleted the track that was playing: STATE_ENDED fired 18ms after the
+ * enqueue, the end-of-track grace then burned its full 5 seconds, and the forced advance landed on
+ * an ad. Captured live at 10:08:15.174.
+ */
+class StaleQueueStartTest {
+
+    @Test
+    fun trimsFromTheSlotAfterTheCurrentTrack() {
+        assertEquals(1, staleQueueStart(currentIndex = 0, itemCount = 2))
+        assertEquals(2, staleQueueStart(currentIndex = 1, itemCount = 3))
+    }
+
+    @Test
+    fun keepsThePlayingTrackAfterAGaplessAdvance() {
+        // The bug: current is item 1, the only queued item, and trimming from 1 removed it.
+        assertNull(staleQueueStart(currentIndex = 1, itemCount = 2))
+        assertNull(staleQueueStart(currentIndex = 2, itemCount = 3))
+    }
+
+    @Test
+    fun trimsNothingWhenTheCurrentTrackIsAlone() {
+        assertNull(staleQueueStart(currentIndex = 0, itemCount = 1))
+        assertNull(staleQueueStart(currentIndex = 0, itemCount = 0))
+    }
+}


### PR DESCRIPTION
setNextUrl trimmed the player queue from a fixed index 1, which removes the currently playing track once a gapless auto-advance has moved the current index past 0, ending playback and leaving a multi-second gap before the forced advance recovers. Trims from the slot after the current index instead.

Closes #492