### PR TITLE
Replace the two deprecated APIs in the release build log

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -32,7 +32,6 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
-import androidx.media3.datasource.RawResourceDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.SeekParameters
 import androidx.media3.exoplayer.DefaultRenderersFactory
@@ -655,7 +654,13 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         // Keep the previous track's metadata frozen on the card (no "Skipping ad…"); the isAdSkipping
         // flag makes updatePlaybackState report BUFFERING so the notification shows a loading spinner.
         isAdSkipping = true
-        val uri = RawResourceDataSource.buildRawResourceUri(ch.snepilatch.app.R.raw.silent_ad)
+        // Replaces media3's deprecated `rawresource://` builder. The package must be spelled out:
+        // an authority-less "android.resource:123" re-parses as opaque and loses its path.
+        val uri = android.net.Uri.Builder()
+            .scheme(android.content.ContentResolver.SCHEME_ANDROID_RESOURCE)
+            .authority(packageName)
+            .path(ch.snepilatch.app.R.raw.silent_ad.toString())
+            .build()
         mainHandler.post {
             val source = ProgressiveMediaSource.Factory(DefaultDataSource.Factory(this))
                 .createMediaSource(MediaItem.fromUri(uri))

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -81,15 +81,19 @@ import kotlinx.coroutines.delay
  * Match the app's transparent, edge-to-edge nav bar inside a ModalBottomSheet. The sheet
  * has its own window that re-enables the nav-bar contrast scrim the Activity turned off,
  * which shows as a static white backdrop behind the system buttons. Call at the top of the
- * sheet's content.
+ * sheet's content. From API 35 the system bars can't be tinted at all and both setters are
+ * deprecated no-ops, hence the version gate rather than a blanket suppression.
  */
 @Composable
 fun SheetNavBarFix() {
     val view = LocalView.current
     SideEffect {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) return@SideEffect
         val window = (view.parent as? DialogWindowProvider)?.window ?: return@SideEffect
+        @Suppress("DEPRECATION")
         window.navigationBarColor = android.graphics.Color.TRANSPARENT
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            @Suppress("DEPRECATION")
             window.isNavigationBarContrastEnforced = false
         }
     }


### PR DESCRIPTION
`RawResourceDataSource.buildRawResourceUri` becomes the canonical `android.resource://` builder media3 points at, and the nav-bar setters in `SheetNavBarFix` are gated to API < 35 where they still do something. `compileProdReleaseKotlin` no longer warns.

Closes #525