### PR TITLE
Save a playlist with a plus that turns into a checkmark

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/KotifyMappers.kt
@@ -164,6 +164,7 @@ fun PlaylistInfo.toDetailData(playlistId: String) = DetailData(
     ownerName = owner.name,
     ownerUri = owner.uri,
     followers = followers,
+    savedInLibrary = following,
     tracks = tracks.map { it.toTrackInfo() },
 )
 

--- a/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
@@ -60,6 +60,7 @@ data class DetailData(
     val ownerName: String? = null,
     val ownerUri: String? = null,
     val followers: Long? = null,
+    val savedInLibrary: Boolean = false,
     // Artist-specific
     val monthlyListeners: Long? = null,
     val biography: String? = null,

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.rounded.DownloadForOffline
 import androidx.compose.material.icons.rounded.OfflinePin
 import androidx.compose.material.icons.rounded.Favorite
-import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -22,7 +21,9 @@ import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.rounded.AddCircleOutline
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.Radio
 import androidx.compose.ui.draw.clip
@@ -219,13 +220,13 @@ fun DetailScreen(vm: PlaybackViewModel) {
                 Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 4.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Save/Follow (albums & artists)
-                if (detail.type == "album" || isArtist) {
+                // Save/Follow (albums, playlists & artists)
+                if (detail.type == "album" || detail.type == "playlist" || isArtist) {
                     val saved by detailVm.detailSaved.collectAsState()
-                    val detailId = detail.uri
-                        .removePrefix("spotify:album:")
-                        .removePrefix("spotify:artist:")
-                    LaunchedEffect(detail.uri) { detailVm.checkDetailSaved(detail.type, detailId) }
+                    val detailId = detail.uri.substringAfterLast(':')
+                    LaunchedEffect(detail.uri, detail.savedInLibrary) {
+                        detailVm.checkDetailSaved(detail.type, detailId)
+                    }
 
                     if (isArtist) {
                         OutlinedButton(
@@ -254,7 +255,7 @@ fun DetailScreen(vm: PlaybackViewModel) {
                             modifier = Modifier.size(HEADER_BUTTON),
                         ) {
                             Icon(
-                                if (saved) Icons.Rounded.Favorite else Icons.Filled.FavoriteBorder,
+                                if (saved) Icons.Rounded.CheckCircle else Icons.Rounded.AddCircleOutline,
                                 stringResource(R.string.save),
                                 modifier = Modifier.size(HEADER_ICON)
                             )

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
@@ -242,6 +242,8 @@ class DetailViewModel : SessionViewModel("DetailVM") {
                 detailSaved.value = when (type) {
                     "album" -> Album(sess).isSaved(id)
                     "artist" -> Artist(sess).isFollowing(id)
+                    // getPlaylist already returned it; asking again would be a second round trip.
+                    "playlist" -> _detail.value.savedInLibrary
                     else -> false
                 }
             } catch (_: Exception) { detailSaved.value = false }
@@ -254,8 +256,19 @@ class DetailViewModel : SessionViewModel("DetailVM") {
             when (type) {
                 "album" -> if (currentlySaved) Album(sess).removeFromLibrary(id) else Album(sess).saveToLibrary(id)
                 "artist" -> if (currentlySaved) Artist(sess).unfollow(id) else Artist(sess).follow(id)
+                // Playlists live in the rootlist, not the generic library, so both sides need the username.
+                "playlist" -> Playlist(sess).let {
+                    if (currentlySaved) {
+                        it.removeFromLibrary(id, SessionHolder.username)
+                    } else {
+                        it.saveToLibrary(id, SessionHolder.username)
+                    }
+                }
             }
             detailSaved.value = !currentlySaved
+            if (type == "playlist") {
+                _detail.value = _detail.value.copy(savedInLibrary = !currentlySaved)
+            }
         }
     }
 


### PR DESCRIPTION
The header's save control was a heart, and it only appeared on albums and artists — a playlist had no way to be saved from its own page at all.

Albums and playlists now share a plus that becomes a filled checkmark once saved, the way Spfy does it. The playlist's saved state comes from `following` on the payload `getPlaylist` already returns, so showing it costs no extra request, and toggling goes through the rootlist save/remove that playlists need. The heart stays on the per-track menus, where liking a song is a different action.

Closes #545