### PR TITLE
Resolve YouTube Music tracks with a feature credit or a hyphen

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/YouTubeMusicSource.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/YouTubeMusicSource.kt
@@ -83,7 +83,7 @@ object YouTubeMusicSource {
         region: String?,
         durationMs: Long,
     ): Stream? = withContext(Dispatchers.IO) {
-        val query = listOf(artist, title).filter { it.isNotBlank() }.joinToString(" ").trim()
+        val query = searchQuery(artist, title)
         if (query.isBlank()) return@withContext null
 
         val visitor = visitorData ?: fetchVisitorData(region)?.also { visitorData = it }
@@ -205,7 +205,7 @@ object YouTubeMusicSource {
 
     /** Null rather than a guess: the wrong recording is worse than none, and the caller skips. */
     internal fun bestMatch(candidates: List<Candidate>, wantTitle: String, durationMs: Long): Candidate? {
-        val want = words(wantTitle)
+        val want = titleWords(wantTitle)
         val titled = candidates.filter { want.isEmpty() || titleScore(it.title, want) >= MIN_TITLE_SCORE }
         if (durationMs <= 0L) return titled.firstOrNull()
         val wantSec = durationMs / 1000
@@ -241,6 +241,32 @@ object YouTubeMusicSource {
         }
         return edits + (long.length - i) + (short.length - j) <= 1
     }
+
+    /**
+     * What to search for, with the operator meaning taken out of a leading hyphen.
+     *
+     * YouTube reads "-word" as "exclude everything containing word". A track called "改変 -罪-"
+     * therefore asked search to drop every result carrying 罪, which is the artist and the whole
+     * release, and the shelf came back empty. Only a hyphen that opens a word is an operator, so a
+     * name like Spider-Man keeps its own.
+     */
+    internal fun searchQuery(artist: String, title: String): String =
+        listOf(artist, title).filter { it.isNotBlank() }.joinToString(" ")
+            .replace(Regex("(^|\\s)-+"), "$1")
+            .trim()
+
+    /**
+     * The words of the wanted title a candidate has to carry, which stops at the feature credit.
+     *
+     * Spotify writes the guest into the track name, YouTube Music puts it in brackets that
+     * [normalize] then strips off the candidate. So "弔花 feat. 他人事" was scored against a
+     * candidate reading "弔花", matched one word of three, and never came near [MIN_TITLE_SCORE].
+     * Only the part before the credit is required; a candidate that does spell the guest out still
+     * matches, because the score measures how much of the wanted title the candidate carries and
+     * never penalises extra words.
+     */
+    internal fun titleWords(title: String): Set<String> =
+        words(normalize(title).split(" feat ", " ft ", limit = 2).first()).ifEmpty { words(title) }
 
     private fun words(s: String): Set<String> =
         normalize(s).split(' ').filter { it.isNotBlank() }.toSet()

--- a/src/app/src/test/java/ch/snepilatch/app/playback/YouTubeMusicSourceTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/playback/YouTubeMusicSourceTest.kt
@@ -145,4 +145,56 @@ class YouTubeMusicSourceTest {
         val denied = """{"playabilityStatus":{"status":"LOGIN_REQUIRED","reason":"Sign in"}}"""
         assertNull(YouTubeMusicSource.pickAudio(denied))
     }
+
+    /**
+     * The rows below are live captures for the KAIHEN -tsumi- release, taken after every track of
+     * it failed to resolve on a device.
+     */
+    @Test
+    fun matchesWhenSpotifyPutsTheGuestInTheTitleAndYouTubeMusicDoesNot() {
+        // Spotify: "弔花 feat. 他人事". YouTube Music: "弔花 - funeral flower". Scoring the credit as
+        // required words gave one match of three, so the track could not be resolved at all.
+        val yt = listOf(
+            YouTubeMusicSource.Candidate("Lxy94QBt1uY", "synchronicity", "Yui Makino", 323),
+            YouTubeMusicSource.Candidate("HIciS5SevlU", "弔花 - funeral flower", "TSUMITOBATSU", 195),
+        )
+        val match = YouTubeMusicSource.bestMatch(yt, "弔花 feat. 他人事", durationMs = 194_000)
+        assertEquals("HIciS5SevlU", match?.videoId)
+    }
+
+    /** The same shape in Latin script, with the guest in the brackets normalize() strips. */
+    @Test
+    fun matchesWhenTheGuestIsBracketedOnTheCandidate() {
+        val yt = listOf(YouTubeMusicSource.Candidate("Fb-UkMZzjj8", "Brrrrrreak It (feat. 平田義久)", "罪十罰", 225))
+        val match = YouTubeMusicSource.bestMatch(yt, "Brrrrrreak It feat. 平田義久", durationMs = 224_000)
+        assertEquals("Fb-UkMZzjj8", match?.videoId)
+    }
+
+    /** Dropping the credit must not empty the requirement and let anything through. */
+    @Test
+    fun aTitleThatIsOnlyACreditKeepsItsWords() {
+        val yt = listOf(YouTubeMusicSource.Candidate("any", "Something Else Entirely", "Daft Punk", 369))
+        assertNull(YouTubeMusicSource.bestMatch(yt, "feat", durationMs = 369_000))
+    }
+
+    @Test
+    fun aLeadingHyphenIsNotSentToSearchAsAnExclusion() {
+        // "改変 -罪-" asked YouTube to exclude every result containing 罪, which is the artist and
+        // the whole release, so the shelf came back empty. A hyphen inside a name has to survive.
+        assertEquals(
+            "TSUMITOBATSU 改変 罪- feat. たなか,LLLL",
+            YouTubeMusicSource.searchQuery("TSUMITOBATSU", "改変 -罪- feat. たなか,LLLL"),
+        )
+        assertEquals("AJR Spider-Man", YouTubeMusicSource.searchQuery("AJR", "Spider-Man"))
+    }
+
+    @Test
+    fun matchesTheRowTheDehyphenatedQueryBringsBack() {
+        // The real top row once the query keeps its results, and the last of the eleven tracks.
+        val yt = listOf(
+            YouTubeMusicSource.Candidate("cm-jH642_-U", "改変 -罪- - KAIHEN -tsumi- (feat. たなか & LLLL)", "罪十罰", 228),
+        )
+        val match = YouTubeMusicSource.bestMatch(yt, "改変 -罪- feat. たなか,LLLL", durationMs = 227_000)
+        assertEquals("cm-jH642_-U", match?.videoId)
+    }
 }


### PR DESCRIPTION
Closes #502

An album download failed on all eleven tracks. Neither cause is in the download path: `resolve` returns nothing, so nothing is ever fetched.

**Feature credits.** Spfy writes the guest into the track name, YouTube Music puts it in brackets, and `normalize()` strips brackets off the candidate:

| | words |
|---|---|
| wanted `弔花 feat. 他人事` | `{弔花, feat, 他人事}` |
| candidate `弔花 - funeral flower` | `{弔花, funeral, flower}` |

1/3 against `MIN_TITLE_SCORE = 0.8`. Ten of the eleven have a credit. `titleWords()` stops the requirement at the credit, which only loosens it, so a candidate that does spell the guest out still matches.

**Hyphens.** The eleventh is `改変 -罪-`, and YouTube reads `-word` as "exclude everything containing word". The query asked search to drop every result carrying 罪, which is the artist 罪十罰 and the release itself:

```
YtmSource: no match for 'TSUMITOBATSU, Tanaka, LLLL 改変 -罪- feat. たなか,LLLL' (0 candidates, 227s)
```

`searchQuery()` removes the operator meaning from a hyphen that opens a word, and leaves `Spider-Man` alone. With it, the track comes back as the **first** row at 3:48 against a wanted 3:47.

**How this was found.** I replayed the app's own InnerTube search from a desktop and diffed the returned rows against the matcher, so the five new tests use the real captured titles, artists and durations rather than invented ones.

`assembleProdDebug`, `testProdDebugUnitTest` (18 in this class, 0 failures) and `detekt` are green. Verified on a device: the same album resolves.