### PR TITLE
Bump AGP to 9.3.1 so compileSdk 37 is a tested combination

### DIFF
--- a/src/gradle/libs.versions.toml
+++ b/src/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.3.1"
 kotlin = "2.2.10"
 coreKtx = "1.18.0"
 junit = "4.13.2"

--- a/src/gradle/wrapper/gradle-wrapper.properties
+++ b/src/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Wed Mar 04 20:24:37 CET 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
AGP 9.1.0 was only tested up to compile SDK 36.1, which every release build warned about. 9.3.1 covers 37 and requires Gradle 9.5.0, so the wrapper moves with it. The warning is gone from the build log.

Closes #523