### PR TITLE
Turn the equalizer on by default

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/AppSettings.kt
@@ -100,7 +100,8 @@ object AppSettings {
     //   [EQ_OFF]      no EQ, no attenuation
     //   [EQ_IN_APP]   our 10-band EQ, which makes its own headroom
     //   [EQ_EXTERNAL] no in-app EQ, just [eqHeadroomDb] of attenuation for the external one
-    val eqMode = MutableStateFlow(EQ_OFF)
+    // Defaults to [EQ_IN_APP]; [eqBands] starts flat, so it's transparent until a slider moves.
+    val eqMode = MutableStateFlow(EQ_IN_APP)
     val eqHeadroomDb = MutableStateFlow(-6f)
 
     // Per-band gains in dB for the in-app EQ (see EqualizerHeadroom.FREQUENCIES).
@@ -302,11 +303,15 @@ object AppSettings {
     /**
      * The two booleans this replaced could both be set, which the UI had to paper over. Carry the old
      * state across once: the in-app EQ wins if it was on, otherwise headroom means an external one.
+     *
+     * Neither flag set means "never opened the screen" — the old booleans only ever recorded an
+     * *enable* — so it lands on the [EQ_IN_APP] default. A deliberate off is stored as `eq_mode` and
+     * never reaches here.
      */
     internal fun migratedEqMode(prefs: android.content.SharedPreferences): String = when {
         prefs.getBoolean("eq_enabled", false) -> EQ_IN_APP
         prefs.getBoolean("eq_headroom_enabled", false) -> EQ_EXTERNAL
-        else -> EQ_OFF
+        else -> EQ_IN_APP
     }
 
     /** Switch equalizer mode: re-attach or drop our EQ, and re-stage the gain for the new mode. */

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/AppSettingsDefaultsTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/AppSettingsDefaultsTest.kt
@@ -28,6 +28,13 @@ class AppSettingsDefaultsTest {
     }
 
     @Test
+    fun freshInstallStartsWithTheInAppEqualizer() {
+        assertEquals(AppSettings.EQ_IN_APP, AppSettings.eqMode.value)
+        AppSettings.load(contextWith(emptyPrefs()))
+        assertEquals(AppSettings.EQ_IN_APP, AppSettings.eqMode.value)
+    }
+
+    @Test
     fun freshInstallStartsWithTheFlowingCover() {
         assertFalse(AppSettings.playerGradientBg.value)
         AppSettings.load(contextWith(emptyPrefs()))
@@ -38,11 +45,13 @@ class AppSettingsDefaultsTest {
     fun aStoredChoiceStillWins() {
         val prefs: SharedPreferences = mockk {
             every { getString(any(), any()) } answers { secondArg() }
+            every { getString("eq_mode", null) } returns AppSettings.EQ_OFF
             every { getBoolean(any(), any()) } answers { secondArg() }
             every { getBoolean("player_gradient_bg", any()) } returns true
             every { getFloat(any(), any()) } answers { secondArg() }
         }
         AppSettings.load(contextWith(prefs))
+        assertEquals(AppSettings.EQ_OFF, AppSettings.eqMode.value)
         assertEquals(true, AppSettings.playerGradientBg.value)
         // Leave the object on the defaults the rest of the suite expects.
         AppSettings.load(contextWith(emptyPrefs()))

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/EqModeMigrationTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/EqModeMigrationTest.kt
@@ -29,8 +29,9 @@ class EqModeMigrationTest {
     }
 
     @Test
-    fun neitherBecomesOff() {
-        assertEquals(AppSettings.EQ_OFF, AppSettings.migratedEqMode(prefs(inApp = false, headroom = false)))
+    fun neitherLandsOnTheInAppDefault() {
+        // "Neither set" is someone who never opened the screen, so it gets the fresh-install default.
+        assertEquals(AppSettings.EQ_IN_APP, AppSettings.migratedEqMode(prefs(inApp = false, headroom = false)))
     }
 
     @Test


### PR DESCRIPTION
`eqMode` now defaults to the in-app EQ. The band curve starts flat so nothing sounds different until a slider moves — it just means the EQ screen is live on first open instead of asking for a mode switch first. A stored `off` still wins, and the old-boolean migration lands on the same default only when neither flag was ever set.

Closes #530