### PR TITLE
Launch into an offline mode when there is no internet

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/OfflineHomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/OfflineHomeScreen.kt
@@ -1,0 +1,59 @@
+package ch.snepilatch.app.ui.screens
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.R
+import ch.snepilatch.app.data.TrackInfo
+import ch.snepilatch.app.download.Downloads
+import ch.snepilatch.app.ui.components.TrackRow
+import ch.snepilatch.app.ui.theme.SpfyLightGray
+import ch.snepilatch.app.ui.theme.SpfyWhite
+import ch.snepilatch.app.viewmodel.PlaybackViewModel
+
+@Composable
+fun OfflineHomeScreen(vm: PlaybackViewModel) {
+    val stored by Downloads.rows.collectAsState()
+    val tracks = stored.map {
+        TrackInfo(uri = it.trackUri, name = it.title, artist = it.artist, albumArt = it.coverUrl)
+    }
+
+    if (tracks.isEmpty()) {
+        Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+            Text(
+                stringResource(R.string.offline_no_downloads),
+                color = SpfyLightGray,
+                fontSize = 15.sp,
+                textAlign = TextAlign.Center
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = LocalBottomOverlayHeight.current.value + 16.dp)
+    ) {
+        item {
+            Text(
+                stringResource(R.string.offline_while_youre_offline),
+                color = SpfyWhite,
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)
+            )
+        }
+        items(tracks, key = { it.uri }) { track -> TrackRow(track, vm) }
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpfyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpfyApp.kt
@@ -138,6 +138,8 @@ fun SpfyApp(vm: PlaybackViewModel) {
         if (screen != Screen.NOW_PLAYING && screen != Screen.LYRICS) contentScreen = screen
     }
 
+    val isOffline by vm.isOffline.collectAsState()
+
     val toastContext = androidx.compose.ui.platform.LocalContext.current
     LaunchedEffect(Unit) {
         vm.errorMessage.collect { message ->
@@ -234,7 +236,18 @@ fun SpfyApp(vm: PlaybackViewModel) {
                     translationY = expand.value * size.height
                 }
             ) {
-                BottomNav(screen, vm, hazeState)
+                Column {
+                    if (isOffline) {
+                        Text(
+                            stringResource(R.string.offline_banner),
+                            color = SpfyLightGray,
+                            fontSize = 12.sp,
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)
+                        )
+                    }
+                    BottomNav(screen, vm, hazeState)
+                }
             }
         }
 
