### PR TITLE
Skip tracks by swiping the artwork

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -52,6 +52,8 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.window.DialogWindowProvider
 import android.os.Build
 import androidx.compose.ui.Alignment
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.draw.alpha
@@ -493,6 +495,38 @@ fun ProfileInfoItem(label: String, value: String, icon: ImageVector) {
         colors = ListItemDefaults.colors(containerColor = Color.Transparent)
     )
 }
+
+/** How far a finger must travel across the artwork before the release counts as a skip. */
+private val SWIPE_TO_SKIP_THRESHOLD = 48.dp
+
+/**
+ * Horizontal swipe over the artwork: left for the next track, right for the previous one.
+ *
+ * Deliberately decides on release against the accumulated distance rather than reacting to a single
+ * frame's [detectHorizontalDragGestures] delta — a slow drag arrives as many small deltas that no
+ * per-frame threshold catches, and a fast one as a couple of huge deltas that would fire twice.
+ *
+ * Claims only the horizontal axis. Compose waits for horizontal touch slop before this gesture wins,
+ * so the vertical drag that expands the mini player and the tap that opens it both still reach the
+ * parent untouched.
+ */
+fun Modifier.swipeToSkip(onNext: () -> Unit, onPrevious: () -> Unit): Modifier =
+    this.pointerInput(onNext, onPrevious) {
+        val threshold = SWIPE_TO_SKIP_THRESHOLD.toPx()
+        var travelled = 0f
+        detectHorizontalDragGestures(
+            onDragStart = { travelled = 0f },
+            onDragEnd = {
+                when {
+                    travelled <= -threshold -> onNext()
+                    travelled >= threshold -> onPrevious()
+                }
+            }
+        ) { change, dragAmount ->
+            travelled += dragAmount
+            change.consume()
+        }
+    }
 
 /**
  * Album cover with spicy-lyrics' cover transition: on [url] change the NEW cover slides in from the

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -45,6 +45,7 @@ import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import ch.snepilatch.app.ui.components.SheetNavBarFix
 import ch.snepilatch.app.ui.components.SpfyImage
+import ch.snepilatch.app.ui.components.swipeToSkip
 import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.components.InfiniPlayTimeline
 import ch.snepilatch.app.ui.components.rememberSmoothPositionMs
@@ -444,7 +445,10 @@ fun NowPlayingScreen(
                             url = displayArtUrl,
                             modifier = Modifier
                                 .fillMaxHeight(0.85f)
-                                .aspectRatio(1f),
+                                .aspectRatio(1f)
+                                // Ahead of the row's drag-right-to-dismiss below: on the artwork a
+                                // horizontal swipe means skip, everywhere else it still closes.
+                                .swipeToSkip(onNext = vm::skipNext, onPrevious = vm::skipPrevious),
                             shape = RoundedCornerShape(16.dp)
                         )
                     }
@@ -684,15 +688,23 @@ fun NowPlayingScreen(
                     Spacer(Modifier.weight(0.3f))
 
                     if (hasCanvas) {
-                        // Invisible placeholder — same size as album art to keep layout stable
-                        Box(Modifier.fillMaxWidth().aspectRatio(1f))
+                        // Invisible placeholder — same size as album art to keep layout stable.
+                        // Still swipeable: in canvas mode the video stands in for the cover, so the
+                        // skip gesture has to live in the same place rather than disappear.
+                        Box(
+                            Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .swipeToSkip(onNext = vm::skipNext, onPrevious = vm::skipPrevious)
+                        )
                     } else {
                         // Album art — large with rounded corners; slides in from the right on song change.
                         ch.snepilatch.app.ui.components.SlidingCoverImage(
                             url = displayArtUrl,
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .aspectRatio(1f),
+                                .aspectRatio(1f)
+                                .swipeToSkip(onNext = vm::skipNext, onPrevious = vm::skipPrevious),
                             shape = RoundedCornerShape(16.dp)
                         )
                     }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpfyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/SpfyApp.kt
@@ -50,6 +50,7 @@ import ch.snepilatch.app.data.Screen
 import ch.snepilatch.app.ui.components.BottomNav
 import ch.snepilatch.app.ui.components.DevicesDialog
 import ch.snepilatch.app.ui.components.MiniPlayer
+import ch.snepilatch.app.ui.components.swipeToSkip
 import ch.snepilatch.app.ui.components.MiniPlayerContent
 import ch.snepilatch.app.ui.components.miniCardBaseColor
 import ch.snepilatch.app.ui.components.SpfyImage
@@ -185,6 +186,10 @@ fun SpfyApp(vm: PlaybackViewModel) {
                         .pointerInput(Unit) {
                             detectTapGestures { vm.navigateTo(Screen.NOW_PLAYING) }
                         }
+                        // Swipe the bar, not just its 44dp thumbnail — at that size the artwork is
+                        // too small to aim a swipe at. Horizontal only, so the tap above and the
+                        // vertical expand drag below are unaffected.
+                        .swipeToSkip(onNext = vm::skipNext, onPrevious = vm::skipPrevious)
                         .pointerInput(Unit) {
                             var opened = false
                             // Rolling ~60ms window of (time, y) samples → an honest release


### PR DESCRIPTION
Swipe left for the next track, right for the previous one. Live on the full player artwork in both orientations, on the canvas placeholder that stands in for it, and on the mini bar.

The gesture claims only the horizontal axis, so the mini player keeps its tap-to-open and vertical expand drag, and the landscape drag-right-to-dismiss still works everywhere except over the artwork itself.

Closes #558