### PR TITLE
fix: simplify the nightly release title to just the tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           gh release create "${{ steps.tag.outputs.tag }}" \
             --repo "${{ github.repository }}" \
-            --title "Snepilatch ${{ steps.tag.outputs.tag }} (nightly)" \
+            --title "${{ steps.tag.outputs.tag }}" \
             --prerelease \
             --generate-notes \
             --notes "⚠️ **Nightly build** — unreviewed and may be unstable. Only visible to users on the Nightly update channel. Install at your own risk."


### PR DESCRIPTION
"Snepilatch vX.Y.Z-nightly.N (nightly)" repeated the repo name and said nightly twice — the Pre-release badge already covers that.

Closes #515