### PR TITLE
Present the README features as a two-column table

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,38 +20,13 @@
 
 ## Features
 
-**Playback**
-
-- Plays locally on your phone as its own Connect device, so transport actions are never skip-capped
-- Ad-free listening
-- Choose your audio source: the standard stream, optional lossless, or YouTube Music
-- Full Connect control: transfer to and from other devices
-
-**Sound**
-
-- Ten-band in-app equalizer with a drag-and-drop curve editor
-- Automatic gain staging so boosted bands cannot clip
-- EQ headroom for anyone running an external equalizer such as Wavelet
-
-**InfiniPlay**
-
-- Turns any track into a never-ending remix, beat-matched and crossfaded in the audio chain
-- Builds a beat graph from the waveform itself, with no per-track analysis API
-
-**Library and browsing**
-
-- Liked songs, playlists, albums, artists and podcasts
-- Search, home feed, and queue management in a bottom drawer
-- Word-level synced lyrics
-
-**Interface**
-
-- Fully native UI built with Jetpack Compose and Material 3
-- Dynamic color theming from album art
-- Gesture-based player with swipe navigation
-- Canvas background animations
-- English, German, Russian and Swiss German
-- Automatic in-app updates
+| | |
+| --- | --- |
+| **Playback** | Plays locally on your phone as its own Connect device, so transport actions are never skip-capped<br>Ad-free listening<br>Choose your audio source: the standard stream, optional lossless, or YouTube Music<br>Full Connect control: transfer to and from other devices |
+| **Sound** | Ten-band in-app equalizer with a drag-and-drop curve editor<br>Automatic gain staging so boosted bands cannot clip<br>EQ headroom for anyone running an external equalizer such as Wavelet |
+| **InfiniPlay** | Turns any track into a never-ending remix, beat-matched and crossfaded in the audio chain<br>Builds a beat graph from the waveform itself, with no per-track analysis API |
+| **Library and browsing** | Liked songs, playlists, albums, artists and podcasts<br>Search, home feed, and queue management in a bottom drawer<br>Word-level synced lyrics |
+| **Interface** | Fully native UI built with Jetpack Compose and Material 3<br>Dynamic color theming from album art<br>Gesture-based player with swipe navigation<br>Canvas background animations<br>English, German, Russian and Swiss German<br>Automatic in-app updates |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 
 | Playback | Sound |
 | --- | --- |
-| Plays locally on your phone as its own Connect device, so transport actions are never skip-capped<br>Ad-free listening<br>Choose your audio source: the standard stream, optional lossless, or YouTube Music<br>Full Connect control: transfer to and from other devices | Ten-band in-app equalizer with a drag-and-drop curve editor<br>Automatic gain staging so boosted bands cannot clip<br>EQ headroom for anyone running an external equalizer such as Wavelet |
+| <ul><li>Plays locally on your phone as its own Connect device, so transport actions are never skip-capped</li><li>Ad-free listening</li><li>Choose your audio source: the standard stream, optional lossless, or YouTube Music</li><li>Full Connect control: transfer to and from other devices</li></ul> | <ul><li>Ten-band in-app equalizer with a drag-and-drop curve editor</li><li>Automatic gain staging so boosted bands cannot clip</li><li>EQ headroom for anyone running an external equalizer such as Wavelet</li></ul> |
 | **InfiniPlay** | **Library and browsing** |
-| Turns any track into a never-ending remix, beat-matched and crossfaded in the audio chain<br>Builds a beat graph from the waveform itself, with no per-track analysis API | Liked songs, playlists, albums, artists and podcasts<br>Search, home feed, and queue management in a bottom drawer<br>Word-level synced lyrics |
+| <ul><li>Turns any track into a never-ending remix, beat-matched and crossfaded in the audio chain</li><li>Builds a beat graph from the waveform itself, with no per-track analysis API</li></ul> | <ul><li>Liked songs, playlists, albums, artists and podcasts</li><li>Search, home feed, and queue management in a bottom drawer</li><li>Word-level synced lyrics</li></ul> |
 | **Interface** | **Languages and updates** |
