### PR TITLE
Default the player background to the flowing album art

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
@@ -88,8 +88,8 @@ object AppSettings {
         return if (gb <= 0f) null else (gb * 1_000_000_000L).toLong()
     }
 
-    // Player background style: true = album-colour gradient (Spfy/YTM style), false = blurred art.
-    val playerGradientBg = MutableStateFlow(true)
+    // Player background style: true = album-colour gradient, false (default) = flowing album art.
+    val playerGradientBg = MutableStateFlow(false)
 
     // Canvas background toggle (the URL itself is playback state on PlaybackViewModel).
     val canvasEnabled = MutableStateFlow(false)
@@ -140,7 +140,7 @@ object AppSettings {
         eqHeadroomDb.value = prefs.getFloat("eq_headroom_db", -6f)
         eqMode.value = prefs.getString("eq_mode", null) ?: migratedEqMode(prefs)
         eqBands.value = parseBands(prefs.getString("eq_bands", null))
-        playerGradientBg.value = prefs.getBoolean("player_gradient_bg", true)
+        playerGradientBg.value = prefs.getBoolean("player_gradient_bg", false)
         contentRegion.value = prefs.getString("content_region", "nearest") ?: "nearest"
         updateChannel.value = prefs.getString("update_channel", CHANNEL_STABLE) ?: CHANNEL_STABLE
         lokiEndpoint.value = prefs.getString("loki_endpoint", "") ?: ""

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/AppSettingsDefaultsTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/AppSettingsDefaultsTest.kt
@@ -1,0 +1,50 @@
+package ch.snepilatch.app.viewmodel
+
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * A default has to be written twice — in the flow initialiser and in [AppSettings.load]'s fallback —
+ * and changing one without the other only shows up after a process restart. These pin both.
+ */
+class AppSettingsDefaultsTest {
+
+    /** Fresh install: every read returns whatever default the caller passed. */
+    private fun emptyPrefs(): SharedPreferences = mockk {
+        every { getString(any(), any()) } answers { secondArg() }
+        every { getBoolean(any(), any()) } answers { secondArg() }
+        every { getFloat(any(), any()) } answers { secondArg() }
+    }
+
+    private fun contextWith(prefs: SharedPreferences): Context = mockk {
+        every { applicationContext } returns this@mockk
+        every { getSharedPreferences(AppSettings.PREFS, any()) } returns prefs
+        every { resources } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun freshInstallStartsWithTheFlowingCover() {
+        assertFalse(AppSettings.playerGradientBg.value)
+        AppSettings.load(contextWith(emptyPrefs()))
+        assertFalse(AppSettings.playerGradientBg.value)
+    }
+
+    @Test
+    fun aStoredChoiceStillWins() {
+        val prefs: SharedPreferences = mockk {
+            every { getString(any(), any()) } answers { secondArg() }
+            every { getBoolean(any(), any()) } answers { secondArg() }
+            every { getBoolean("player_gradient_bg", any()) } returns true
+            every { getFloat(any(), any()) } answers { secondArg() }
+        }
+        AppSettings.load(contextWith(prefs))
+        assertEquals(true, AppSettings.playerGradientBg.value)
+        // Leave the object on the defaults the rest of the suite expects.
+        AppSettings.load(contextWith(emptyPrefs()))
+    }
+}


### PR DESCRIPTION
`playerGradientBg` now defaults to false, so a fresh install gets the flowing cover and the flat gradient becomes the opt-out. The new test pins the default in both places it has to be written.

Closes #529