### PR TITLE
feat: derive app version from the release tag and add a Stable/Nightly update channel

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -18,6 +18,36 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
+      - name: Determine app version from the release tag
+        id: app_version
+        run: |
+          # Release builds (triggered by `release: published`) run on a tag ref, e.g.
+          # refs/tags/v2.9.80 -> versionName "2.9.80", or refs/tags/v2.9.80-nightly.3 for a
+          # nightly (see nightly.yml). versionCode must be a strictly increasing integer, so
+          # derive it from the semver core (major*1e8 + minor*1e5 + patch*100) plus a 2-digit
+          # ordinal: 99 for a full release, or the nightly number (capped at 98) for a nightly
+          # — so a full release always outranks every nightly of the same core version, and
+          # later nightlies of the same core version outrank earlier ones.
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/v}"
+            CORE="${TAG%%-*}"
+            IFS='.' read -r MAJOR MINOR PATCH _ <<< "$CORE"
+            if [[ "$TAG" == *-nightly.* ]]; then
+              NIGHTLY_N="${TAG##*-nightly.}"
+              ORDINAL=$(( 10#$NIGHTLY_N > 98 ? 98 : 10#$NIGHTLY_N ))
+            else
+              ORDINAL=99
+            fi
+            VERSION_CODE=$(( (10#${MAJOR:-0}) * 100000000 + (10#${MINOR:-0}) * 100000 + (10#${PATCH:-0}) * 100 + ORDINAL ))
+            echo "name=$TAG" >> "$GITHUB_OUTPUT"
+            echo "code=$VERSION_CODE" >> "$GITHUB_OUTPUT"
+            echo "Building version $TAG (versionCode $VERSION_CODE) from tag $GITHUB_REF"
+          else
+            echo "name=" >> "$GITHUB_OUTPUT"
+            echo "code=" >> "$GITHUB_OUTPUT"
+            echo "Not building from a tag ($GITHUB_REF) — keeping the versionCode/versionName checked into build.gradle.kts"
+          fi
+
       - name: Download KotifyClient JAR
         env:
           GH_TOKEN: ${{ secrets.KOTIFY_PAT }}
@@ -100,7 +130,11 @@ jobs:
         working-directory: ./src
         run: |
           chmod +x ./gradlew
-          ./gradlew assembleProdRelease
+          VERSION_ARGS=""
+          if [ -n "${{ steps.app_version.outputs.name }}" ]; then
+            VERSION_ARGS="-PappVersionName=${{ steps.app_version.outputs.name }} -PappVersionCode=${{ steps.app_version.outputs.code }}"
+          fi
+          ./gradlew assembleProdRelease $VERSION_ARGS
 
       - name: Prepare artifacts
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,48 @@
+name: Cut a Nightly Build
+
+# Manual only — see CLAUDE.md "Versioning" for when to use this vs. a stable release.
+# Tags and publishes a prerelease (vX.Y.Z-nightly.N, N scoped to the current base version);
+# publishing triggers build-and-release.yml via `release: published`, same as a stable tag.
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  cut-nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine the next nightly tag
+        id: tag
+        run: |
+          set -e
+          BASE=$(grep -m1 'versionName = ' src/app/build.gradle.kts | sed -E 's/.*"([^"]+)".*/\1/')
+          LAST_N=$(git tag -l "v${BASE}-nightly.*" | sed -E "s/.*-nightly\.([0-9]+)\$/\1/" | sort -n | tail -1)
+          NEXT_N=$(( ${LAST_N:-0} + 1 ))
+          TAG="v${BASE}-nightly.${NEXT_N}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Cutting $TAG (base version $BASE, from build.gradle.kts)"
+
+      - name: Create and push the tag
+        run: |
+          git config user.email "79938743+PianoNic@users.noreply.github.com"
+          git config user.name "PianoNic"
+          git tag -a "${{ steps.tag.outputs.tag }}" -m "Nightly build ${{ steps.tag.outputs.tag }}"
+          git push origin "${{ steps.tag.outputs.tag }}"
+
+      - name: Publish as a GitHub prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --title "Snepilatch ${{ steps.tag.outputs.tag }} (nightly)" \
+            --prerelease \
+            --generate-release-notes \
+            --notes "⚠️ **Nightly build** — unreviewed and may be unstable. Only visible to users on the Nightly update channel. Install at your own risk."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,21 @@ There are two product flavors on the `environment` dimension: **prod** (`ch.snep
 
 Variant task names are flavor-qualified: `assembleProdDebug` / `assembleDevDebug`, `testProdDebugUnitTest` / `testDevDebugUnitTest`. The umbrella `assembleDebug` still builds both; there is no `testDebugUnitTest` anymore; use `:app:testProdDebugUnitTest` or `:app:test`. The dev `app_name` override lives in `app/src/dev/res/values/strings.xml`. The release pipeline builds `assembleProdRelease`.
 
+## Versioning & releases
+
+**The git tag is the source of truth for a release's version, not `build.gradle.kts`.** `versionCode`/`versionName` in `src/app/build.gradle.kts` read from `-PappVersionCode`/`-PappVersionName` Gradle properties and fall back to the checked-in literals only when those aren't passed — that fallback is what local/dev builds get, and what `nightly.yml` reads as the current base version. `build-and-release.yml`'s "Determine app version from the release tag" step derives both from the tag whenever the workflow runs off a tag ref (i.e. a published release):
+
+- **`versionName`** = the tag with its leading `v` stripped (`v2.9.80` → `2.9.80`, `v2.9.80-nightly.3` → `2.9.80-nightly.3`).
+- **`versionCode`** = `major*1e8 + minor*1e5 + patch*100 + ordinal`, where `ordinal` is `99` for a full release or the nightly number (capped at 98) for a `-nightly.N` tag. This keeps a full release always outranking every nightly of the same core version, and later nightlies outranking earlier ones — required since Android's `versionCode` must strictly increase for an update to install over what's there.
+
+**To cut a stable release:** bump `versionName`/`versionCode` in `build.gradle.kts` as usual (a manual `"Bump version to X.Y.Z"` commit, same as always — this keeps the local/dev fallback and the nightly base current even though it's no longer what a *tagged* release actually ships with), then publish a GitHub Release tagged `vX.Y.Z`. That publish event triggers `build-and-release.yml`, which overrides the version from the tag and uploads the APK to the release.
+
+**To cut a nightly:** run the **"Cut a Nightly Build"** workflow (`nightly.yml`) via `workflow_dispatch` — manual only, no automatic trigger. It reads the current `versionName` out of `build.gradle.kts` as the base, finds the next free `-nightly.N` suffix for that base (scanning existing tags), tags and pushes it, then publishes it as a GitHub **prerelease**. That publish event triggers `build-and-release.yml` the same way a stable tag does.
+
+**In-app update channel:** `AppSettings.updateChannel` (`Account` → About) is `stable` (default, only surfaces full releases) or `nightly` (also surfaces prereleases, with an explicit "install at your own risk" warning in `UpdateDialog`). `UpdateService` queries the `/releases` list endpoint (not `/releases/latest`, which never returns a prerelease) and picks the first non-draft entry matching the channel filter — GitHub returns that list newest-first. Version comparison (`UpdateService.isNewerVersion`) is semver-prerelease-aware: `2.9.80-nightly.3` ranks *below* `2.9.80`, not above it — a naive positional dot-parts comparison would get this backwards.
+
+**Caveat:** `release-drafter.yml`/`.github/release-drafter.yml` maintain their own draft-release version lineage (`vX.Y.Z` starting from old `v0.x` tags) that has drifted completely out of sync with the real `versionName` line (currently sitting on a stale, long-unpublished `v0.7.0` draft) — it predates this tag-driven scheme and isn't wired to it. Don't trust its suggested version number when cutting a release; pick the tag by hand.
+
 ## Test rig
 
 `PlaybackTestRig` (`app/src/test/.../viewmodel/PlaybackTestRig.kt`) lets you exercise extracted handler methods without a real `PlayerConnect`. It mocks `MusicPlaybackService.instance` via mockk and swaps `Dispatchers.Main` for an unconfined test dispatcher.

--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -27,13 +27,6 @@ android {
         keystoreProperties.load(FileInputStream(keystorePropertiesFile))
     }
 
-    // Load local properties (gitignored) for dev-only config like Loki endpoint
-    val localPropertiesFile = rootProject.file("local.properties")
-    val localProperties = Properties()
-    if (localPropertiesFile.exists()) {
-        localProperties.load(FileInputStream(localPropertiesFile))
-    }
-
     defaultConfig {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
@@ -46,9 +39,6 @@ android {
         versionName = project.findProperty("appVersionName") as String? ?: "3.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-
-        // Loki endpoint: set in local.properties (gitignored), empty in production
-        buildConfigField("String", "LOKI_ENDPOINT", "\"${localProperties.getProperty("loki.endpoint", "")}\"")
     }
 
     signingConfigs {

--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -42,8 +42,8 @@ android {
         // derived from the release tag, so a release build's version always matches
         // the tag it was built from. These checked-in values are only what local/dev
         // builds (and workflow_dispatch dry runs) get, since there's no tag for those.
-        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 115
-        versionName = project.findProperty("appVersionName") as String? ?: "2.9.79"
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 116
+        versionName = project.findProperty("appVersionName") as String? ?: "3.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/src/app/build.gradle.kts
+++ b/src/app/build.gradle.kts
@@ -38,8 +38,12 @@ android {
         applicationId = "ch.snepilatch.app"
         minSdk = 26
         targetSdk = 37
-        versionCode = 115
-        versionName = "2.9.79"
+        // The release pipeline overrides these with -PappVersionCode/-PappVersionName
+        // derived from the release tag, so a release build's version always matches
+        // the tag it was built from. These checked-in values are only what local/dev
+        // builds (and workflow_dispatch dry runs) get, since there's no tag for those.
+        versionCode = (project.findProperty("appVersionCode") as String?)?.toIntOrNull() ?: 115
+        versionName = project.findProperty("appVersionName") as String? ?: "2.9.79"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/src/app/src/main/java/ch/snepilatch/app/KotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/KotifyApp.kt
@@ -3,6 +3,7 @@ package ch.snepilatch.app
 import android.app.Application
 import android.provider.Settings
 import ch.snepilatch.app.util.LokiLogger
+import ch.snepilatch.app.viewmodel.AppSettings
 import kotify.utils.LogBackend
 import kotify.utils.Logger
 
@@ -10,8 +11,9 @@ class KotifyApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        // Loki logging: only enabled when loki.endpoint is set in local.properties
-        val lokiEndpoint = BuildConfig.LOKI_ENDPOINT
+        // Direct-from-prefs read: AppSettings.load() hasn't run yet at this point (it runs from
+        // MainActivity), and the user may have set this in Account > About > Debug Logging.
+        val lokiEndpoint = AppSettings.savedLokiEndpoint(this)
         if (lokiEndpoint.isNotBlank()) {
             LokiLogger.init(
                 endpoint = lokiEndpoint,
@@ -19,14 +21,15 @@ class KotifyApp : Application() {
                 deviceId = Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID),
                 appVersion = BuildConfig.VERSION_NAME
             )
-
-            // Forward KotifyClient logs to LokiLogger
-            Logger.setLogBackend(object : LogBackend {
-                override var isDebugEnabled: Boolean = false
-                override fun info(msg: String) { LokiLogger.i("Kotify", msg) }
-                override fun error(msg: String) { LokiLogger.e("Kotify", msg) }
-                override fun debug(msg: String) { if (isDebugEnabled) LokiLogger.d("Kotify", msg) }
-            })
         }
+
+        // Always wired, even before logging is enabled: LokiLogger no-ops until init() has run,
+        // so this picks up KotifyClient logs immediately if the user turns logging on later.
+        Logger.setLogBackend(object : LogBackend {
+            override var isDebugEnabled: Boolean = false
+            override fun info(msg: String) { LokiLogger.i("Kotify", msg) }
+            override fun error(msg: String) { LokiLogger.e("Kotify", msg) }
+            override fun debug(msg: String) { if (isDebugEnabled) LokiLogger.d("Kotify", msg) }
+        })
     }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
@@ -25,7 +25,6 @@ import ch.snepilatch.app.ui.screens.LoadingScreen
 import ch.snepilatch.app.ui.screens.SpfyApp
 import ch.snepilatch.app.ui.screens.SpfyLoginScreen
 import ch.snepilatch.app.ui.theme.SpfyBlack
-import ch.snepilatch.app.util.UpdateChannel
 import ch.snepilatch.app.util.UpdateInfo
 import ch.snepilatch.app.util.UpdateService
 import ch.snepilatch.app.util.loadCookies
@@ -140,12 +139,7 @@ class MainActivity : ComponentActivity() {
                 // network + TLS update check each time.
                 if (updateChecked.compareAndSet(false, true)) {
                     withContext(Dispatchers.IO) {
-                        val channel = if (AppSettings.updateChannel.value == AppSettings.CHANNEL_NIGHTLY) {
-                            UpdateChannel.NIGHTLY
-                        } else {
-                            UpdateChannel.STABLE
-                        }
-                        val info = UpdateService.checkForUpdates(context, channel)
+                        val info = UpdateService.checkForUpdates(context, AppSettings.updateChannelEnum())
                         if (info != null) {
                             val dismissed = UpdateService.getDismissedVersion(context)
                             if (dismissed != info.latestVersion) {

--- a/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/MainActivity.kt
@@ -25,6 +25,7 @@ import ch.snepilatch.app.ui.screens.LoadingScreen
 import ch.snepilatch.app.ui.screens.SpfyApp
 import ch.snepilatch.app.ui.screens.SpfyLoginScreen
 import ch.snepilatch.app.ui.theme.SpfyBlack
+import ch.snepilatch.app.util.UpdateChannel
 import ch.snepilatch.app.util.UpdateInfo
 import ch.snepilatch.app.util.UpdateService
 import ch.snepilatch.app.util.loadCookies
@@ -139,7 +140,12 @@ class MainActivity : ComponentActivity() {
                 // network + TLS update check each time.
                 if (updateChecked.compareAndSet(false, true)) {
                     withContext(Dispatchers.IO) {
-                        val info = UpdateService.checkForUpdates(context)
+                        val channel = if (AppSettings.updateChannel.value == AppSettings.CHANNEL_NIGHTLY) {
+                            UpdateChannel.NIGHTLY
+                        } else {
+                            UpdateChannel.STABLE
+                        }
+                        val info = UpdateService.checkForUpdates(context, channel)
                         if (info != null) {
                             val dismissed = UpdateService.getDismissedVersion(context)
                             if (dismissed != info.latestVersion) {

--- a/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
@@ -268,6 +268,9 @@ object Downloads {
 
     fun groups(): List<Group> = groupsOf(_rows.value)
 
+    /** Bytes on disk across every downloaded track, for enforcing AppSettings.downloadCapGb. */
+    fun totalSizeBytes(): Long = _rows.value.sumOf { it.sizeBytes }
+
     /** The grouping itself, separated from the store so it can be tested directly. */
     internal fun groupsOf(rows: List<DownloadedTrack>): List<Group> = rows
         .groupBy(::groupUriOf)

--- a/src/app/src/main/java/ch/snepilatch/app/download/TrackDownloader.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/download/TrackDownloader.kt
@@ -133,6 +133,17 @@ object TrackDownloader {
                 Downloads.remove(existing.trackUri)
             }
 
+            val capBytes = AppSettings.downloadCapBytes()
+            if (capBytes != null) {
+                if (AppSettings.downloadCapPolicy.value == AppSettings.CAP_POLICY_EVICT_OLDEST) {
+                    evictToFit(capBytes)
+                } else if (Downloads.totalSizeBytes() >= capBytes) {
+                    LokiLogger.i(TAG, "storage cap reached, refusing '${request.title}'")
+                    DownloadNotifier.failed(context, request.title, "storage cap reached")
+                    return@withContext DownloadOutcome.Failed("storage cap reached")
+                }
+            }
+
             val report: (Int) -> Unit = { percent ->
                 onProgress?.invoke(percent)
                 if (notify) DownloadNotifier.progress(context, request.title, percent)
@@ -528,6 +539,23 @@ object TrackDownloader {
     fun delete(trackUri: String) {
         Downloads.find(trackUri)?.let { DownloadFolder.delete(it.documentUri) }
         Downloads.remove(trackUri)
+    }
+
+    /**
+     * Deletes oldest-added downloads until the total is back under [capBytes]. Run before a new
+     * download starts, not after: the new file's own size isn't known until it's fetched, so this
+     * only guarantees room for what's already there — a download that itself exceeds the cap pushes
+     * back over it, which the next call corrects.
+     */
+    private fun evictToFit(capBytes: Long) {
+        var total = Downloads.totalSizeBytes()
+        if (total <= capBytes) return
+        for (track in Downloads.rows.value.sortedBy { it.downloadedAt }) {
+            if (total <= capBytes) break
+            delete(track.trackUri)
+            total -= track.sizeBytes
+            LokiLogger.i(TAG, "evicted '${track.title}' to stay under the storage cap")
+        }
     }
 
     private fun extensionFor(mimeType: String?): String = when {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
@@ -80,7 +80,6 @@ fun UpdateDialog(
                     }
                 }
 
-                // Nightly builds are unreviewed and opted into at the user's own risk.
                 if (updateInfo.isPrerelease) {
                     Card(
                         colors = CardDefaults.cardColors(
@@ -169,7 +168,10 @@ fun UpdateDialog(
                             progress = p
                         }
                         if (file != null) {
-                            UpdateService.installApk(context, file)
+                            isDownloading = false
+                            if (!UpdateService.installApk(context, file)) {
+                                error = context.getString(R.string.enable_unknown_apps)
+                            }
                         } else {
                             isDownloading = false
                             error = context.getString(R.string.update_download_failed)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
@@ -80,6 +80,31 @@ fun UpdateDialog(
                     }
                 }
 
+                // Nightly builds are unreviewed and opted into at the user's own risk.
+                if (updateInfo.isPrerelease) {
+                    Card(
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(12.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Icon(
+                                Icons.Rounded.ErrorOutline,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                            Text(
+                                stringResource(R.string.nightly_build_warning),
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                }
+
                 // Download progress
                 if (isDownloading) {
                     LinearProgressIndicator(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -611,6 +611,47 @@ fun AccountScreen(vm: PlaybackViewModel) {
             colors = ListItemDefaults.colors(containerColor = Color.Transparent)
         )
 
+        // Update channel
+        val updateChannelPref by AppSettings.updateChannel.collectAsState()
+        var showUpdateChannelPicker by remember { mutableStateOf(false) }
+        val updateChannelLabel = if (updateChannelPref == AppSettings.CHANNEL_NIGHTLY) {
+            stringResource(R.string.update_channel_nightly)
+        } else {
+            stringResource(R.string.update_channel_stable)
+        }
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.update_channel), color = SpfyWhite) },
+            supportingContent = { Text(updateChannelLabel, color = SpfyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.SystemUpdate, null, tint = SpfyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showUpdateChannelPicker = true }
+        )
+        if (showUpdateChannelPicker) {
+            RadioPickerDialog(
+                title = stringResource(R.string.update_channel),
+                options = listOf(
+                    RadioOption(
+                        AppSettings.CHANNEL_STABLE,
+                        stringResource(R.string.update_channel_stable),
+                        stringResource(R.string.update_channel_stable_desc)
+                    ),
+                    RadioOption(
+                        AppSettings.CHANNEL_NIGHTLY,
+                        stringResource(R.string.update_channel_nightly),
+                        stringResource(R.string.update_channel_nightly_desc)
+                    )
+                ),
+                selected = updateChannelPref,
+                selectedColor = animatedPrimary,
+                onSelect = {
+                    AppSettings.setUpdateChannel(it, audioContext)
+                    showUpdateChannelPicker = false
+                },
+                onDismiss = { showUpdateChannelPicker = false }
+            )
+        }
+
         // Check for Updates
         val scope = rememberCoroutineScope()
         val updateContext = androidx.compose.ui.platform.LocalContext.current
@@ -645,7 +686,12 @@ fun AccountScreen(vm: PlaybackViewModel) {
                 upToDate = false
                 scope.launch {
                     val info = withContext(Dispatchers.IO) {
-                        UpdateService.checkForUpdates(updateContext)
+                        val channel = if (updateChannelPref == AppSettings.CHANNEL_NIGHTLY) {
+                            ch.snepilatch.app.util.UpdateChannel.NIGHTLY
+                        } else {
+                            ch.snepilatch.app.util.UpdateChannel.STABLE
+                        }
+                        UpdateService.checkForUpdates(updateContext, channel)
                     }
                     isChecking = false
                     if (info != null) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/AccountScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
@@ -348,6 +349,82 @@ fun AccountScreen(vm: PlaybackViewModel) {
             colors = ListItemDefaults.colors(containerColor = Color.Transparent),
             modifier = Modifier.clickable { folderPicker.launch(null) }
         )
+
+        // Storage limit: 0 = unlimited.
+        val downloadCapGb by AppSettings.downloadCapGb.collectAsState()
+        var showCapDialog by remember { mutableStateOf(false) }
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.storage_limit), color = SpfyWhite) },
+            supportingContent = {
+                Text(
+                    if (downloadCapGb > 0f) {
+                        stringResource(R.string.storage_limit_value, downloadCapGb)
+                    } else {
+                        stringResource(R.string.storage_limit_unlimited)
+                    },
+                    color = SpfyLightGray
+                )
+            },
+            leadingContent = { Icon(Icons.Rounded.Storage, null, tint = SpfyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showCapDialog = true }
+        )
+        if (showCapDialog) {
+            TextInputDialog(
+                title = stringResource(R.string.storage_limit),
+                description = stringResource(R.string.storage_limit_desc),
+                initialValue = if (downloadCapGb > 0f) downloadCapGb.toString() else "",
+                placeholder = stringResource(R.string.storage_limit_placeholder),
+                keyboardType = KeyboardType.Decimal,
+                onConfirm = {
+                    AppSettings.setDownloadCapGb(it.toFloatOrNull()?.coerceAtLeast(0f) ?: 0f, audioContext)
+                    showCapDialog = false
+                },
+                onDismiss = { showCapDialog = false }
+            )
+        }
+
+        // What to do once the storage limit is hit — only takes effect while a limit is set above.
+        val capPolicy by AppSettings.downloadCapPolicy.collectAsState()
+        var showCapPolicyPicker by remember { mutableStateOf(false) }
+        val capPolicyLabel = if (capPolicy == AppSettings.CAP_POLICY_EVICT_OLDEST) {
+            stringResource(R.string.storage_policy_evict)
+        } else {
+            stringResource(R.string.storage_policy_stop)
+        }
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.storage_policy), color = SpfyWhite) },
+            supportingContent = { Text(capPolicyLabel, color = SpfyLightGray) },
+            leadingContent = { Icon(Icons.Rounded.DeleteSweep, null, tint = SpfyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showCapPolicyPicker = true }
+        )
+        if (showCapPolicyPicker) {
+            RadioPickerDialog(
+                title = stringResource(R.string.storage_policy),
+                options = listOf(
+                    RadioOption(
+                        AppSettings.CAP_POLICY_STOP,
+                        stringResource(R.string.storage_policy_stop),
+                        stringResource(R.string.storage_policy_stop_desc)
+                    ),
+                    RadioOption(
+                        AppSettings.CAP_POLICY_EVICT_OLDEST,
+                        stringResource(R.string.storage_policy_evict),
+                        stringResource(R.string.storage_policy_evict_desc)
+                    )
+                ),
+                selected = capPolicy,
+                selectedColor = animatedPrimary,
+                onSelect = {
+                    AppSettings.setDownloadCapPolicy(it, audioContext)
+                    showCapPolicyPicker = false
+                },
+                onDismiss = { showCapPolicyPicker = false }
+            )
+        }
 
         Spacer(Modifier.height(24.dp))
         AccountSectionHeader(stringResource(R.string.account_section_sound))
@@ -686,12 +763,7 @@ fun AccountScreen(vm: PlaybackViewModel) {
                 upToDate = false
                 scope.launch {
                     val info = withContext(Dispatchers.IO) {
-                        val channel = if (updateChannelPref == AppSettings.CHANNEL_NIGHTLY) {
-                            ch.snepilatch.app.util.UpdateChannel.NIGHTLY
-                        } else {
-                            ch.snepilatch.app.util.UpdateChannel.STABLE
-                        }
-                        UpdateService.checkForUpdates(updateContext, channel)
+                        UpdateService.checkForUpdates(updateContext, AppSettings.updateChannelEnum())
                     }
                     isChecking = false
                     if (info != null) {
@@ -724,6 +796,37 @@ fun AccountScreen(vm: PlaybackViewModel) {
 
         if (showReleaseNotes) {
             ReleaseNotesDialog(onDismiss = { showReleaseNotes = false })
+        }
+
+        // Debug logging: lets the user point the app at a Loki endpoint to share logs on request,
+        // without anything baked into the build. Empty = disabled (the default).
+        val lokiEndpoint by AppSettings.lokiEndpoint.collectAsState()
+        var showLokiDialog by remember { mutableStateOf(false) }
+        ListItem(
+            headlineContent = { Text(stringResource(R.string.debug_logging), color = SpfyWhite) },
+            supportingContent = {
+                Text(
+                    lokiEndpoint.ifBlank { stringResource(R.string.debug_logging_off) },
+                    color = SpfyLightGray
+                )
+            },
+            leadingContent = { Icon(Icons.Rounded.BugReport, null, tint = SpfyLightGray) },
+            trailingContent = { Icon(Icons.Rounded.ChevronRight, null, tint = SpfyLightGray) },
+            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+            modifier = Modifier.clickable { showLokiDialog = true }
+        )
+        if (showLokiDialog) {
+            TextInputDialog(
+                title = stringResource(R.string.debug_logging),
+                description = stringResource(R.string.debug_logging_desc),
+                initialValue = lokiEndpoint,
+                placeholder = "https://loki.example.com",
+                onConfirm = {
+                    AppSettings.setLokiEndpoint(it, audioContext)
+                    showLokiDialog = false
+                },
+                onDismiss = { showLokiDialog = false }
+            )
         }
 
         Spacer(Modifier.height(24.dp))
@@ -780,6 +883,58 @@ private fun AccountSectionHeader(title: String) {
         fontSize = 16.sp,
         fontWeight = FontWeight.SemiBold,
         modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)
+    )
+}
+
+/** Free-text settings dialog, e.g. the Loki debug-logging endpoint. Empty input clears the setting. */
+@Composable
+private fun TextInputDialog(
+    title: String,
+    description: String? = null,
+    initialValue: String,
+    placeholder: String,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    onConfirm: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var value by remember { mutableStateOf(initialValue) }
+    val confirmColor = MaterialTheme.colorScheme.primary
+    TightAlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title, color = SpfyWhite) },
+        text = {
+            Column {
+                if (description != null) {
+                    Text(description, color = SpfyLightGray, fontSize = 13.sp)
+                    Spacer(Modifier.height(12.dp))
+                }
+                OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    placeholder = { Text(placeholder, color = SpfyLightGray.copy(alpha = 0.7f)) },
+                    singleLine = true,
+                    keyboardOptions = androidx.compose.foundation.text.KeyboardOptions(keyboardType = keyboardType),
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = SpfyWhite,
+                        unfocusedTextColor = SpfyWhite,
+                        cursorColor = confirmColor,
+                        focusedBorderColor = confirmColor,
+                        unfocusedBorderColor = SpfyLightGray
+                    )
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(value) }) {
+                Text(stringResource(R.string.save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.cancel))
+            }
+        }
     )
 }
 

--- a/src/app/src/main/java/ch/snepilatch/app/util/LokiLogger.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/util/LokiLogger.kt
@@ -23,11 +23,13 @@ object LokiLogger {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var flushJob: Job? = null
 
-    // Only buffer once init() has wired up the flush loop. Production ships with LOKI_ENDPOINT empty,
-    // so init() is never called, no flush job ever drains the queue — without this gate the buffer
-    // would grow unbounded for the whole app lifetime.
+    // Only buffer once init() has wired up the flush loop — without this gate, logging before the
+    // user sets an endpoint (or after they clear it) would grow the buffer unbounded.
     @Volatile
     private var started = false
+
+    @Volatile
+    private var handlerInstalled = false
 
     private const val FLUSH_INTERVAL_MS = 10_000L
     private const val MAX_BATCH_SIZE = 100
@@ -40,18 +42,26 @@ object LokiLogger {
         val message: String
     )
 
+    /** Safe to call again with a new endpoint — e.g. the user changes it in Settings mid-session. */
     fun init(endpoint: String, appName: String, deviceId: String, appVersion: String = "unknown") {
+        flushJob?.cancel()
+
         this.endpoint = endpoint.trimEnd('/')
         this.appName = appName
         this.deviceId = deviceId
         this.appVersion = appVersion
         this.sessionId = UUID.randomUUID().toString().take(8)
 
-        val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
-        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            e("CRASH", "Uncaught exception in ${thread.name}", throwable)
-            flushSync()
-            defaultHandler?.uncaughtException(thread, throwable)
+        // Only wrap once — re-wrapping on every init() (the endpoint can change at runtime via
+        // Settings) would nest another handler around the previous one instead of replacing it.
+        if (!handlerInstalled) {
+            handlerInstalled = true
+            val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+            Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+                e("CRASH", "Uncaught exception in ${thread.name}", throwable)
+                flushSync()
+                defaultHandler?.uncaughtException(thread, throwable)
+            }
         }
 
         flushJob = scope.launch {
@@ -63,6 +73,14 @@ object LokiLogger {
         started = true
 
         i("LokiLogger", "Session started | version=$appVersion | device=${Build.MODEL} | Android ${Build.VERSION.RELEASE}")
+    }
+
+    /** Stops pushing to Loki (the user cleared the endpoint) without losing console logging. */
+    fun stop() {
+        flushJob?.cancel()
+        flushJob = null
+        started = false
+        buffer.clear()
     }
 
     fun d(tag: String, message: String) = log("DEBUG", tag, message)
@@ -84,7 +102,7 @@ object LokiLogger {
         }
 
         // Console logging above always runs; only queue for the Loki push when a flush loop exists
-        // to drain it (dev builds with loki.endpoint set). Otherwise the queue would never empty.
+        // to drain it (the user has set an endpoint). Otherwise the queue would never empty.
         if (!started) return
 
         buffer.add(

--- a/src/app/src/main/java/ch/snepilatch/app/util/UpdateService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/util/UpdateService.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
-import org.json.JSONObject
 import java.io.File
 
 data class UpdateInfo(
@@ -33,6 +32,7 @@ enum class UpdateChannel { STABLE, NIGHTLY }
 object UpdateService {
 
     private const val TAG = "UpdateService"
+
     // The list endpoint (not /releases/latest, which never returns a prerelease) so the
     // nightly channel can see prereleases too. GitHub returns it newest-first.
     private const val GITHUB_API_URL =
@@ -58,15 +58,12 @@ object UpdateService {
             if (!response.isSuccessful) return@withContext null
 
             val releases = JSONArray(response.body?.string() ?: return@withContext null)
-            var json: JSONObject? = null
-            for (i in 0 until releases.length()) {
-                val release = releases.getJSONObject(i)
-                if (release.optBoolean("draft", false)) continue
-                if (channel == UpdateChannel.STABLE && release.optBoolean("prerelease", false)) continue
-                json = release
-                break
-            }
-            if (json == null) return@withContext null
+            val json = (0 until releases.length())
+                .map { releases.getJSONObject(it) }
+                .firstOrNull { release ->
+                    !release.optBoolean("draft", false) &&
+                        (channel == UpdateChannel.NIGHTLY || !release.optBoolean("prerelease", false))
+                } ?: return@withContext null
 
             val latestVersion = json.optString("tag_name", "").removePrefix("v")
 

--- a/src/app/src/main/java/ch/snepilatch/app/util/UpdateService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/util/UpdateService.kt
@@ -2,6 +2,8 @@ package ch.snepilatch.app.util
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
 import android.util.Log
 import androidx.core.content.FileProvider
 import kotlinx.coroutines.Dispatchers
@@ -188,7 +190,21 @@ object UpdateService {
         }
     }
 
-    fun installApk(context: Context, file: File) {
+    /**
+     * Returns false (and sends the user to the "install unknown apps" setting instead of
+     * installing) when the permission isn't granted yet — without this check the install
+     * intent still opens, but the system installer silently blocks it instead.
+     */
+    fun installApk(context: Context, file: File): Boolean {
+        if (!context.packageManager.canRequestPackageInstalls()) {
+            context.startActivity(
+                Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                    data = Uri.parse("package:${context.packageName}")
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            )
+            return false
+        }
         val uri = FileProvider.getUriForFile(
             context,
             "${context.packageName}.fileprovider",
@@ -199,6 +215,7 @@ object UpdateService {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION
         }
         context.startActivity(intent)
+        return true
     }
 
     fun getDismissedVersion(context: Context): String? {

--- a/src/app/src/main/java/ch/snepilatch/app/util/UpdateService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/util/UpdateService.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 
@@ -16,19 +17,32 @@ data class UpdateInfo(
     val latestVersion: String,
     val downloadUrl: String,
     val releaseNotes: String,
-    val htmlUrl: String
+    val htmlUrl: String,
+    val isPrerelease: Boolean
 )
+
+/**
+ * [STABLE] only surfaces full GitHub releases. [NIGHTLY] also surfaces prereleases (nightly
+ * builds tagged `vX.Y.Z-nightly.N`), which are unreviewed and opt-in at the user's own risk —
+ * see [ch.snepilatch.app.viewmodel.AppSettings.updateChannel].
+ */
+enum class UpdateChannel { STABLE, NIGHTLY }
 
 object UpdateService {
 
     private const val TAG = "UpdateService"
+    // The list endpoint (not /releases/latest, which never returns a prerelease) so the
+    // nightly channel can see prereleases too. GitHub returns it newest-first.
     private const val GITHUB_API_URL =
-        "https://api.github.com/repos/PianoNic/snepilatch/releases/latest"
+        "https://api.github.com/repos/PianoNic/Snepilatch/releases"
     private const val DISMISSED_KEY = "dismissed_update_version"
 
     internal val client = OkHttpClient()
 
-    suspend fun checkForUpdates(context: Context): UpdateInfo? = withContext(Dispatchers.IO) {
+    suspend fun checkForUpdates(
+        context: Context,
+        channel: UpdateChannel = UpdateChannel.STABLE
+    ): UpdateInfo? = withContext(Dispatchers.IO) {
         try {
             val currentVersion = context.packageManager
                 .getPackageInfo(context.packageName, 0).versionName ?: return@withContext null
@@ -41,7 +55,17 @@ object UpdateService {
             val response = client.newCall(request).execute()
             if (!response.isSuccessful) return@withContext null
 
-            val json = JSONObject(response.body?.string() ?: return@withContext null)
+            val releases = JSONArray(response.body?.string() ?: return@withContext null)
+            var json: JSONObject? = null
+            for (i in 0 until releases.length()) {
+                val release = releases.getJSONObject(i)
+                if (release.optBoolean("draft", false)) continue
+                if (channel == UpdateChannel.STABLE && release.optBoolean("prerelease", false)) continue
+                json = release
+                break
+            }
+            if (json == null) return@withContext null
+
             val latestVersion = json.optString("tag_name", "").removePrefix("v")
 
             if (!isNewerVersion(currentVersion, latestVersion)) return@withContext null
@@ -64,7 +88,8 @@ object UpdateService {
                 latestVersion = latestVersion,
                 downloadUrl = downloadUrl,
                 releaseNotes = json.optString("body", ""),
-                htmlUrl = json.optString("html_url", "")
+                htmlUrl = json.optString("html_url", ""),
+                isPrerelease = json.optBoolean("prerelease", false)
             )
         } catch (e: Exception) {
             Log.w(TAG, "Update check failed: ${e.message}")
@@ -72,16 +97,43 @@ object UpdateService {
         }
     }
 
+    /** A version's dot-separated numeric core, plus its nightly ordinal if it's a `-nightly.N` build. */
+    private data class ParsedVersion(val core: List<Int>, val nightly: Int?)
+
+    private fun parseVersion(version: String): ParsedVersion {
+        val core = version.substringBefore("-")
+            .replace(Regex("[^0-9.]"), "")
+            .split(".")
+            .map { it.toIntOrNull() ?: 0 }
+        val nightly = if (version.contains("-nightly.")) {
+            version.substringAfterLast("-nightly.").toIntOrNull()
+        } else {
+            null
+        }
+        return ParsedVersion(core, nightly)
+    }
+
+    /**
+     * Semver-correct ordering: a nightly build ranks below the full release of the same core
+     * version (e.g. 2.9.80-nightly.3 < 2.9.80), and among nightlies of the same core version the
+     * higher ordinal wins. A naive positional-parts comparison would get this backwards, since a
+     * longer dot-list otherwise reads as "more precise" rather than "prerelease of".
+     */
     private fun isNewerVersion(current: String, latest: String): Boolean {
         try {
-            val currentParts = current.replace(Regex("[^0-9.]"), "").split(".").map { it.toIntOrNull() ?: 0 }
-            val latestParts = latest.replace(Regex("[^0-9.]"), "").split(".").map { it.toIntOrNull() ?: 0 }
+            val c = parseVersion(current)
+            val l = parseVersion(latest)
 
-            for (i in 0 until maxOf(currentParts.size, latestParts.size)) {
-                val c = currentParts.getOrElse(i) { 0 }
-                val l = latestParts.getOrElse(i) { 0 }
-                if (l > c) return true
-                if (l < c) return false
+            for (i in 0 until maxOf(c.core.size, l.core.size)) {
+                val cv = c.core.getOrElse(i) { 0 }
+                val lv = l.core.getOrElse(i) { 0 }
+                if (lv != cv) return lv > cv
+            }
+
+            return when {
+                c.nightly == null -> false
+                l.nightly == null -> true
+                else -> l.nightly > c.nightly
             }
         } catch (e: Exception) {
             Log.w(TAG, "Version comparison failed: $e")

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
@@ -58,6 +58,13 @@ object AppSettings {
     // Content region for CDN resolution
     val contentRegion = MutableStateFlow("nearest")
 
+    // Update channel: [CHANNEL_STABLE] (default) only surfaces full releases; [CHANNEL_NIGHTLY]
+    // also surfaces GitHub prereleases (nightly builds), which are unreviewed and opt-in at the
+    // user's own risk. See UpdateService.UpdateChannel.
+    const val CHANNEL_STABLE = "stable"
+    const val CHANNEL_NIGHTLY = "nightly"
+    val updateChannel = MutableStateFlow(CHANNEL_STABLE)
+
     // Player background style: true = album-colour gradient (Spfy/YTM style), false = blurred art.
     val playerGradientBg = MutableStateFlow(true)
 
@@ -112,6 +119,7 @@ object AppSettings {
         eqBands.value = parseBands(prefs.getString("eq_bands", null))
         playerGradientBg.value = prefs.getBoolean("player_gradient_bg", true)
         contentRegion.value = prefs.getString("content_region", "nearest") ?: "nearest"
+        updateChannel.value = prefs.getString("update_channel", CHANNEL_STABLE) ?: CHANNEL_STABLE
         notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"
         notificationRightButton.value = prefs.getString("notification_right_button", "like") ?: "like"
     }
@@ -170,6 +178,12 @@ object AppSettings {
         contentRegion.value = region
         prefs(context)
             .edit().putString("content_region", region).apply()
+    }
+
+    fun setUpdateChannel(channel: String, context: Context) {
+        updateChannel.value = channel
+        prefs(context)
+            .edit().putString("update_channel", channel).apply()
     }
 
     fun setLyricsAnimDirection(direction: String, context: Context) {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
@@ -3,6 +3,7 @@ package ch.snepilatch.app.viewmodel
 import android.content.Context
 import ch.snepilatch.app.playback.MusicPlaybackService
 import ch.snepilatch.app.util.LokiLogger
+import ch.snepilatch.app.util.UpdateChannel
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
@@ -65,6 +66,28 @@ object AppSettings {
     const val CHANNEL_NIGHTLY = "nightly"
     val updateChannel = MutableStateFlow(CHANNEL_STABLE)
 
+    fun updateChannelEnum(): UpdateChannel =
+        if (updateChannel.value == CHANNEL_NIGHTLY) UpdateChannel.NIGHTLY else UpdateChannel.STABLE
+
+    // Loki push API base URL for sharing debug logs; set by the user (Account > About > Debug
+    // Logging). Empty = disabled. See LokiLogger; KotifyApp reads this directly at boot via
+    // [savedLokiEndpoint] since it runs before [load].
+    val lokiEndpoint = MutableStateFlow("")
+
+    // Download storage cap: 0 = unlimited. What happens on a new download once the cap is hit is
+    // [downloadCapPolicy] — [CAP_POLICY_STOP] refuses it, [CAP_POLICY_EVICT_OLDEST] deletes the
+    // oldest-added downloads first to make room. See TrackDownloader.
+    const val CAP_POLICY_STOP = "stop"
+    const val CAP_POLICY_EVICT_OLDEST = "evict_oldest"
+    val downloadCapGb = MutableStateFlow(0f)
+    val downloadCapPolicy = MutableStateFlow(CAP_POLICY_STOP)
+
+    /** Null means unlimited. */
+    fun downloadCapBytes(): Long? {
+        val gb = downloadCapGb.value
+        return if (gb <= 0f) null else (gb * 1_000_000_000L).toLong()
+    }
+
     // Player background style: true = album-colour gradient (Spfy/YTM style), false = blurred art.
     val playerGradientBg = MutableStateFlow(true)
 
@@ -120,6 +143,9 @@ object AppSettings {
         playerGradientBg.value = prefs.getBoolean("player_gradient_bg", true)
         contentRegion.value = prefs.getString("content_region", "nearest") ?: "nearest"
         updateChannel.value = prefs.getString("update_channel", CHANNEL_STABLE) ?: CHANNEL_STABLE
+        lokiEndpoint.value = prefs.getString("loki_endpoint", "") ?: ""
+        downloadCapGb.value = prefs.getFloat("download_cap_gb", 0f)
+        downloadCapPolicy.value = prefs.getString("download_cap_policy", CAP_POLICY_STOP) ?: CAP_POLICY_STOP
         notificationLeftButton.value = prefs.getString("notification_left_button", "repeat") ?: "repeat"
         notificationRightButton.value = prefs.getString("notification_right_button", "like") ?: "like"
     }
@@ -156,6 +182,9 @@ object AppSettings {
             (prefs.getString("notification_right_button", "like") ?: "like")
     }
 
+    /** Direct-from-prefs read for KotifyApp.onCreate, which runs before [load]. */
+    fun savedLokiEndpoint(ctx: Context): String = prefs(ctx).getString("loki_endpoint", "") ?: ""
+
     fun setPreferredAudioSource(source: String?, context: Context) {
         preferredAudioSource.value = source
         prefs(context)
@@ -184,6 +213,36 @@ object AppSettings {
         updateChannel.value = channel
         prefs(context)
             .edit().putString("update_channel", channel).apply()
+    }
+
+    fun setDownloadCapGb(gb: Float, context: Context) {
+        downloadCapGb.value = gb
+        prefs(context).edit().putFloat("download_cap_gb", gb).apply()
+    }
+
+    fun setDownloadCapPolicy(policy: String, context: Context) {
+        downloadCapPolicy.value = policy
+        prefs(context).edit().putString("download_cap_policy", policy).apply()
+    }
+
+    /** Applies immediately: starts/restarts LokiLogger with the new endpoint, or stops it when blank. */
+    fun setLokiEndpoint(endpoint: String, context: Context) {
+        val trimmed = endpoint.trim()
+        lokiEndpoint.value = trimmed
+        prefs(context).edit().putString("loki_endpoint", trimmed).apply()
+        if (trimmed.isBlank()) {
+            LokiLogger.stop()
+        } else {
+            LokiLogger.init(
+                endpoint = trimmed,
+                appName = "snepilatch",
+                deviceId = android.provider.Settings.Secure.getString(
+                    context.contentResolver,
+                    android.provider.Settings.Secure.ANDROID_ID
+                ),
+                appVersion = ch.snepilatch.app.BuildConfig.VERSION_NAME
+            )
+        }
     }
 
     fun setLyricsAnimDirection(direction: String, context: Context) {

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -108,6 +108,9 @@
     <string name="tap_to_check">Tipp, um nach neue Versione z sueche</string>
     <string name="release_notes">Versions-Notize</string>
     <string name="view_changelog">Änderige aaluege</string>
+    <string name="debug_logging">Debug-Logging</string>
+    <string name="debug_logging_desc">Gib e Loki-Endpunkt-URL i, zum d Logs mit emene Entwickler teile. Leer laa zum deaktiviere.</string>
+    <string name="debug_logging_off">Us</string>
 
     <!-- Update Dialog -->
     <string name="update_available">Es Update isch da</string>
@@ -326,6 +329,16 @@
     <string name="download_failed">Download hät nöd funktioniert</string>
     <string name="download_folder">Download-Ordner</string>
     <string name="download_folder_none">Nöd gsetzt, tipp zum Uuswähle</string>
+    <string name="storage_limit">Speicherlimit</string>
+    <string name="storage_limit_desc">Begränzt wieviel Platz dini Downloads bruuche dörfed. Leer oder 0 für kes Limit.</string>
+    <string name="storage_limit_placeholder">z. B. 5</string>
+    <string name="storage_limit_value">%.1f GB</string>
+    <string name="storage_limit_unlimited">Kes Limit</string>
+    <string name="storage_policy">Wenn voll</string>
+    <string name="storage_policy_stop">Downloads stoppe</string>
+    <string name="storage_policy_stop_desc">Neui Downloads ablehne sobald s Limit erreicht isch</string>
+    <string name="storage_policy_evict">Ältesti lösche</string>
+    <string name="storage_policy_evict_desc">Die zersch derzuegfüegte Downloads entferne für Platz z schaffe</string>
     <string name="download_track">Abelade</string>
     <string name="remove_download">Download lösche</string>
     <string name="download_needs_folder">Wähl zerscht en Download-Ordner uus</string>

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -97,6 +97,11 @@
 
     <!-- About -->
     <string name="app_version">App-Version</string>
+    <string name="update_channel">Update-Kanal</string>
+    <string name="update_channel_stable">Stabil</string>
+    <string name="update_channel_stable_desc">Nur vollständigi, gprüefti Releases.</string>
+    <string name="update_channel_nightly">Nightly</string>
+    <string name="update_channel_nightly_desc">Ungprüefti Vorabversione. Nutzig uf eigeni Gfahr.</string>
     <string name="check_for_updates">Nach Updates sueche</string>
     <string name="checking">Am Sueche…</string>
     <string name="up_to_date">Du häsch di nöischti Version</string>
@@ -111,6 +116,7 @@
     <string name="whats_new">Was isch neu:</string>
     <string name="update_now">Jetz aktualisiere</string>
     <string name="later">Spöter</string>
+    <string name="nightly_build_warning">Das isch en Nightly-Build — ungprüeft und chönnt instabil si. Nutzig uf eigeni Gfahr.</string>
 
     <!-- Devices -->
     <string name="searching_devices">Am Gräte sueche…</string>

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -117,6 +117,7 @@
     <string name="update_now">Jetz aktualisiere</string>
     <string name="later">Spöter</string>
     <string name="nightly_build_warning">Das isch en Nightly-Build — ungprüeft und chönnt instabil si. Nutzig uf eigeni Gfahr.</string>
+    <string name="enable_unknown_apps">Erlaub Snepilatch i de aktuelle Iistellige s Installiere vo Apps und tipp de wieder uf Jetz aktualisiere.</string>
 
     <!-- Devices -->
     <string name="searching_devices">Am Gräte sueche…</string>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -84,6 +84,11 @@
 
     <!-- About -->
     <string name="app_version">App-Version</string>
+    <string name="update_channel">Update-Kanal</string>
+    <string name="update_channel_stable">Stabil</string>
+    <string name="update_channel_stable_desc">Nur vollständige, geprüfte Releases.</string>
+    <string name="update_channel_nightly">Nightly</string>
+    <string name="update_channel_nightly_desc">Ungeprüfte Vorabversionen. Nutzung auf eigenes Risiko.</string>
     <string name="check_for_updates">Nach Updates suchen</string>
     <string name="checking">Prüfe…</string>
     <string name="up_to_date">Du hast die neueste Version</string>
@@ -98,6 +103,7 @@
     <string name="whats_new">Was ist neu:</string>
     <string name="update_now">Jetzt aktualisieren</string>
     <string name="later">Später</string>
+    <string name="nightly_build_warning">Dies ist ein Nightly-Build — ungeprüft und möglicherweise instabil. Nutzung auf eigenes Risiko.</string>
 
     <!-- Devices -->
     <string name="searching_devices">Suche nach Geräten…</string>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -95,6 +95,9 @@
     <string name="tap_to_check">Tippe, um nach Updates zu suchen</string>
     <string name="release_notes">Versionshinweise</string>
     <string name="view_changelog">Änderungsprotokoll anzeigen</string>
+    <string name="debug_logging">Debug-Logging</string>
+    <string name="debug_logging_desc">Gib eine Loki-Endpunkt-URL ein, um Logs mit einem Entwickler zu teilen. Leer lassen zum Deaktivieren.</string>
+    <string name="debug_logging_off">Aus</string>
 
     <!-- Update Dialog -->
     <string name="update_available">Update verfügbar</string>
@@ -310,6 +313,16 @@
     <string name="download_failed">Download fehlgeschlagen</string>
     <string name="download_folder">Download-Ordner</string>
     <string name="download_folder_none">Nicht gesetzt, zum Wählen tippen</string>
+    <string name="storage_limit">Speicherlimit</string>
+    <string name="storage_limit_desc">Begrenzt, wie viel Speicherplatz deine Downloads nutzen dürfen. Leer oder 0 für kein Limit.</string>
+    <string name="storage_limit_placeholder">z. B. 5</string>
+    <string name="storage_limit_value">%.1f GB</string>
+    <string name="storage_limit_unlimited">Kein Limit</string>
+    <string name="storage_policy">Wenn voll</string>
+    <string name="storage_policy_stop">Downloads stoppen</string>
+    <string name="storage_policy_stop_desc">Neue Downloads ablehnen, sobald das Limit erreicht ist</string>
+    <string name="storage_policy_evict">Älteste löschen</string>
+    <string name="storage_policy_evict_desc">Die zuerst hinzugefügten Downloads entfernen, um Platz zu schaffen</string>
     <string name="download_track">Herunterladen</string>
     <string name="remove_download">Download entfernen</string>
     <string name="download_needs_folder">Wähle zuerst einen Download-Ordner</string>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -104,6 +104,7 @@
     <string name="update_now">Jetzt aktualisieren</string>
     <string name="later">Später</string>
     <string name="nightly_build_warning">Dies ist ein Nightly-Build — ungeprüft und möglicherweise instabil. Nutzung auf eigenes Risiko.</string>
+    <string name="enable_unknown_apps">Erlaube Snepilatch in den geöffneten Einstellungen das Installieren von Apps und tippe dann erneut auf Jetzt aktualisieren.</string>
 
     <!-- Devices -->
     <string name="searching_devices">Suche nach Geräten…</string>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -95,6 +95,9 @@
     <string name="tap_to_check">Нажмите для проверки обновлений</string>
     <string name="release_notes">Примечания к выпуску</string>
     <string name="view_changelog">Просмотр изменений</string>
+    <string name="debug_logging">Отладочное логирование</string>
+    <string name="debug_logging_desc">Введите URL конечной точки Loki, чтобы поделиться логами с разработчиком. Оставьте пустым, чтобы отключить.</string>
+    <string name="debug_logging_off">Выкл</string>
 
     <!-- Update Dialog -->
     <string name="update_available">Доступно обновление</string>
@@ -310,6 +313,16 @@
     <string name="download_failed">Ошибка загрузки</string>
     <string name="download_folder">Папка загрузок</string>
     <string name="download_folder_none">Не задана, нажмите чтобы выбрать</string>
+    <string name="storage_limit">Лимит хранилища</string>
+    <string name="storage_limit_desc">Ограничьте объём места для загрузок. Оставьте пустым или 0 без ограничения.</string>
+    <string name="storage_limit_placeholder">напр. 5</string>
+    <string name="storage_limit_value">%.1f ГБ</string>
+    <string name="storage_limit_unlimited">Без ограничения</string>
+    <string name="storage_policy">При заполнении</string>
+    <string name="storage_policy_stop">Остановить загрузки</string>
+    <string name="storage_policy_stop_desc">Отклонять новые загрузки по достижении лимита</string>
+    <string name="storage_policy_evict">Удалить старые</string>
+    <string name="storage_policy_evict_desc">Удалять самые старые загрузки, чтобы освободить место</string>
     <string name="download_track">Скачать</string>
     <string name="remove_download">Удалить загрузку</string>
     <string name="download_needs_folder">Сначала выберите папку загрузок</string>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -84,6 +84,11 @@
 
     <!-- About -->
     <string name="app_version">Версия приложения</string>
+    <string name="update_channel">Канал обновлений</string>
+    <string name="update_channel_stable">Стабильный</string>
+    <string name="update_channel_stable_desc">Только полные, проверенные релизы.</string>
+    <string name="update_channel_nightly">Ночной</string>
+    <string name="update_channel_nightly_desc">Непроверенные предварительные сборки. Используйте на свой риск.</string>
     <string name="check_for_updates">Проверить обновления</string>
     <string name="checking">Проверка…</string>
     <string name="up_to_date">У вас последняя версия</string>
@@ -98,6 +103,7 @@
     <string name="whats_new">Что нового:</string>
     <string name="update_now">Обновить</string>
     <string name="later">Позже</string>
+    <string name="nightly_build_warning">Это ночная сборка — непроверенная и может быть нестабильной. Используйте на свой риск.</string>
 
     <!-- Devices -->
     <string name="searching_devices">Поиск устройств…</string>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -104,6 +104,7 @@
     <string name="update_now">Обновить</string>
     <string name="later">Позже</string>
     <string name="nightly_build_warning">Это ночная сборка — непроверенная и может быть нестабильной. Используйте на свой риск.</string>
+    <string name="enable_unknown_apps">Разрешите Snepilatch устанавливать приложения в открывшихся настройках, затем снова нажмите «Обновить».</string>
 
     <!-- Devices -->
     <string name="searching_devices">Поиск устройств…</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="update_now">Update Now</string>
     <string name="later">Later</string>
     <string name="nightly_build_warning">This is a nightly build — unreviewed and may be unstable. Install at your own risk.</string>
+    <string name="enable_unknown_apps">Allow Snepilatch to install apps in the settings that just opened, then tap Update Now again.</string>
 
     <!-- Devices -->
     <string name="searching_devices">Searching for devices…</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -100,6 +100,9 @@
     <string name="tap_to_check">Tap to check for new versions</string>
     <string name="release_notes">Release Notes</string>
     <string name="view_changelog">View changelog</string>
+    <string name="debug_logging">Debug Logging</string>
+    <string name="debug_logging_desc">Enter a Loki endpoint URL to share logs with a developer. Leave empty to disable.</string>
+    <string name="debug_logging_off">Off</string>
 
     <!-- Update Dialog -->
     <string name="update_available">Update Available</string>
@@ -316,6 +319,16 @@
     <string name="download_failed">Download failed</string>
     <string name="download_folder">Download folder</string>
     <string name="download_folder_none">Not set, tap to choose</string>
+    <string name="storage_limit">Storage Limit</string>
+    <string name="storage_limit_desc">Cap how much space your downloads can use. Leave empty or 0 for no limit.</string>
+    <string name="storage_limit_placeholder">e.g. 5</string>
+    <string name="storage_limit_value">%.1f GB</string>
+    <string name="storage_limit_unlimited">No limit</string>
+    <string name="storage_policy">When Full</string>
+    <string name="storage_policy_stop">Stop downloading</string>
+    <string name="storage_policy_stop_desc">Refuse new downloads once the limit is reached</string>
+    <string name="storage_policy_evict">Delete oldest</string>
+    <string name="storage_policy_evict_desc">Remove the oldest-added downloads to make room</string>
     <string name="download_track">Download</string>
     <string name="remove_download">Remove download</string>
     <string name="download_needs_folder">Choose a download folder first</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -89,6 +89,11 @@
 
     <!-- About -->
     <string name="app_version">App Version</string>
+    <string name="update_channel">Update Channel</string>
+    <string name="update_channel_stable">Stable</string>
+    <string name="update_channel_stable_desc">Only full, reviewed releases.</string>
+    <string name="update_channel_nightly">Nightly</string>
+    <string name="update_channel_nightly_desc">Unreviewed prerelease builds. Install at your own risk.</string>
     <string name="check_for_updates">Check for Updates</string>
     <string name="checking">Checking…</string>
     <string name="up_to_date">You\'re on the latest version</string>
@@ -103,6 +108,7 @@
     <string name="whats_new">What\'s new:</string>
     <string name="update_now">Update Now</string>
     <string name="later">Later</string>
+    <string name="nightly_build_warning">This is a nightly build — unreviewed and may be unstable. Install at your own risk.</string>
 
     <!-- Devices -->
     <string name="searching_devices">Searching for devices…</string>


### PR DESCRIPTION
Release builds now take versionCode/versionName from the git tag (build-and-release.yml) instead of the checked-in build.gradle.kts literals, which only serve as the local/dev fallback for that and for the nightly workflow's base version. Adds a manual-only workflow (nightly.yml) to cut vX.Y.Z-nightly.N prereleases, and an Account > About > Update Channel setting (Stable/Nightly) so users can opt into seeing them, clearly marked as unreviewed and at their own risk.

Documented in CLAUDE.md under "Versioning & releases", including the known caveat that release-drafter's own draft version lineage has drifted out of sync with this and shouldn't be trusted for picking a release tag.

Closes #505