### PR TITLE
Report audio focus changes to Spfy instead of acting on them

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -151,6 +151,19 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     var onShuffleToggle: (() -> Unit)? = null
     var onRepeatToggle: (() -> Unit)? = null
 
+    /**
+     * Audio focus moved, so tell Spfy where we now stand — and nothing else.
+     *
+     * These are deliberately not [onPlay]/[onPause]: those are wired to a *toggle*, which decides
+     * from UI state rather than from the event, and which drives the local player. ExoPlayer already
+     * owns focus ([setAudioAttributes] with `handleAudioFocus = true`): it suppresses itself on a
+     * transient loss and resumes itself when focus returns. Re-issuing a local resume on top is what
+     * took focus straight back off whatever app had asked for it. All that is left for us is the
+     * report, because Spfy's cloud clock keeps advancing while our audio is muted.
+     */
+    var onAudioFocusPaused: (() -> Unit)? = null
+    var onAudioFocusResumed: (() -> Unit)? = null
+
     // Notification custom button state
     var isLiked: Boolean = false
     var isShuffling: Boolean = false
@@ -163,10 +176,6 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
     // Which extra buttons to show: "like", "shuffle", "repeat"
     var notificationLeftButton: String = "repeat"
     var notificationRightButton: String = "like"
-
-    /** True while playback is paused because another app holds transient audio focus.
-     *  Used to auto-resume Spfy when focus returns. */
-    private var wasSuppressedByFocus = false
 
     // Control-plane keep-awake. ExoPlayer's WAKE_MODE_NETWORK only holds a wake/Wi-Fi lock while the
     // PLAYER needs the network (i.e. buffering); once a track is buffered it lets the radio sleep. But
@@ -325,33 +334,33 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
                     openAudioEffectSession = false
                 }
 
-                // Full (permanent) audio focus loss — e.g. phone call answered.
-                // ExoPlayer flips playWhenReady to false. Mirror to Spfy side.
+                // Permanent focus loss (a call answered, another app taking over): ExoPlayer clears
+                // playWhenReady and will not come back on its own, which is correct. Report it.
                 if (!playWhenReady && reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS) {
-                    LokiLogger.i(TAG, "Pausing Spfy side due to audio focus loss")
-                    onPause?.invoke()
+                    LokiLogger.i(TAG, "Audio focus lost for good — reporting pause to Spfy")
+                    onAudioFocusPaused?.invoke()
                 }
             }
 
