### PR TITLE
Require loaded media before taking the hot resume path

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -671,12 +671,27 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         }
     }
 
+    /**
+     * Whether ExoPlayer still holds something [syncPlay] could resume.
+     *
+     * Callers decide between resuming what is loaded and re-resolving the stream from scratch, and
+     * the answer is not the same as "the app thinks it is streaming" — the service can be reclaimed
+     * or the player released while paused, leaving that flag stale.
+     *
+     * Main thread only: ExoPlayer is confined to the thread that created it.
+     */
+    fun hasLoadedMedia(): Boolean = player.mediaItemCount > 0
+
     fun syncPlay(positionMs: Long) {
         mainHandler.post {
             if (player.mediaItemCount > 0) {
                 player.seekTo(positionMs)
                 player.play()
                 updateNotification()
+            } else {
+                // Silence here was a resume that reported itself as succeeding while never asking for
+                // audio, which left nothing in the log to explain a play button that did nothing.
+                LokiLogger.w(TAG, "syncPlay ignored — ExoPlayer holds no media (caller should cold start)")
             }
         }
     }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -1217,7 +1217,14 @@ class PlaybackViewModel : ViewModel() {
                     return@launch
                 }
                 if (action == "resume") {
-                    if (isStreaming.value) {
+                    // `isStreaming` says we loaded a stream at some point, not that ExoPlayer still
+                    // holds it: the service can be reclaimed or the player released while paused, and
+                    // nothing clears the flag when that happens. Resuming on the flag alone flipped the
+                    // UI to playing and reported the position to Spfy while `syncPlay` silently
+                    // returned — a play button that did nothing, however many times it was tapped.
+                    val canResumeLoaded = isStreaming.value &&
+                        withContext(Dispatchers.Main) { MusicPlaybackService.instance?.hasLoadedMedia() == true }
+                    if (canResumeLoaded) {
                         // Hot path: ExoPlayer is already loaded — flip the UI to playing
                         // and start audio locally + sync Spfy Connect.
                         _playback.value = _playback.value.copy(isPlaying = true, isPaused = false)
@@ -1226,6 +1233,13 @@ class PlaybackViewModel : ViewModel() {
                         // Local state report — never fails the way a command can, so no transfer/retry needed.
                         p.localResume(_playback.value.positionMs)
                     } else {
+                        if (isStreaming.value) {
+                            // The stream is gone underneath us; drop the claim so the cold start below
+                            // reloads rather than trusting what it finds.
+                            LokiLogger.w(TAG, "resume: streaming flag set but ExoPlayer has no media — cold starting")
+                            isStreaming.value = false
+                            currentStreamUri = null
+                        }
                         // Cold start: nothing loaded in ExoPlayer yet. Mirror the Spfy
                         // web player's protocol — fetch track metadata directly (no WS,
                         // no Spfy state changes), claim the device with

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackTestRig.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/PlaybackTestRig.kt
@@ -58,8 +58,12 @@ class PlaybackTestRig {
      * Put the VM into "streaming locally" state so handleRemote* exercise the
      * streaming branches. The default state is "not streaming".
      */
-    fun seedStreaming(positionMs: Long = 0L, isPaused: Boolean = false) {
+    fun seedStreaming(positionMs: Long = 0L, isPaused: Boolean = false, hasLoadedMedia: Boolean = true) {
         vm.isStreaming.value = true
+        // Streaming and "ExoPlayer still holds the media" are separate facts; resume checks the second
+        // one. Default to loaded so this stays "we are playing normally", and pass false for the case
+        // where the service lost the media while the flag stayed set.
+        every { service.hasLoadedMedia() } returns hasLoadedMedia
         vm._playback.value = PlaybackUiState(
             track = TrackInfo(uri = "spotify:track:test", name = "Test", artist = "Tester", albumArt = null, durationMs = 200_000),
             isPlaying = !isPaused,

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/ResumeWithoutLoadedMediaTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/ResumeWithoutLoadedMediaTest.kt
@@ -1,0 +1,59 @@
+package ch.snepilatch.app.viewmodel
+
+import io.mockk.coVerify
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression tests for issue #589: resume picked its path from `isStreaming` alone.
+ *
+ * That flag says a stream was loaded at some point, not that ExoPlayer still holds it — the service
+ * can be reclaimed or the player released while paused, and nothing clears it when that happens.
+ * Resuming on the flag alone flipped the UI to playing and reported the position to Spfy while
+ * `syncPlay` hit its `mediaItemCount > 0` guard and returned, so no audio was ever requested and
+ * tapping play again just repeated it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResumeWithoutLoadedMediaTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() = rig.install()
+
+    @After
+    fun tearDown() = rig.uninstall()
+
+    /** The bug: streaming flag set, media gone. Resume must not pretend the hot path can work. */
+    @Test
+    fun resumeWithStreamingFlagButNoLoadedMedia_doesNotTakeTheHotPath() {
+        rig.seedStreaming(positionMs = 42_000, isPaused = true, hasLoadedMedia = false)
+
+        rig.vm.togglePlayPause()
+        runBlocking { rig.vm.awaitCommandForTest() }
+
+        verify(exactly = 0) { rig.service.syncPlay(any()) }
+        coVerify(exactly = 0) { rig.player.localResume(any()) }
+        assertFalse(
+            "the stale streaming claim must be dropped so the cold start reloads",
+            rig.vm.isStreaming.value
+        )
+    }
+
+    /** The other half: with media actually loaded, resume still resumes rather than cold starting. */
+    @Test
+    fun resumeWithLoadedMedia_stillTakesTheHotPath() {
+        rig.seedStreaming(positionMs = 42_000, isPaused = true, hasLoadedMedia = true)
+
+        rig.vm.togglePlayPause()
+        runBlocking { rig.vm.awaitCommandForTest() }
+
+        verify(exactly = 1) { rig.service.syncPlay(42_000) }
+        coVerify(exactly = 1) { rig.player.localResume(42_000) }
+    }
+}


### PR DESCRIPTION
Resume chose its path from `isStreaming` alone, which only says a stream was loaded at some point. When the service is reclaimed or the player released while paused, `syncPlay` returns at its `mediaItemCount > 0` guard and nothing asks for audio, while the UI flips to playing and `localResume` reports the position to Spfy. Resume now checks that ExoPlayer still holds media, clears the stale claim and cold starts otherwise, and `syncPlay` logs when it ignores a call.

Closes #589