### PR TITLE
Add song and artist radio to the context menus

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.rounded.Album
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.PlaylistRemove
+import androidx.compose.material.icons.rounded.Radio
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Text
@@ -325,6 +326,7 @@ fun TrackRow(
             val visitAlbumLabel = stringResource(R.string.visit_album)
             val visitArtistLabel = stringResource(R.string.visit_artist)
             val removeFromPlaylistLabel = stringResource(R.string.remove_from_playlist)
+            val songRadioLabel = stringResource(R.string.go_to_song_radio)
             val downloadLabel = if (isDownloaded) {
                 stringResource(R.string.remove_download)
             } else {
@@ -355,6 +357,9 @@ fun TrackRow(
                 },
                 Triple(Icons.Rounded.Favorite, likeLabel) {
                     vm.likeSong(track.uri.removePrefix("spotify:track:")); showMenu = false
+                },
+                Triple(Icons.Rounded.Radio, songRadioLabel) {
+                    showMenu = false; detailVm.openRadio(track.uri)
                 },
                 Triple(Icons.Rounded.Album, visitAlbumLabel) {
                     showMenu = false; detailVm.openAlbumForTrack(track.uri)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.rounded.Album
 import androidx.compose.material.icons.rounded.Person
+import androidx.compose.material.icons.rounded.Radio
 import androidx.compose.ui.draw.clip
 import androidx.compose.material3.*
 import androidx.compose.runtime.LaunchedEffect
@@ -866,6 +867,26 @@ private fun AlbumTrackRow(
  * Skips "Remove from Library" because the like/save toggle already lives
  * elsewhere in the header.
  */
+@Composable
+private fun DetailHeaderMenuTitle(detail: ch.snepilatch.app.data.DetailData, type: String) {
+    Row(
+        Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ch.snepilatch.app.ui.components.SpfyImage(
+            url = detail.imageUrl,
+            modifier = Modifier.size(48.dp),
+            shape = RoundedCornerShape(8.dp)
+        )
+        Spacer(Modifier.width(12.dp))
+        Column {
+            Text(detail.name, color = SpfyWhite, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            val subtitle = detail.artistName ?: detail.ownerName ?: type.replaceFirstChar { it.uppercase() }
+            Text(subtitle, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DetailHeaderMenu(
@@ -882,28 +903,14 @@ private fun DetailHeaderMenu(
     val isAlbum = type == "album"; val isCollection = type == "collection"; val isArtist = type == "artist"
     val shareLabel = stringResource(R.string.share); val addToQueueLabel = stringResource(R.string.add_to_queue)
     val addToPlaylistLabel = stringResource(R.string.add_to_playlist); val visitArtistLabel = stringResource(R.string.visit_artist)
+    val artistRadioLabel = stringResource(R.string.go_to_artist_radio)
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
         containerColor = SpfyElevated,
     ) {
         ch.snepilatch.app.ui.components.SheetNavBarFix()
-        Row(
-            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            ch.snepilatch.app.ui.components.SpfyImage(
-                url = detail.imageUrl,
-                modifier = Modifier.size(48.dp),
-                shape = RoundedCornerShape(8.dp)
-            )
-            Spacer(Modifier.width(12.dp))
-            Column {
-                Text(detail.name, color = SpfyWhite, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                val subtitle = detail.artistName ?: detail.ownerName ?: type.replaceFirstChar { it.uppercase() }
-                Text(subtitle, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            }
-        }
+        DetailHeaderMenuTitle(detail, type)
         Spacer(Modifier.height(8.dp))
         HorizontalDivider(color = SpfyLightGray.copy(alpha = 0.15f))
         val items = buildList<Triple<androidx.compose.ui.graphics.vector.ImageVector, String, () -> Unit>> {
@@ -933,6 +940,14 @@ private fun DetailHeaderMenu(
                     onDismiss()
                     val artistId = detail.artistUri.substringAfterLast(":")
                     DetailRoutes.openArtist(artistId)
+                })
+            }
+            // An album seeds with its artist, same as the desktop client — hence "artist radio" there.
+            val radioSeed = if (isArtist) detail.uri else detail.artistUri?.takeIf { isAlbum }
+            if (radioSeed != null) {
+                add(Triple(Icons.Rounded.Radio, artistRadioLabel) {
+                    onDismiss()
+                    DetailRoutes.openRadio(radioSeed)
                 })
             }
         }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -1169,6 +1169,7 @@ private fun NowPlayingMenu(
             val addPlaylistLabel = stringResource(R.string.add_to_playlist)
             val viewQueueLabel = stringResource(R.string.view_queue)
             val visitAlbumLabel = stringResource(R.string.visit_album)
+            val songRadioLabel = stringResource(R.string.go_to_song_radio)
             val devicesLabel = stringResource(R.string.devices)
             val shareLabel = stringResource(R.string.share)
             val downloadCtx = androidx.compose.ui.platform.LocalContext.current
@@ -1199,6 +1200,11 @@ private fun NowPlayingMenu(
                 },
                 Triple(Icons.Rounded.Album, visitAlbumLabel) {
                     onShowMore(false); vm.openAlbumFromCurrentTrack()
+                },
+                Triple(Icons.Rounded.Radio, songRadioLabel) {
+                    onShowMore(false)
+                    // Via the router: this menu is built outside a composable that owns a DetailViewModel.
+                    track?.uri?.let { ch.snepilatch.app.viewmodel.DetailRoutes.openRadio(it) }
                 },
                 // Same glyphs as the track rows in SharedComponents: the same track reached two ways
                 // showed two different icons for one state.

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
@@ -8,6 +8,7 @@ import kotify.api.album.Album
 import kotify.api.artist.Artist
 import kotify.api.playlist.Playlist
 import kotify.api.podcast.Podcast
+import kotify.api.radio.Radio
 import kotify.api.song.Song
 import kotify.session.Session
 import kotlinx.coroutines.CancellationException
@@ -83,6 +84,24 @@ class DetailViewModel : SessionViewModel("DetailVM") {
                 ?.toDetailData(showId, publisher, imageUrl)
                 .also { if (it == null) LokiLogger.e(logTag, "openShow: no podcast info for $showId") }
         }
+
+    /**
+     * Open the station for [seedUri] (track = song radio, artist = artist radio) as a normal playlist
+     * page. Nothing starts playing — a station *is* a generated playlist.
+     *
+     * Unlike the other openers this navigates only after the response: the destination isn't known
+     * until then, and a seed with no radio would otherwise strand the user on an empty screen.
+     */
+    fun openRadio(seedUri: String) {
+        launchWithSession("openRadio") { sess ->
+            val stationUri = Radio(sess).getRadioPlaylistUri(seedUri)
+            if (stationUri == null) {
+                LokiLogger.w(logTag, "No radio station for $seedUri")
+                return@launchWithSession
+            }
+            openPlaylist(stationUri.substringAfterLast(':'))
+        }
+    }
 
     fun openAlbumForTrack(trackUri: String) {
         launchWithSession("openAlbumForTrack") { sess ->
@@ -301,5 +320,6 @@ object DetailRoutes {
     }
     fun openLikedSongs() { target?.openLikedSongs() }
     fun openAlbumForTrack(trackUri: String) { target?.openAlbumForTrack(trackUri) }
+    fun openRadio(seedUri: String) { target?.openRadio(seedUri) }
     fun openArtistForTrack(trackUri: String) { target?.openArtistForTrack(trackUri) }
 }

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -38,6 +38,8 @@
     <string name="add_to_queue">I d Wartelischte</string>
     <string name="add_to_playlist">I d Playlist iifüege</string>
     <string name="remove_from_playlist">Us dere Playlist uusenäh</string>
+    <string name="go_to_song_radio">Zum Song-Radio</string>
+    <string name="go_to_artist_radio">Zum Künstler*inne-Radio</string>
     <string name="like">Gfallt mer</string>
     <string name="unlike">Gfallt mer nüm</string>
     <string name="visit_album">Album aaluege</string>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -28,6 +28,8 @@
     <string name="add_to_queue">Zur Warteschlange</string>
     <string name="add_to_playlist">Zu Playlist hinzufügen</string>
     <string name="remove_from_playlist">Aus dieser Playlist entfernen</string>
+    <string name="go_to_song_radio">Zum Song-Radio</string>
+    <string name="go_to_artist_radio">Zum Künstler*innen-Radio</string>
     <string name="like">Gefällt mir</string>
     <string name="unlike">Gefällt mir nicht mehr</string>
     <string name="visit_album">Album anzeigen</string>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -28,6 +28,8 @@
     <string name="add_to_queue">В очередь</string>
     <string name="add_to_playlist">В плейлист</string>
     <string name="remove_from_playlist">Удалить из плейлиста</string>
+    <string name="go_to_song_radio">Радио по треку</string>
+    <string name="go_to_artist_radio">Радио по исполнителю</string>
     <string name="like">Нравится</string>
     <string name="unlike">Не нравится</string>
     <string name="visit_album">Перейти к альбому</string>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="add_to_queue">Add to Queue</string>
     <string name="add_to_playlist">Add to Playlist</string>
     <string name="remove_from_playlist">Remove from this Playlist</string>
+    <string name="go_to_song_radio">Go to song radio</string>
+    <string name="go_to_artist_radio">Go to artist radio</string>
     <string name="like">Like</string>
     <string name="unlike">Unlike</string>
     <string name="visit_album">Visit Album</string>


### PR DESCRIPTION
Adds "Go to song radio" to the track sheet and the player's overflow menu, and "Go to artist radio" to the artist and album header menus — an album seeds with its artist, matching the desktop client.

A station is an ordinary generated playlist, so this resolves the seed through KotifyClient's new `Radio` API and opens the result on the normal playlist screen. Nothing starts playing.

Needs KotifyClient v3.1.0.

Closes #528