### PR TITLE
Clear the nav-bar scrim behind bottom sheets on Android 15

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -83,20 +83,23 @@ import kotlinx.coroutines.delay
  * Match the app's transparent, edge-to-edge nav bar inside a ModalBottomSheet. The sheet
  * has its own window that re-enables the nav-bar contrast scrim the Activity turned off,
  * which shows as a static white backdrop behind the system buttons. Call at the top of the
- * sheet's content. From API 35 the system bars can't be tinted at all and both setters are
- * deprecated no-ops, hence the version gate rather than a blanket suppression.
+ * sheet's content.
  */
 @Composable
 fun SheetNavBarFix() {
     val view = LocalView.current
     SideEffect {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) return@SideEffect
         val window = (view.parent as? DialogWindowProvider)?.window ?: return@SideEffect
-        @Suppress("DEPRECATION")
-        window.navigationBarColor = android.graphics.Color.TRANSPARENT
+        // The scrim is all that's left from API 35 — the bar can't be tinted there — and this is the
+        // only setter that still removes it. NOT deprecated, and NOT skippable on 35+: doing so is
+        // what put the white backdrop back behind the buttons.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            @Suppress("DEPRECATION")
             window.isNavigationBarContrastEnforced = false
+        }
+        // Deprecated and ignored from API 35; below that it's the only way to clear the bar.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+            @Suppress("DEPRECATION")
+            window.navigationBarColor = android.graphics.Color.TRANSPARENT
         }
     }
 }


### PR DESCRIPTION
`SheetNavBarFix` returned early from API 35 on the assumption that both nav-bar setters were deprecated no-ops there. `setNavigationBarContrastEnforced` is neither — it isn't deprecated at compileSdk 37, and it's the only remaining way to drop the translucent scrim the system draws behind 3-button navigation. Skipping it put the white backdrop back behind the buttons whenever a sheet was open.

The contrast setter now runs on every API from 29 up, and only the genuinely-deprecated `navigationBarColor` is gated below 35. The build stays warning-free.

Closes #538