### PR TITLE
fix: use gh CLI's --generate-notes, not the Action field name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,5 +53,5 @@ jobs:
             --repo "${{ github.repository }}" \
             --title "Snepilatch ${{ steps.tag.outputs.tag }} (nightly)" \
             --prerelease \
-            --generate-release-notes \
+            --generate-notes \
             --notes "⚠️ **Nightly build** — unreviewed and may be unstable. Only visible to users on the Nightly update channel. Install at your own risk."


### PR DESCRIPTION
--generate-release-notes is softprops/action-gh-release's field, not a gh release create flag. Broke the first automatic nightly run (#508's own merge) at the publish step, after the tag had already been pushed; verified --notes and --generate-notes are meant to combine (--notes prepends to the auto-generated body). Deleted the orphaned v3.0.0-nightly.1 tag from the failed run.

Closes #509