### PR TITLE
Show the skipped-to track before the dealer confirms it

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -504,16 +504,19 @@ fun ProfileInfoItem(label: String, value: String, icon: ImageVector) {
 fun SlidingCoverImage(
     url: String?,
     modifier: Modifier = Modifier,
-    shape: androidx.compose.ui.graphics.Shape = RoundedCornerShape(8.dp)
+    shape: androidx.compose.ui.graphics.Shape = RoundedCornerShape(8.dp),
+    trackKey: Any? = url
 ) {
     var currentUrl by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(url) }
+    var currentKey by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(trackKey) }
     var previousUrl by androidx.compose.runtime.remember {
         androidx.compose.runtime.mutableStateOf<String?>(null)
     }
     val anim = androidx.compose.runtime.remember { androidx.compose.animation.core.Animatable(1f) }
-    androidx.compose.runtime.LaunchedEffect(url) {
-        if (url != currentUrl) {
+    androidx.compose.runtime.LaunchedEffect(trackKey, url) {
+        if (trackKey != currentKey) {
             previousUrl = currentUrl
+            currentKey = trackKey
             currentUrl = url
             anim.snapTo(0f)
             anim.animateTo(
@@ -521,6 +524,12 @@ fun SlidingCoverImage(
                 tween(750, easing = androidx.compose.animation.core.CubicBezierEasing(0.835f, -0.008f, 0.149f, 0.866f))
             )
             previousUrl = null
+        } else if (url != currentUrl) {
+            // Same track, better artwork. An optimistic skip paints the queue entry's `imageUrl`,
+            // then the confirmed state upgrades it to `imageLargeUrl` — a different string for the
+            // same picture. Swap it in place; replaying the entrance would slide the identical
+            // cover in a second time, a beat after the first.
+            currentUrl = url
         }
     }
     // Clip to the cover frame (like spicy's `overflow: hidden` MediaImageContainer) so the incoming

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -445,7 +445,8 @@ fun NowPlayingScreen(
                             modifier = Modifier
                                 .fillMaxHeight(0.85f)
                                 .aspectRatio(1f),
-                            shape = RoundedCornerShape(16.dp)
+                            shape = RoundedCornerShape(16.dp),
+                            trackKey = track?.uri
                         )
                     }
 
@@ -693,7 +694,8 @@ fun NowPlayingScreen(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .aspectRatio(1f),
-                            shape = RoundedCornerShape(16.dp)
+                            shape = RoundedCornerShape(16.dp),
+                            trackKey = track?.uri
                         )
                     }
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -132,7 +132,18 @@ class PlaybackViewModel : ViewModel() {
     private var pendingUserPlay = false
     private var nextCdnUrl: String? = null      // Pre-resolved Spfy CDN URL (DRM)
     private var nextCdnFileId: String? = null   // File ID for the pre-resolved CDN track
-    private var lastCommandTs: Long = 0L  // timing: when last user command was sent
+
+    // --- Optimistic skip (see #560) ---------------------------------------------------------
+    // Scaffolding, deliberately confined to `applyOptimisticSkip` and one guard in
+    // updatePlaybackFromState so it can be lifted out wholesale once the local state machine owns
+    // playback state. The web player never needs this: its core walks the state-machine graph on
+    // the spot (Application.ts `_transitionTo`) and the UI renders the new state immediately, with
+    // audio resolution trailing. We wait for the dealer instead, so we stand in for that here.
+    private var optimisticSkipFromUri: String? = null
+    private var optimisticSkipAt: Long = 0L
+
+    // timing: when last user command was sent
+    private var lastCommandTs: Long = 0L
     private var lastCommandName: String = ""
 
     // Diagnostic: wall-clock when the current ad-skip began (onAd). Milestones log deltas against it
@@ -262,6 +273,7 @@ class PlaybackViewModel : ViewModel() {
     val queueSheetVisible: StateFlow<Boolean> = _queueSheetVisible
     // Next track info (always available from WebSocket state for mini player swipe)
     val nextTrackPreview = MutableStateFlow<TrackInfo?>(null)
+    val prevTrackPreview = MutableStateFlow<TrackInfo?>(null)
 
     // Detail state + openers live in DetailViewModel; PlaybackViewModel's deep-link/playback bridges
     // reach them through DetailRoutes.
@@ -983,8 +995,16 @@ class PlaybackViewModel : ViewModel() {
             }
         }
 
-        val displayTrack = if (isTrackMismatch) _playback.value.track else trackInfo
-        val displayDuration = if (isTrackMismatch) _playback.value.durationMs else state.duration
+        // Hold the optimistic track while the dealer is still describing the one we skipped away
+        // from; without this the in-flight push reverts the UI for a frame before the real one lands.
+        val optimisticHold = optimisticSkipFromUri != null &&
+            stateTrackUri == optimisticSkipFromUri &&
+            System.currentTimeMillis() - optimisticSkipAt < OPTIMISTIC_SKIP_WINDOW_MS
+        if (!optimisticHold) optimisticSkipFromUri = null
+
+        val pinDisplay = isTrackMismatch || optimisticHold
+        val displayTrack = if (pinDisplay) _playback.value.track else trackInfo
+        val displayDuration = if (pinDisplay) _playback.value.durationMs else state.duration
 
         _playback.value = PlaybackUiState(
             track = displayTrack,
@@ -1025,7 +1045,7 @@ class PlaybackViewModel : ViewModel() {
 
         // Only update theme/liked/canvas for the track we're ACTUALLY displaying
         val displayUri = displayTrack?.uri
-        if (!isTrackMismatch) {
+        if (!pinDisplay) {
             ThemeController.updateFromArt(imageUrl)
             if (displayUri != null) {
                 checkLikedState(displayUri)
@@ -1035,6 +1055,8 @@ class PlaybackViewModel : ViewModel() {
 
         // Extract next track info for mini player swipe preview
         nextTrackPreview.value = state.next_tracks.firstOrNull()?.toTrackInfo()
+        // prev_tracks runs oldest-first, so the track we'd go back to is the LAST entry.
+        prevTrackPreview.value = state.prev_tracks.lastOrNull()?.toTrackInfo()
 
         if (actuallyPlaying) {
             startPositionTicker()
@@ -1589,7 +1611,29 @@ class PlaybackViewModel : ViewModel() {
         return PlaybackCache.keyFor(trackUri, AppSettings.preferredAudioSource.value)
     }
 
+    /**
+     * Show [to] as the playing track right now, before the dealer confirms it.
+     *
+     * Records which track we left so a state push still describing it can be held off — without that
+     * guard the push lands between the tap and the confirmation and snaps the UI back for a frame.
+     * The window is a backstop: if the skip never lands, truth wins after [OPTIMISTIC_SKIP_WINDOW_MS]
+     * rather than leaving the wrong track on screen forever.
+     */
+    private fun applyOptimisticSkip(to: TrackInfo?) {
+        val target = to ?: return
+        optimisticSkipFromUri = _playback.value.track?.uri
+        optimisticSkipAt = System.currentTimeMillis()
+        _playback.value = _playback.value.copy(
+            track = target,
+            positionMs = 0,
+            durationMs = target.durationMs
+        )
+        // The accent palette is as much of the "did it react" impression as the title is.
+        ThemeController.updateFromArt(target.albumArt)
+    }
+
     fun skipNext() {
+        applyOptimisticSkip(nextTrackPreview.value)
         commandJob?.cancel()
         lastCommandTs = System.currentTimeMillis()
         lastCommandName = "skipNext"
@@ -1614,6 +1658,7 @@ class PlaybackViewModel : ViewModel() {
             return
         }
         val pos = _playback.value.positionMs
+        applyOptimisticSkip(prevTrackPreview.value)
         commandJob?.cancel()
         lastCommandTs = System.currentTimeMillis()
         lastCommandName = "skipPrevious"
@@ -3277,6 +3322,13 @@ class PlaybackViewModel : ViewModel() {
          *  restart the track instead of going to the previous one. Matches the
          *  behavior most music players use. */
         private const val PREV_RESTART_THRESHOLD_MS = 3000L
+
+        /**
+         * How long an optimistic skip outranks the dealer's view. Long enough to cover a slow
+         * confirmation, short enough that a skip which never lands corrects itself rather than
+         * stranding the UI on a track that isn't playing.
+         */
+        private const val OPTIMISTIC_SKIP_WINDOW_MS = 8000L
 
         /** Cap on best-effort localNext() steps when a queue row has no uid (skipToTrack impossible).
          *  Deep no-uid jumps become approximate; we log when capped so the user can tap again. */


### PR DESCRIPTION
A skip now paints the next (or previous) track immediately from `nextTrackPreview`/`prevTrackPreview`, including the accent palette, instead of waiting for the dealer to echo the new state and for ExoPlayer to load it.

A state push still describing the track we left is held off for 8s so it cannot revert the UI for a frame before the real one lands; after that window truth wins, so a skip that never happens corrects itself.

Adds `prevTrackPreview` from `state.prev_tracks.last()`, mirroring the existing `nextTrackPreview`.

Scaffolding on purpose: it stands in for what the web player gets for free by walking its state-machine graph locally (`Application.ts` `_transitionTo`). Confined to `applyOptimisticSkip` plus one guard in `updatePlaybackFromState` so it lifts out cleanly when the local state machine owns playback state.

Known limit: only one step ahead. Several fast taps still lag, because `nextTrackPreview` is a single value rather than a cursor into the graph.

Closes #560