@@ -341,6 +354,7 @@ fun SpfyApp(vm: PlaybackViewModel) {
 @Composable
 private fun MainContent(screen: Screen, vm: PlaybackViewModel, hazeState: HazeState) {
     val libraryVm: LibraryViewModel = viewModel()
+    val isOffline by vm.isOffline.collectAsState()
     Box(
         Modifier
             .fillMaxSize()
@@ -348,7 +362,7 @@ private fun MainContent(screen: Screen, vm: PlaybackViewModel, hazeState: HazeSt
             .hazeSource(hazeState)
     ) {
         when (screen) {
-            Screen.HOME -> HomeScreen(vm)
+            Screen.HOME -> if (isOffline) OfflineHomeScreen(vm) else HomeScreen(vm)
             Screen.SEARCH -> SearchScreen(vm)
             Screen.LIBRARY -> { LaunchedEffect(Unit) { libraryVm.loadLibrary() }; LibraryScreen() }
             Screen.ACCOUNT -> AccountScreen(vm)

--- a/src/app/src/main/java/ch/snepilatch/app/util/Connectivity.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/util/Connectivity.kt
@@ -1,0 +1,13 @@
+package ch.snepilatch.app.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+/** VALIDATED as well as INTERNET: a captive portal reports the capability without carrying traffic. */
+fun hasInternet(context: Context): Boolean {
+    val cm = context.getSystemService(ConnectivityManager::class.java) ?: return true
+    val caps = cm.getNetworkCapabilities(cm.activeNetwork) ?: return false
+    return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+        caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -9,6 +9,7 @@ import ch.snepilatch.app.R
 import ch.snepilatch.app.data.UiMessage
 import ch.snepilatch.app.util.LokiLogger
 import ch.snepilatch.app.util.detectActiveAudioOutput
+import ch.snepilatch.app.util.hasInternet
 import ch.snepilatch.app.util.normalizeSpfyImageUrl
 import ch.snepilatch.app.playback.InfiniPlayController
 import ch.snepilatch.app.playback.InfiniPlayViz
@@ -79,6 +80,9 @@ class PlaybackViewModel : ViewModel() {
         set(value) { SessionHolder.player = value }
     private var username: String = ""
     val isInitialized = MutableStateFlow(false)
+
+    /** Set instead of [initError] so the UI still renders; only downloaded tracks play. */
+    val isOffline = MutableStateFlow(false)
     val initError = MutableStateFlow<UiMessage?>(null)
     val rateLimitCooldown = MutableStateFlow(false)
     val cooldownSeconds = MutableStateFlow(0)
@@ -457,6 +461,13 @@ class PlaybackViewModel : ViewModel() {
             } catch (e: Exception) {
                 LokiLogger.e(TAG, "Init failed", e)
                 val msg = e.message ?: "Unknown error"
+                val ctx = MusicPlaybackService.instance as? android.content.Context
+                if (ctx != null && !hasInternet(ctx)) {
+                    LokiLogger.w(TAG, "No internet — starting offline, downloads only")
+                    isOffline.value = true
+                    isInitialized.value = true
+                    return@launch
+                }
                 if (msg.contains("Unauthorized") || msg.contains("401") || msg.contains("code\":400")) {
                     initRetryCount++
                     if (initRetryCount > 5) {
@@ -1698,6 +1709,10 @@ class PlaybackViewModel : ViewModel() {
     internal suspend fun startUserPlayback(track: TrackInfo, contextUri: String?, trackIndex: Int? = null) {
         // Honor the resulting onTrackChange even if we're starting from idle (no local audio yet).
         pendingUserPlay = true
+        if (isOffline.value) {
+            playDownloaded(track.uri, track.name, track.artist, track.albumArt)
+            return
+        }
         val pc = player ?: return
         coroutineScope {
             // Instant tap-to-play (always on): self-resolve the tapped track's audio and start

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -366,4 +366,7 @@
     </plurals>
     <string name="auto_save_listened">Bhalte, was i lose</string>
     <string name="auto_save_listened_desc">Spicheret en Song, sobald du ne dureghört häsch</string>
+    <string name="offline_banner">Du bisch offline</string>
+    <string name="offline_while_youre_offline">Wärend du offline bisch</string>
+    <string name="offline_no_downloads">Du bisch offline und es isch no nüt abeglade. Abegladeni Songs erschine da.</string>
 </resources>

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -350,4 +350,7 @@
     </plurals>
     <string name="auto_save_listened">Gehörtes behalten</string>
     <string name="auto_save_listened_desc">Speichert einen Titel, sobald du ihn durchgehört hast</string>
+    <string name="offline_banner">Du bist offline</string>
+    <string name="offline_while_youre_offline">Während du offline bist</string>
+    <string name="offline_no_downloads">Du bist offline und es ist noch nichts heruntergeladen. Heruntergeladene Songs erscheinen hier.</string>
 </resources>

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -352,4 +352,7 @@
     </plurals>
     <string name="auto_save_listened">Сохранять прослушанное</string>
     <string name="auto_save_listened_desc">Сохраняет трек после полного прослушивания</string>
+    <string name="offline_banner">Вы офлайн</string>
+    <string name="offline_while_youre_offline">Пока вы офлайн</string>
+    <string name="offline_no_downloads">Вы офлайн, и пока ничего не загружено. Загруженные треки появятся здесь.</string>
 </resources>

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -356,4 +356,7 @@
     </plurals>
     <string name="auto_save_listened">Keep what I listen to</string>
     <string name="auto_save_listened_desc">Save a track once you have played it through</string>
+    <string name="offline_banner">You\'re offline</string>
+    <string name="offline_while_youre_offline">While you\'re offline</string>
+    <string name="offline_no_downloads">You\'re offline and nothing is downloaded yet. Downloaded songs will show up here.</string>
 </resources>


### PR DESCRIPTION
With no connectivity `initialize()` threw on `Session.load()` and the app stopped on the connect-failed screen, so downloads were unreachable exactly when they matter.

Init failure now checks whether the device actually has validated internet. If it doesn't, the app comes up in an offline mode instead of erroring: Home shows the downloaded tracks, a "You're offline" line sits above the bottom nav, and tapping a track routes through the existing `playDownloaded` path rather than the Connect command, so it plays straight off disk with no session.

Closes #544