### PR TITLE
Use the exact nightly warning wording everywhere

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -87,7 +87,7 @@ jobs:
             --title "${{ steps.tag.outputs.tag }}" \
             --prerelease \
             --generate-notes \
-            --notes "⚠️ **Nightly build** — unreviewed and may be unstable. Only visible to users on the Nightly update channel. Install at your own risk."
+            --notes "⚠️ Nightly build. Unreviewed, probably buggy. Install at your own risk."
 
   build:
     needs: cut-nightly

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -122,7 +122,7 @@
     <string name="whats_new">Was isch neu:</string>
     <string name="update_now">Jetz aktualisiere</string>
     <string name="later">Spöter</string>
-    <string name="nightly_build_warning">⚠️ Nightly-Build — ungprüeft und chönnt instabil si. Nur sichtbar für Lüt uf em Nightly-Update-Kanal. Nutzig uf eigeni Gfahr.</string>
+    <string name="nightly_build_warning">⚠️ Nightly-Build. Ungprüeft, wahrschinlich fehlerhaft. Nutzig uf eigeni Gfahr.</string>
     <string name="enable_unknown_apps">Erlaub Snepilatch i de aktuelle Iistellige s Installiere vo Apps und tipp de wieder uf Jetz aktualisiere.</string>
 
     <!-- Devices -->

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -109,7 +109,7 @@
     <string name="whats_new">Was ist neu:</string>
     <string name="update_now">Jetzt aktualisieren</string>
     <string name="later">Später</string>
-    <string name="nightly_build_warning">⚠️ Nightly-Build — ungeprüft und möglicherweise instabil. Nur für Nutzer im Nightly-Update-Kanal sichtbar. Nutzung auf eigenes Risiko.</string>
+    <string name="nightly_build_warning">⚠️ Nightly-Build. Ungeprüft, wahrscheinlich fehlerhaft. Nutzung auf eigenes Risiko.</string>
     <string name="enable_unknown_apps">Erlaube Snepilatch in den geöffneten Einstellungen das Installieren von Apps und tippe dann erneut auf Jetzt aktualisieren.</string>
 
     <!-- Devices -->

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -109,7 +109,7 @@
     <string name="whats_new">Что нового:</string>
     <string name="update_now">Обновить</string>
     <string name="later">Позже</string>
-    <string name="nightly_build_warning">⚠️ Ночная сборка — непроверенная и может быть нестабильной. Видна только пользователям канала обновлений Nightly. Используйте на свой риск.</string>
+    <string name="nightly_build_warning">⚠️ Ночная сборка. Непроверенная, вероятно с ошибками. Используйте на свой риск.</string>
     <string name="enable_unknown_apps">Разрешите Snepilatch устанавливать приложения в открывшихся настройках, затем снова нажмите «Обновить».</string>
 
     <!-- Devices -->

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
     <string name="whats_new">What\'s new:</string>
     <string name="update_now">Update Now</string>
     <string name="later">Later</string>
-    <string name="nightly_build_warning">⚠️ Nightly build — unreviewed and may be unstable. Only visible to users on the Nightly update channel. Install at your own risk.</string>
+    <string name="nightly_build_warning">⚠️ Nightly build. Unreviewed, probably buggy. Install at your own risk.</string>
     <string name="enable_unknown_apps">Allow Snepilatch to install apps in the settings that just opened, then tap Update Now again.</string>
 
     <!-- Devices -->


### PR DESCRIPTION
Sets the nightly warning to the requested wording exactly, in both places it appears: the four locale strings shown in the update dialog, and the `--notes` text on the prerelease that `nightly.yml` publishes.

Shorter than what #596 shipped, and it drops the sentence about the Nightly channel. Both places now carry byte-identical text, and the string still leads with the warning glyph so the icon stays removed.