### PR TITLE
Hand LocalTextStyle back its pre-theme default

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/theme/Theme.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/theme/Theme.kt
@@ -1,8 +1,11 @@
 package ch.snepilatch.app.ui.theme
 
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.text.TextStyle
 
 /**
  * The app paints itself dark everywhere, so the Material scheme is dark-only — no dynamic colour and
@@ -33,11 +36,20 @@ private val SnepilatchColors = darkColorScheme(
     onError = SpfyWhite
 )
 
+/**
+ * [MaterialTheme] hands every unstyled `Text` its `typography.bodyLarge` — 16sp on a 24sp line with
+ * 0.5sp tracking. The screens were all laid out before the app had a theme at all, against the bare
+ * [TextStyle.Default] (14sp, natural line height, no tracking), so adopting it grew the type and the
+ * rows built around it everywhere at once. Handing [LocalTextStyle] back its old value keeps the
+ * colour scheme without the reflow; `MaterialTheme.typography` still reads normally where a screen
+ * asks for a style by name.
+ */
 @Composable
 fun SnepilatchTheme(content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = SnepilatchColors,
-        typography = Typography,
-        content = content
-    )
+        typography = Typography
+    ) {
+        CompositionLocalProvider(LocalTextStyle provides TextStyle.Default, content = content)
+    }
 }


### PR DESCRIPTION
Adopting `MaterialTheme` gave every unstyled `Text` the 16sp/24sp/0.5sp `bodyLarge`, which grew type and row heights across the app. Provide `TextStyle.Default` for `LocalTextStyle` so the screens lay out as they did before, while keeping the dark colour scheme.

Closes #556