### PR TITLE
Show the downloaded checkmark for tracks matched by title and artist

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
@@ -205,6 +205,19 @@ object Downloads {
         }
     }
 
+    /**
+     * Whether [trackUri] is downloaded, checking the exact uri first and falling back to
+     * title/artist like [ch.snepilatch.app.playback.AudioSourceResolver.localOrNull] does to
+     * resolve playback. Without this, a track that only matches through the fallback plays from
+     * disk correctly but every checkmark in the UI still called it not downloaded.
+     *
+     * Pure over [rows], like [matchByMetadata]: callers pass whatever [rows] StateFlow snapshot
+     * they already collected, so this stays cheap enough to call per row in a list.
+     */
+    fun isDownloaded(rows: List<DownloadedTrack>, trackUri: String, title: String? = null, artist: String? = null): Boolean =
+        rows.any { it.trackUri == trackUri } ||
+            (!title.isNullOrBlank() && matchByMetadata(rows, title, artist.orEmpty()) != null)
+
     /** Case- and width-insensitive: half- and full-width forms of a title are the same song. */
     private fun normalize(value: String): String =
         java.text.Normalizer.normalize(value.trim(), java.text.Normalizer.Form.NFKC).lowercase()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -240,10 +240,11 @@ fun TrackRow(
     val isPlaying = currentUri == track.uri && playing
     val theme by ThemeController.themeColors.collectAsState()
     val accent = theme.primary
-    // One set for the whole list, so a row costs a lookup rather than a query.
-    val downloadedUris by Downloads.downloaded.collectAsState()
+    // One list for the whole screen, so a row costs a scan rather than a query. Falls back to
+    // title/artist like playback does, so a relinked track's checkmark agrees with what plays.
+    val downloadedRows by Downloads.rows.collectAsState()
     val inFlight by Downloads.inProgress.collectAsState()
-    val isDownloaded = track.uri in downloadedUris
+    val isDownloaded = Downloads.isDownloaded(downloadedRows, track.uri, track.name, track.artist)
     val isDownloading = track.uri in inFlight
 
     Row(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -266,8 +266,10 @@ fun DetailScreen(vm: PlaybackViewModel) {
                 // Albums and playlists are a fixed set of tracks worth keeping; an artist page just
                 // lists their popular songs, so downloading "an artist" means nothing.
                 val downloadable = detail.type in setOf("album", "playlist", "collection")
-                // Flips to a tick once every track is on disk, and then removes them instead.
-                val downloadedUris by Downloads.downloaded.collectAsState()
+                // Flips to a tick once every track is on disk, and then removes them instead. Falls
+                // back to title/artist per track like playback does, so a relinked track that only
+                // matches that way still counts toward "all downloaded".
+                val downloadedRows by Downloads.rows.collectAsState()
                 val inFlight by Downloads.inProgress.collectAsState()
                 val downloading = detail.tracks.any { it.uri in inFlight }
                 // detail.tracks is one loaded page. Downloading it would silently cover the first 50 of
@@ -277,7 +279,7 @@ fun DetailScreen(vm: PlaybackViewModel) {
                 // with no confirmation while the rest stayed downloaded.
                 val loadingAll by detailVm.isLoadingAll.collectAsState()
                 val allDownloaded = !hasMore && detail.tracks.isNotEmpty() &&
-                    detail.tracks.all { it.uri in downloadedUris }
+                    detail.tracks.all { Downloads.isDownloaded(downloadedRows, it.uri, it.name, it.artist) }
                 if (downloadable) {
                     IconButton(
                         onClick = {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -1189,12 +1189,14 @@ private fun NowPlayingMenu(
             val joinJamLabel = stringResource(R.string.join_jam)
             val shareContext = LocalContext.current
             val downloadCtx = androidx.compose.ui.platform.LocalContext.current
-            val downloadedUris by Downloads.downloaded.collectAsState()
+            // Falls back to title/artist like playback does, so a relinked track's menu label
+            // agrees with what's actually on disk.
+            val downloadedRows by Downloads.rows.collectAsState()
             // In-flight as well as downloaded, like every track row: isDownloaded is still false while
             // the fetch runs, so without this the entry looked untouched and a second tap started a
             // second download of the same track.
             val inFlight by Downloads.inProgress.collectAsState()
-            val isDownloaded = track?.uri?.let { it in downloadedUris } == true
+            val isDownloaded = track?.let { Downloads.isDownloaded(downloadedRows, it.uri, it.name, it.artist) } == true
             val isDownloading = track?.uri?.let { it in inFlight } == true
             val downloadLabel = when {
                 isDownloading -> stringResource(R.string.downloading)

--- a/src/app/src/test/java/ch/snepilatch/app/download/FindByMetadataTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/download/FindByMetadataTest.kt
@@ -1,7 +1,9 @@
 package ch.snepilatch.app.download
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -63,5 +65,34 @@ class FindByMetadataTest {
     @Test
     fun aBlankTitleNeverMatches() {
         assertNull(match("", "GEMN"))
+    }
+
+    // --- isDownloaded: the checkmark's uri-then-metadata lookup, same fallback playback uses ---
+
+    @Test
+    fun isDownloadedMatchesByExactUriRegardlessOfMetadata() {
+        assertTrue(Downloads.isDownloaded(listOf(row), row.trackUri, title = "Some Other Title", artist = "Someone Else"))
+    }
+
+    @Test
+    fun isDownloadedFallsBackToMetadataWhenTheUriDiffers() {
+        assertTrue(
+            Downloads.isDownloaded(
+                listOf(row),
+                trackUri = "spotify:track:relinkedIdNotInTheIndex",
+                title = "ファタール - Fatal",
+                artist = "GEMN, Kento Nakajima, Tatsuya Kitani",
+            )
+        )
+    }
+
+    @Test
+    fun isDownloadedIsFalseWhenNeitherUriNorMetadataMatch() {
+        assertFalse(Downloads.isDownloaded(listOf(row), "spotify:track:notDownloaded", "Another Song", "Nobody"))
+    }
+
+    @Test
+    fun isDownloadedIsFalseForAMissingUriAndNoMetadataToFallBackOn() {
+        assertFalse(Downloads.isDownloaded(listOf(row), "spotify:track:notDownloaded"))
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Downloads.isDownloaded`, the same uri-then-title/artist fallback `AudioSourceResolver.localOrNull` already uses for playback
- Switches the three places that only checked the exact uri (playlist/library rows, the album/playlist header badge, the Now Playing download menu label) to use it, so a relinked track's checkmark agrees with what actually plays

Closes #568