### PR TITLE
Render release notes as markdown in the update dialog

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/MarkdownText.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/MarkdownText.kt
@@ -1,0 +1,88 @@
+package ch.snepilatch.app.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.ui.theme.SpfyLightGray
+import ch.snepilatch.app.ui.theme.SpfyWhite
+
+/**
+ * Enough markdown for a GitHub release body, and no more.
+ *
+ * Release notes use headings, bullets, the occasional quote, and inline bold, links
+ * and code. Anything printed into a plain `Text` shows its syntax, which is what a
+ * changelog full of `**bold**` and `[text](url)` looked like before.
+ *
+ * Block markers become real layout. Inline markers are stripped rather than styled:
+ * the alternative is building an `AnnotatedString` per line, and nothing in a
+ * changelog reads worse for losing its bold. Add that when something needs it.
+ *
+ * Lives here rather than beside the release notes screen because two screens show
+ * the same bodies, and one had already gone without.
+ */
+@Composable
+fun MarkdownText(
+    markdown: String,
+    modifier: Modifier = Modifier,
+    headingColor: Color = SpfyWhite,
+    bodyColor: Color = SpfyLightGray,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        for (line in markdown.lines()) {
+            val trimmed = line.trim()
+            when {
+                trimmed.isEmpty() -> Spacer(Modifier.height(4.dp))
+                trimmed.startsWith("### ") -> Text(
+                    trimmed.removePrefix("### ").cleanMarkdown(),
+                    color = headingColor, fontSize = 14.sp, fontWeight = FontWeight.SemiBold
+                )
+                trimmed.startsWith("## ") -> Text(
+                    trimmed.removePrefix("## ").cleanMarkdown(),
+                    color = headingColor, fontSize = 15.sp, fontWeight = FontWeight.Bold
+                )
+                trimmed.startsWith("# ") -> Text(
+                    trimmed.removePrefix("# ").cleanMarkdown(),
+                    color = headingColor, fontSize = 16.sp, fontWeight = FontWeight.Bold
+                )
+                trimmed.startsWith("- ") || trimmed.startsWith("* ") -> Text(
+                    "  •  ${trimmed.drop(2).cleanMarkdown()}",
+                    color = bodyColor, fontSize = 14.sp, lineHeight = 20.sp
+                )
+                trimmed.startsWith("> ") -> Text(
+                    trimmed.removePrefix("> ").cleanMarkdown(),
+                    color = bodyColor.copy(alpha = 0.7f), fontSize = 13.sp,
+                    modifier = Modifier.padding(start = 12.dp)
+                )
+                else -> Text(
+                    trimmed.cleanMarkdown(),
+                    color = bodyColor, fontSize = 14.sp, lineHeight = 20.sp
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Strip inline markers, leaving the text they wrapped.
+ *
+ * Bold runs before italic on purpose: `*(.+?)*` matches the first two asterisks of
+ * `**bold**`, so the other order turns it into `*bold*`.
+ *
+ * Internal so it can be tested without a Compose harness.
+ */
+internal fun String.cleanMarkdown(): String = this
+    // Bold before italic: see the KDoc above.
+    .replace(Regex("""\*\*(.+?)\*\*"""), "$1")
+    .replace(Regex("""\*(.+?)\*"""), "$1")
+    // Links keep their label and lose the url.
+    .replace(Regex("""\[(.+?)]\((.+?)\)"""), "$1")
+    .replace(Regex("""`(.+?)`"""), "$1")

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/UpdateDialog.kt
@@ -1,6 +1,8 @@
 package ch.snepilatch.app.ui.components
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.SystemUpdate
@@ -146,10 +148,14 @@ fun UpdateDialog(
                             containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
                         )
                     ) {
-                        Text(
-                            updateInfo.releaseNotes.take(500),
-                            modifier = Modifier.padding(12.dp),
-                            style = MaterialTheme.typography.bodySmall
+                        // Scrolled rather than truncated: take(500) used to cut a
+                        // changelog mid-word, and the last entries are the newest.
+                        MarkdownText(
+                            updateInfo.releaseNotes,
+                            modifier = Modifier
+                                .heightIn(max = 220.dp)
+                                .verticalScroll(rememberScrollState())
+                                .padding(12.dp)
                         )
                     }
                 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/ReleaseNotesScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.R
+import ch.snepilatch.app.ui.components.MarkdownText
 import ch.snepilatch.app.ui.components.TightAlertDialog
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.util.UpdateService
@@ -93,53 +94,6 @@ private fun ReleaseNoteCard(note: ReleaseNote, isLatest: Boolean) {
             }
         }
     }
-}
-
-@Composable
-private fun MarkdownText(markdown: String) {
-    // Simple markdown rendering: headers, bullets, bold, links
-    val lines = markdown.lines()
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        for (line in lines) {
-            val trimmed = line.trim()
-            when {
-                trimmed.isEmpty() -> Spacer(Modifier.height(4.dp))
-                trimmed.startsWith("### ") -> Text(
-                    trimmed.removePrefix("### "),
-                    color = SpfyWhite, fontSize = 14.sp, fontWeight = FontWeight.SemiBold
-                )
-                trimmed.startsWith("## ") -> Text(
-                    trimmed.removePrefix("## "),
-                    color = SpfyWhite, fontSize = 15.sp, fontWeight = FontWeight.Bold
-                )
-                trimmed.startsWith("# ") -> Text(
-                    trimmed.removePrefix("# "),
-                    color = SpfyWhite, fontSize = 16.sp, fontWeight = FontWeight.Bold
-                )
-                trimmed.startsWith("- ") || trimmed.startsWith("* ") -> Text(
-                    "  •  ${trimmed.drop(2).cleanMarkdown()}",
-                    color = SpfyLightGray, fontSize = 14.sp, lineHeight = 20.sp
-                )
-                trimmed.startsWith("> ") -> Text(
-                    trimmed.removePrefix("> ").cleanMarkdown(),
-                    color = SpfyLightGray.copy(alpha = 0.7f), fontSize = 13.sp,
-                    modifier = Modifier.padding(start = 12.dp)
-                )
-                else -> Text(
-                    trimmed.cleanMarkdown(),
-                    color = SpfyLightGray, fontSize = 14.sp, lineHeight = 20.sp
-                )
-            }
-        }
-    }
-}
-
-private fun String.cleanMarkdown(): String {
-    return this
-        .replace(Regex("\\*\\*(.+?)\\*\\*"), "$1")  // bold
-        .replace(Regex("\\*(.+?)\\*"), "$1")          // italic
-        .replace(Regex("\\[(.+?)]\\(.+?\\)"), "$1")  // links
-        .replace(Regex("`(.+?)`"), "$1")               // inline code
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/src/app/src/test/java/ch/snepilatch/app/ui/components/CleanMarkdownTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/ui/components/CleanMarkdownTest.kt
@@ -1,0 +1,58 @@
+package ch.snepilatch.app.ui.components
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for the inline stripping behind [MarkdownText] (issue #598).
+ *
+ * The update dialog printed release bodies into a plain `Text`, so a changelog showed
+ * its own syntax. These pin the cases a GitHub release body actually contains.
+ */
+class CleanMarkdownTest {
+
+    @Test
+    fun stripsBold() {
+        assertEquals("Full Changelog", "**Full Changelog**".cleanMarkdown())
+    }
+
+    /**
+     * The ordering trap: `*(.+?)*` matches the first two asterisks of `**bold**`, so
+     * running italic first would leave `*bold*` behind rather than `bold`.
+     */
+    @Test
+    fun boldIsStrippedBeforeItalic() {
+        assertEquals("bold", "**bold**".cleanMarkdown())
+        assertEquals("italic", "*italic*".cleanMarkdown())
+        assertEquals("both bold and italic", "**both bold** and *italic*".cleanMarkdown())
+    }
+
+    @Test
+    fun linksKeepTheirLabel() {
+        assertEquals(
+            "See v3.0.0...v3.1.0 for details",
+            "See [v3.0.0...v3.1.0](https://github.com/a/b/compare/x) for details".cleanMarkdown()
+        )
+    }
+
+    @Test
+    fun stripsInlineCode() {
+        assertEquals("set AUDIT_STAFF to true", "set `AUDIT_STAFF` to true".cleanMarkdown())
+    }
+
+    /** A real release-note line, which is the shape that matters. */
+    @Test
+    fun handlesARealChangelogLine() {
+        assertEquals(
+            "Join a jam from a shared link @PianoNic (#549)",
+            "* Join a jam from a shared link @PianoNic ([#549](https://github.com/x/pull/549))"
+                .removePrefix("* ")
+                .cleanMarkdown()
+        )
+    }
+
+    @Test
+    fun leavesPlainTextAlone() {
+        assertEquals("nothing to strip here", "nothing to strip here".cleanMarkdown())
+    }
+}


### PR DESCRIPTION
The update dialog printed the release body into a plain `Text`, so a changelog showed its own syntax, and `take(500)` cut it mid-word just as the newest entries arrived.

A renderer already existed, private inside `ReleaseNotesScreen`. It is now a shared `MarkdownText` component used by both, so the two screens showing the same bodies cannot drift again. The dialog scrolls the notes inside a bounded height instead of truncating them.

Block markers become layout. Inline markers are stripped rather than styled, which is the existing behaviour: styling each line means building an `AnnotatedString` per line, and nothing in a changelog reads worse for losing its bold. Worth adding when something needs it.

Tests cover the stripping, including the ordering trap where running the italic pattern first turns `**bold**` into `*bold*`.

Closes #598