-| Fully native UI built with Jetpack Compose and Material 3<br>Dynamic color theming from album art<br>Gesture-based player with swipe navigation<br>Canvas background animations | English, German, Russian and Swiss German<br>Automatic in-app updates |
+| <ul><li>Fully native UI built with Jetpack Compose and Material 3</li><li>Dynamic color theming from album art</li><li>Gesture-based player with swipe navigation</li><li>Canvas background animations</li></ul> | <ul><li>English, German, Russian and Swiss German</li><li>Automatic in-app updates</li></ul> |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
 
 ## Features
 
-| | |
+| Playback | Sound |
 | --- | --- |
-| **Playback** | Plays locally on your phone as its own Connect device, so transport actions are never skip-capped<br>Ad-free listening<br>Choose your audio source: the standard stream, optional lossless, or YouTube Music<br>Full Connect control: transfer to and from other devices |
-| **Sound** | Ten-band in-app equalizer with a drag-and-drop curve editor<br>Automatic gain staging so boosted bands cannot clip<br>EQ headroom for anyone running an external equalizer such as Wavelet |
-| **InfiniPlay** | Turns any track into a never-ending remix, beat-matched and crossfaded in the audio chain<br>Builds a beat graph from the waveform itself, with no per-track analysis API |
-| **Library and browsing** | Liked songs, playlists, albums, artists and podcasts<br>Search, home feed, and queue management in a bottom drawer<br>Word-level synced lyrics |
-| **Interface** | Fully native UI built with Jetpack Compose and Material 3<br>Dynamic color theming from album art<br>Gesture-based player with swipe navigation<br>Canvas background animations<br>English, German, Russian and Swiss German<br>Automatic in-app updates |
+| Plays locally on your phone as its own Connect device, so transport actions are never skip-capped<br>Ad-free listening<br>Choose your audio source: the standard stream, optional lossless, or YouTube Music<br>Full Connect control: transfer to and from other devices | Ten-band in-app equalizer with a drag-and-drop curve editor<br>Automatic gain staging so boosted bands cannot clip<br>EQ headroom for anyone running an external equalizer such as Wavelet |
+| **InfiniPlay** | **Library and browsing** |
+| Turns any track into a never-ending remix, beat-matched and crossfaded in the audio chain<br>Builds a beat graph from the waveform itself, with no per-track analysis API | Liked songs, playlists, albums, artists and podcasts<br>Search, home feed, and queue management in a bottom drawer<br>Word-level synced lyrics |
+| **Interface** | **Languages and updates** |
+| Fully native UI built with Jetpack Compose and Material 3<br>Dynamic color theming from album art<br>Gesture-based player with swipe navigation<br>Canvas background animations | English, German, Russian and Swiss German<br>Automatic in-app updates |
 
 ## Installation
 


### PR DESCRIPTION
Closes #500

The Features section was five bold headings each followed by a bullet list. It read as a wall on the repo page and the groups carried no weight, since a heading plus bullets looks like any other bold line plus bullets.

Now a grid, two groups per row, so the section is about half as tall and the whole feature set fits in one look.

One content change, and it is only a regrouping: the last row would have been a lone **Interface** cell with a gap beside it, so the two entries that are not about the interface itself, the languages and the automatic in-app updates, became their own **Languages and updates** group. No feature is added or dropped.

Rendered:

| Playback | Sound |
| --- | --- |
| Plays locally on your phone as its own Connect device, so transport actions are never skip-capped<br>Ad-free listening<br>Choose your audio source: the standard stream, optional lossless, or YouTube Music<br>Full Connect control: transfer to and from other devices | Ten-band in-app equalizer with a drag-and-drop curve editor<br>Automatic gain staging so boosted bands cannot clip<br>EQ headroom for anyone running an external equalizer such as Wavelet |
| **InfiniPlay** | **Library and browsing** |
| Turns any track into a never-ending remix, beat-matched and crossfaded in the audio chain<br>Builds a beat graph from the waveform itself, with no per-track analysis API | Liked songs, playlists, albums, artists and podcasts<br>Search, home feed, and queue management in a bottom drawer<br>Word-level synced lyrics |
| **Interface** | **Languages and updates** |
| Fully native UI built with Jetpack Compose and Material 3<br>Dynamic color theming from album art<br>Gesture-based player with swipe navigation<br>Canvas background animations | English, German, Russian and Swiss German<br>Automatic in-app updates |