### PR TITLE
Throttle the smooth position bar instead of requesting a frame every vsync

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -72,6 +72,7 @@ import ch.snepilatch.app.viewmodel.ThemeController
 import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import coil.compose.AsyncImage
+import kotlinx.coroutines.delay
 
 /**
  * Match the app's transparent, edge-to-edge nav bar inside a ModalBottomSheet. The sheet
@@ -158,11 +159,12 @@ fun SpfyImage(
  * A playback position (ms) that advances at the display's native refresh rate instead of stepping
  * when the upstream [positionMs] StateFlow ticks.
  *
- * Each authoritative [positionMs] (and every play/pause flip) becomes an anchor; while playing,
- * withFrameNanos advances the returned value once per frame from that anchor, so the progress bar
- * glides with no visible steps. It stays honest because every upstream tick re-anchors it to the
- * true position (for local streaming that is ExoPlayer's own clock), correcting any drift twice a
- * second. Costs nothing when paused or off-screen — no frames are requested.
+ * Each authoritative [positionMs] (and every play/pause flip) becomes an anchor; while playing, the
+ * returned value advances from that anchor roughly every [PROGRESS_TICK_MS], read off the real frame
+ * timestamp, so the progress bar glides with no visible steps. It stays honest because every upstream
+ * tick re-anchors it to the true position (for local streaming that is ExoPlayer's own clock),
+ * correcting any drift twice a second. Costs nothing when paused or off-screen — no frames are
+ * requested.
  */
 @Composable
 fun rememberSmoothPositionMs(positionMs: Long, durationMs: Long, isPlaying: Boolean): State<Long> {
@@ -181,10 +183,24 @@ fun rememberSmoothPositionMs(positionMs: Long, durationMs: Long, isPlaying: Bool
                 if (anchorFrame < 0) anchorFrame = frame
                 displayed.longValue = (positionMs + (frame - anchorFrame) / 1_000_000L).coerceIn(0L, cap)
             }
+            // Yield the display back between updates. withFrameNanos registers a Choreographer
+            // callback, which schedules a frame — so looping it bare held the whole app at the panel's
+            // full rate (~120fps, ~1 CPU core plus up to half of surfaceflinger) for as long as audio
+            // played, on every screen. A progress bar advances about one pixel every 200ms, so 30
+            // updates a second is already more than it can show. Same cadence P0-1 settled on for the
+            // fluid background.
+            delay(PROGRESS_TICK_MS)
         }
     }
     return displayed
 }
+
+/**
+ * How often the smooth position advances while playing, in ms (~30fps). Not per-frame: see the loop
+ * in [rememberSmoothPositionMs]. The value stays derived from the real frame timestamp, so throttling
+ * the cadence costs accuracy nothing — only the number of frames requested.
+ */
+private const val PROGRESS_TICK_MS = 32L
 
 // --- Track Row ---
 


### PR DESCRIPTION
Closes #496.

`rememberSmoothPositionMs` looped `withFrameNanos` with no delay while `isPlaying`. That call registers a Choreographer callback, which schedules a frame — so the loop held the entire app at the panel's full refresh rate for the whole track, on **every** screen. On Home, where the only moving pixel is the mini-player progress bar, that was ~122fps and about one CPU core.

This is the same always-on-frame-loop class `WS-P0-FRAMELOOPS` addressed for the paused case; paused was already idle, playing was not.

The value is still read off the real frame timestamp, so accuracy is unchanged — only the number of frames requested drops. ~30fps is the cadence `P0-1` settled on for the fluid background, and a progress bar advances roughly one pixel per 200ms, so it cannot show more than that anyway.

### Measurements

Xiaomi Mi 11 Ultra (SDK 34, 120Hz), **gradient** background, Home screen, `devRelease`, `dumpsys gfxinfo` over 8-second windows:

| | frames / 8s | app CPU | surfaceflinger |
|---|---|---|---|
| before | 978 (~122fps) | 106–113% | 46–48% |
| after | **201–204** (~25fps) | **45–48%** | **13–15%** |

Paused, both before and after: **0 frames, ~0% CPU.**

Cross-checked on a Samsung S25 Ultra (SDK 36, 120Hz LTPO) before the change: 972 frames / 8s while playing, 0 paused — same signature, and worse there in principle since a per-vsync request stops the LTPO panel dropping to 10Hz.

### On the janky-frame number

`gfxinfo` reports 13–20% janky after the change, up from ~0%. That is an accounting artifact, not a regression: it scores every frame against the per-vsync deadline, which rendering at 25fps on a 120Hz panel cannot meet by construction. **Missed Vsync is 0** after the change, i.e. nothing is presented late. For comparison, the pre-change build reported 61 missed vsyncs.

Worth an eyeball on the bar before merging, since smoothness is ultimately a visual judgement and I could only measure it.

### Not from #495

- #495 touches neither `rememberSmoothPositionMs`, `MiniPlayer.kt`, nor `PositionInterpolator.kt`.
- Same-device, same-session A/B: `main` 978 frames / 106–113% CPU vs `#495` 979 frames / 100–105%. Identical within noise.

`git log -S withFrameNanos` attributes the loop to fb1ce45 (#359).

### Verification

`:app:assembleDevRelease`, `:app:testProdDebugUnitTest`, `detekt` — all green. Device-tested on the Xiaomi with a force-stop and relaunch between installs.
