### PR TITLE
Mask pull request links in the Discord release post

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -197,6 +197,17 @@ jobs:
           description = re.sub(r"^## What's Changed\n*", '', description, flags=re.MULTILINE)
           description = re.sub(r'\*\*Full Changelog[:\*].*', '', description, flags=re.DOTALL)
           description = re.sub(r'📝 \*\*Note:\*\*.*\n*', '', description)
+
+          # GitHub's generated notes end every line with a bare pull request url, which in
+          # an embed means each entry is mostly url. Mask them as #number pointing at the
+          # same place. The lookbehind leaves anything already written as [text](url) alone,
+          # and the compare link in the footer is neither a pull nor an issue url, so it
+          # survives untouched.
+          description = re.sub(
+              r'(?<!\()(https://github\.com/[^/\s]+/[^/\s]+/(?:pull|issues)/(\d+))',
+              r'[#\2](\1)',
+              description,
+          )
           description = description.strip()
 
           if not description:


### PR DESCRIPTION
GitHub''s generated notes end every entry with a bare `https://github.com/.../pull/590`, so the embed was mostly url. They now render as `#590` linking to the same place.

A lookbehind leaves anything already written as `[text](url)` alone, and the compare link in the footer is neither a pull nor an issue url so it is untouched. Verified by running the workflow''s own embedded script against the body from nightly.7 and checking the resulting payload.

Closes #606