### PR TITLE
Reword the nightly build warning

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
@@ -90,11 +90,8 @@ fun UpdateDialog(
                             modifier = Modifier.padding(12.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            Icon(
-                                Icons.Rounded.ErrorOutline,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onErrorContainer
-                            )
+                            // No Icon here: the string leads with a warning glyph, and an
+                            // ErrorOutline next to it read as two warnings stacked.
                             Text(
                                 stringResource(R.string.nightly_build_warning),
                                 color = MaterialTheme.colorScheme.onErrorContainer,

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -122,7 +122,7 @@
     <string name="whats_new">Was isch neu:</string>
     <string name="update_now">Jetz aktualisiere</string>
     <string name="later">Spöter</string>
-    <string name="nightly_build_warning">Das isch en Nightly-Build — ungprüeft und chönnt instabil si. Nutzig uf eigeni Gfahr.</string>
+    <string name="nightly_build_warning">⚠️ Nightly-Build — ungprüeft und chönnt instabil si. Nur sichtbar für Lüt uf em Nightly-Update-Kanal. Nutzig uf eigeni Gfahr.</string>
     <string name="enable_unknown_apps">Erlaub Snepilatch i de aktuelle Iistellige s Installiere vo Apps und tipp de wieder uf Jetz aktualisiere.</string>
 
     <!-- Devices -->

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -109,7 +109,7 @@
     <string name="whats_new">Was ist neu:</string>
     <string name="update_now">Jetzt aktualisieren</string>
     <string name="later">Später</string>
-    <string name="nightly_build_warning">Dies ist ein Nightly-Build — ungeprüft und möglicherweise instabil. Nutzung auf eigenes Risiko.</string>
+    <string name="nightly_build_warning">⚠️ Nightly-Build — ungeprüft und möglicherweise instabil. Nur für Nutzer im Nightly-Update-Kanal sichtbar. Nutzung auf eigenes Risiko.</string>
     <string name="enable_unknown_apps">Erlaube Snepilatch in den geöffneten Einstellungen das Installieren von Apps und tippe dann erneut auf Jetzt aktualisieren.</string>
 
     <!-- Devices -->

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -109,7 +109,7 @@
     <string name="whats_new">Что нового:</string>
     <string name="update_now">Обновить</string>
     <string name="later">Позже</string>
-    <string name="nightly_build_warning">Это ночная сборка — непроверенная и может быть нестабильной. Используйте на свой риск.</string>
+    <string name="nightly_build_warning">⚠️ Ночная сборка — непроверенная и может быть нестабильной. Видна только пользователям канала обновлений Nightly. Используйте на свой риск.</string>
     <string name="enable_unknown_apps">Разрешите Snepilatch устанавливать приложения в открывшихся настройках, затем снова нажмите «Обновить».</string>
 
     <!-- Devices -->

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="whats_new">What\'s new:</string>
     <string name="update_now">Update Now</string>
     <string name="later">Later</string>
-    <string name="nightly_build_warning">This is a nightly build — unreviewed and may be unstable. Install at your own risk.</string>
+    <string name="nightly_build_warning">⚠️ Nightly build — unreviewed and may be unstable. Only visible to users on the Nightly update channel. Install at your own risk.</string>
     <string name="enable_unknown_apps">Allow Snepilatch to install apps in the settings that just opened, then tap Update Now again.</string>
 
     <!-- Devices -->


### PR DESCRIPTION
New wording in all four locales, and it now says the build is only visible to people on the Nightly channel, which was the part users had no way to know.

The string leads with a warning glyph, so the `ErrorOutline` icon beside it is gone. Two warning symbols side by side read as a mistake.

Closes #596