+            /**
+             * Transient focus loss and its return, reported to Spfy and nothing more.
+             *
+             * ExoPlayer handles the focus itself — it suppresses playback here and un-suppresses when
+             * focus comes back. The only thing it cannot know is that we are also a Spfy Connect
+             * device whose cloud clock keeps advancing while our audio is muted; left unreported the
+             * track "finishes" server-side and the next one auto-plays over whatever app took focus.
+             *
+             * So this reports and never commands. Driving the local player from here is what made the
+             * app un-shareable: resuming on focus return re-requested focus and took it straight back
+             * off the other app.
+             */
             override fun onPlaybackSuppressionReasonChanged(playbackSuppressionReason: Int) {
-                // Transient focus loss (e.g. Instagram video starts) — ExoPlayer keeps
-                // playWhenReady = true but suppresses playback. Spfy's cloud position
-                // keeps advancing though, so we must mirror the pause to the Spfy side
-                // — otherwise the muted track ends and the next one auto-plays over the
-                // focus-stealing app. Resume both sides when focus returns.
-                when (playbackSuppressionReason) {
-                    Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS -> {
-                        LokiLogger.i(TAG, "Pausing Spfy side due to transient focus loss")
-                        wasSuppressedByFocus = true
-                        onPause?.invoke()
-                    }
-                    Player.PLAYBACK_SUPPRESSION_REASON_NONE -> {
-                        if (wasSuppressedByFocus) {
-                            wasSuppressedByFocus = false
-                            LokiLogger.i(TAG, "Resuming Spfy side — transient focus restored")
-                            onPlay?.invoke()
-                        }
-                    }
+                if (playbackSuppressionReason == Player.PLAYBACK_SUPPRESSION_REASON_TRANSIENT_AUDIO_FOCUS_LOSS) {
+                    LokiLogger.i(TAG, "Transient focus loss — reporting pause to Spfy")
+                    onAudioFocusPaused?.invoke()
+                } else {
+                    LokiLogger.i(TAG, "Playback no longer suppressed — reporting play to Spfy")
+                    onAudioFocusResumed?.invoke()
                 }
             }
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -2173,28 +2173,31 @@ class PlaybackViewModel : ViewModel() {
     }
 
     /**
-     * ExoPlayer suppressed itself because another app took audio focus. Tell Spfy, touch nothing else.
+     * Audio focus moved, so report it to Spfy — and *only* report it.
      *
-     * No `syncPause` here: the audio has already stopped, and issuing a local transport command is
-     * what used to re-request focus and yank it back off the other app. Internal for the test rig.
+     * Both directions deliberately leave [_playback] and ExoPlayer alone, because the echo does that
+     * work already: Spfy pushes the new state straight back, and [handleRemotePause]/[handleRemotePlay]
+     * are what pause and resume the local player. Two earlier attempts got this wrong from opposite
+     * sides. Driving the local player from here re-requested audio focus and took it back off the app
+     * that had asked for it. Then merely pre-setting `isPaused = false` here was just as bad: the echo
+     * arrives, [handleRemotePlay] finds the flag already cleared, its `isPaused` guard fails and the
+     * audio never restarts — Spfy shows playing while the phone stays silent.
+     *
+     * Internal for the test rig.
      */
     internal fun handleAudioFocusPaused() {
         if (!isStreaming.value) return
-        _playback.value = _playback.value.copy(isPlaying = false, isPaused = true)
-        stopPositionTicker()
         launchWithPlayer("focusPaused") { p -> p.localPause(_playback.value.positionMs) }
     }
 
     /**
-     * Focus came back and ExoPlayer resumed on its own. Report that, and again touch nothing else.
+     * Focus came back. Report it and let the echo restart the audio, per [handleAudioFocusPaused].
      *
-     * Fires on every un-suppression, so it must be safe to run when we were never suppressed —
-     * reporting the position we are already at is a no-op as far as Spfy is concerned.
+     * Fires on every un-suppression, including when we were never suppressed, so it has to be safe to
+     * run spuriously — reporting the position we already hold is a no-op as far as Spfy is concerned.
      */
     internal fun handleAudioFocusResumed() {
         if (!isStreaming.value) return
-        _playback.value = _playback.value.copy(isPlaying = true, isPaused = false)
-        startPositionTicker()
         launchWithPlayer("focusResumed") { p -> p.localResume(_playback.value.positionMs) }
     }
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -2172,10 +2172,38 @@ class PlaybackViewModel : ViewModel() {
         wirePlaybackLifecycleCallbacks(svc)
     }
 
+    /**
+     * ExoPlayer suppressed itself because another app took audio focus. Tell Spfy, touch nothing else.
+     *
+     * No `syncPause` here: the audio has already stopped, and issuing a local transport command is
+     * what used to re-request focus and yank it back off the other app. Internal for the test rig.
+     */
+    internal fun handleAudioFocusPaused() {
+        if (!isStreaming.value) return
+        _playback.value = _playback.value.copy(isPlaying = false, isPaused = true)
+        stopPositionTicker()
+        launchWithPlayer("focusPaused") { p -> p.localPause(_playback.value.positionMs) }
+    }
+
+    /**
+     * Focus came back and ExoPlayer resumed on its own. Report that, and again touch nothing else.
+     *
+     * Fires on every un-suppression, so it must be safe to run when we were never suppressed —
+     * reporting the position we are already at is a no-op as far as Spfy is concerned.
+     */
+    internal fun handleAudioFocusResumed() {
+        if (!isStreaming.value) return
+        _playback.value = _playback.value.copy(isPlaying = true, isPaused = false)
+        startPositionTicker()
+        launchWithPlayer("focusResumed") { p -> p.localResume(_playback.value.positionMs) }
+    }
+
     /** Play / pause / skip / seek — forwarded through KotifyClient's local-device transport (uncapped). */
     private fun wireTransportCallbacks(svc: MusicPlaybackService) {
         svc.onPlay = { togglePlayPause() }
         svc.onPause = { togglePlayPause() }
+        svc.onAudioFocusPaused = { handleAudioFocusPaused() }
+        svc.onAudioFocusResumed = { handleAudioFocusResumed() }
         svc.onSkipNext = {
             viewModelScope.launch(Dispatchers.IO) {
                 try { player?.localNext() }

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/AudioFocusReportOnlyTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/AudioFocusReportOnlyTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.After
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -12,14 +11,14 @@ import org.junit.Test
 /**
  * Regression tests for issue #571: Snepilatch would not let another app play.
  *
- * ExoPlayer is built with `handleAudioFocus = true`, so it owns focus entirely — it suppresses itself
- * on a transient loss and un-suppresses when focus returns. Android's guidance is that an app with
- * automatic handling should contain no code responding to focus changes. Snepilatch had some anyway:
- * on focus return it called `togglePlayPause()`, which resumed the local player, which re-requested
- * focus and took it straight back off whatever app had asked for it.
+ * ExoPlayer is built with `handleAudioFocus = true`, so it owns focus entirely, and Android's guidance
+ * is that an app with automatic handling should contain no code responding to focus changes. Snepilatch
+ * had some anyway: on focus return it called `togglePlayPause()`, which restarted the local player,
+ * re-requested focus and took it straight back off whatever app had asked for it.
  *
- * What remains is a report to Spfy, because we are also a Connect device whose cloud clock keeps
- * advancing while our audio is muted. These tests pin "report, never command".
+ * All that is left is a report to Spfy, because we are also a Connect device whose cloud clock keeps
+ * advancing while our audio is muted. The local player is moved by the *echo* of that report through
+ * [PlaybackViewModel.handleRemotePause] / [PlaybackViewModel.handleRemotePlay], not from here.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class AudioFocusReportOnlyTest {
@@ -33,7 +32,7 @@ class AudioFocusReportOnlyTest {
     fun tearDown() = rig.uninstall()
 
     @Test
-    fun focusLoss_reportsPauseToSpfyWithoutTouchingTheLocalPlayer() {
+    fun focusLoss_reportsPauseAndLeavesTheLocalPlayerAlone() {
         rig.seedStreaming(positionMs = 30_000)
 
         rig.vm.handleAudioFocusPaused()
@@ -41,25 +40,41 @@ class AudioFocusReportOnlyTest {
         coVerify(exactly = 1) { rig.player.localPause(30_000) }
         verify(exactly = 0) { rig.service.syncPause() }
         verify(exactly = 0) { rig.service.syncPlay(any()) }
-        assertTrue(rig.vm._playback.value.isPaused)
     }
 
-    /** The actual #571 bug: regaining focus must not start the local player back up. */
     @Test
-    fun focusRegain_reportsPlayToSpfyWithoutRestartingTheLocalPlayer() {
+    fun focusRegain_reportsResumeAndLeavesTheLocalPlayerAlone() {
         rig.seedStreaming(positionMs = 30_000, isPaused = true)
 
         rig.vm.handleAudioFocusResumed()
 
         coVerify(exactly = 1) { rig.player.localResume(30_000) }
         verify(exactly = 0) { rig.service.syncPlay(any()) }
-        assertFalse(rig.vm._playback.value.isPaused)
     }
 
     /**
-     * Un-suppression fires whether or not we were ever suppressed, and while idle there is nothing to
-     * report — an unsolicited resume would claim the device.
+     * The bug that survived the first fix: focus regain must not pre-clear `isPaused`.
+     *
+     * [PlaybackViewModel.handleRemotePlay] only restarts ExoPlayer when it still sees `isPaused`, so
+     * clearing the flag here made the echo a no-op — Spfy showed playing while the phone stayed silent.
      */
+    @Test
+    fun focusRegain_leavesIsPausedSetSoTheEchoStillRestartsTheAudio() {
+        rig.seedStreaming(positionMs = 30_000, isPaused = true)
+
+        rig.vm.handleAudioFocusResumed()
+
+        assertTrue(
+            "isPaused must survive the report, or handleRemotePlay's guard skips syncPlay",
+            rig.vm._playback.value.isPaused
+        )
+
+        // The echo lands and *this* is what restarts the audio.
+        rig.vm.handleRemotePlay(30_000)
+        verify(exactly = 1) { rig.service.syncPlay(30_000) }
+    }
+
+    /** Un-suppression fires whether or not we were suppressed; idle means nothing to report. */
     @Test
     fun focusCallbacksAreInertWhenNotStreaming() {
         rig.vm.handleAudioFocusResumed()

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/AudioFocusReportOnlyTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/AudioFocusReportOnlyTest.kt
@@ -1,0 +1,71 @@
+package ch.snepilatch.app.viewmodel
+
+import io.mockk.coVerify
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Regression tests for issue #571: Snepilatch would not let another app play.
+ *
+ * ExoPlayer is built with `handleAudioFocus = true`, so it owns focus entirely — it suppresses itself
+ * on a transient loss and un-suppresses when focus returns. Android's guidance is that an app with
+ * automatic handling should contain no code responding to focus changes. Snepilatch had some anyway:
+ * on focus return it called `togglePlayPause()`, which resumed the local player, which re-requested
+ * focus and took it straight back off whatever app had asked for it.
+ *
+ * What remains is a report to Spfy, because we are also a Connect device whose cloud clock keeps
+ * advancing while our audio is muted. These tests pin "report, never command".
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AudioFocusReportOnlyTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() = rig.install()
+
+    @After
+    fun tearDown() = rig.uninstall()
+
+    @Test
+    fun focusLoss_reportsPauseToSpfyWithoutTouchingTheLocalPlayer() {
+        rig.seedStreaming(positionMs = 30_000)
+
+        rig.vm.handleAudioFocusPaused()
+
+        coVerify(exactly = 1) { rig.player.localPause(30_000) }
+        verify(exactly = 0) { rig.service.syncPause() }
+        verify(exactly = 0) { rig.service.syncPlay(any()) }
+        assertTrue(rig.vm._playback.value.isPaused)
+    }
+
+    /** The actual #571 bug: regaining focus must not start the local player back up. */
+    @Test
+    fun focusRegain_reportsPlayToSpfyWithoutRestartingTheLocalPlayer() {
+        rig.seedStreaming(positionMs = 30_000, isPaused = true)
+
+        rig.vm.handleAudioFocusResumed()
+
+        coVerify(exactly = 1) { rig.player.localResume(30_000) }
+        verify(exactly = 0) { rig.service.syncPlay(any()) }
+        assertFalse(rig.vm._playback.value.isPaused)
+    }
+
+    /**
+     * Un-suppression fires whether or not we were ever suppressed, and while idle there is nothing to
+     * report — an unsolicited resume would claim the device.
+     */
+    @Test
+    fun focusCallbacksAreInertWhenNotStreaming() {
+        rig.vm.handleAudioFocusResumed()
+        rig.vm.handleAudioFocusPaused()
+
+        coVerify(exactly = 0) { rig.player.localResume(any()) }
+        coVerify(exactly = 0) { rig.player.localPause(any()) }
+    }
+}


### PR DESCRIPTION
ExoPlayer is built with `handleAudioFocus = true`, so it already suppresses itself on a transient focus loss and un-suppresses when focus returns. The app resumed on top of that through `togglePlayPause()`, which restarted the local player, re-requested focus and took it back off whatever app had asked for it — so nothing else could play.

Focus now only produces a report to Spfy, which is the one thing ExoPlayer cannot know: we are also a Connect device whose cloud clock keeps advancing while our audio is muted, and left unreported the track finishes server-side and the next one auto-plays over the other app. The `wasSuppressedByFocus` flag and the resume command are gone, and focus no longer routes through the `onPlay`/`onPause` toggle, which decided from UI state rather than from the event.

Kept on the suppression-reason callback rather than `onIsPlayingChanged`: `isPlaying` is also false while buffering, so the simpler callback would report a pause to Spfy on every mid-track rebuffer.

Closes #571