### PR TITLE
Let session init outlive the Activity that started it

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -41,8 +41,10 @@ import kotify.cdn.StreamInfo
 import kotify.cdn.StreamResult
 import kotify.session.Session
 import kotify.session.SessionConfig
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -353,6 +355,9 @@ class PlaybackViewModel : ViewModel() {
                 surfaceAuthLost()
             } else {
                 LokiLogger.i(TAG, "Auth recovery: re-initializing session from saved cookies")
+                // Deliberately replacing the current session, so drop the in-flight guard first,
+                // otherwise initialize() waits on the job this is recovering from.
+                initJob = null
                 initialize(savedCookies)
             }
         }
@@ -369,14 +374,71 @@ class PlaybackViewModel : ViewModel() {
         )
     }
 
+    /** [_account] is ViewModel state, not holder state, so an adopting ViewModel has to refetch it. */
+    private suspend fun loadAccount(sess: Session) {
+        val userApi = User(sess)
+        val me = userApi.getCurrentUser()
+        username = me.username
+        SessionHolder.username = me.username
+        val isPremium = userApi.hasPremium()
+        // Get public profile (display name + avatar) from user-profile-view API
+        val pubProfile = userApi.getProfile(username)
+        val displayName = pubProfile.displayName.ifEmpty { username }
+        val imageUrl = pubProfile.imageUrl
+        LokiLogger.i(TAG, "Profile: display=$displayName, user=$username, image=${imageUrl?.take(40)}")
+        _account.value = AccountInfo(
+            username = username,
+            displayName = displayName,
+            isPremium = isPremium,
+            profileImageUrl = imageUrl,
+            userId = username,
+            followers = pubProfile.followers,
+            playlistCount = pubProfile.publicPlaylists
+        )
+        LokiLogger.i(TAG, "User: $username ($displayName), premium: $isPremium")
+    }
+
+    /** Rewire this ViewModel to a session that is already live, without touching the network path. */
+    internal fun adoptRunningSession() {
+        val pc = SessionHolder.player ?: return
+        LokiLogger.i(TAG, "Adopting the running session, device: ${pc.ourDeviceId()}")
+        username = SessionHolder.username
+        wirePlayerConnectCallbacks(pc)
+        wireServiceControls()
+        isInitialized.value = true
+        MusicPlaybackService.instance?.clearError()
+        launchWithSession("adoptAccount") { sess -> loadAccount(sess) }
+        launchWithPlayer("adoptState") { p -> p.getState()?.let { updatePlaybackFromState(it) } }
+    }
+
     fun initialize(cookies: Map<String, String>) {
         startInfiniPlayRepeatGuard()
+
+        // A recreated Activity gets a fresh ViewModel, but not a fresh session: the holder is
+        // process-scoped and still live. Rewire to it rather than tearing it down and paying for the
+        // whole network init again.
+        if (SessionHolder.isReady) {
+            adoptRunningSession()
+            return
+        }
+
+        // An init started by a ViewModel that has since died is still running. Wait for it — clearing
+        // the holder here is what turned a slow init into an app that never got past "connecting".
+        initJob?.takeIf { it.isActive }?.let { running ->
+            LokiLogger.i(TAG, "Init already in flight, waiting for it instead of restarting")
+            viewModelScope.launch {
+                running.join()
+                if (SessionHolder.isReady) adoptRunningSession()
+            }
+            return
+        }
+
         // Clean up any leftover from previous session
         SessionHolder.player?.let {
             try { kotlinx.coroutines.runBlocking { it.disconnect() } } catch (_: Exception) {}
         }
         SessionHolder.clear()
-        viewModelScope.launch(Dispatchers.IO) {
+        initJob = initScope.launch {
             try {
                 val sess = Session(SessionConfig(
                     identifier = "kotify-android",
@@ -403,27 +465,7 @@ class PlaybackViewModel : ViewModel() {
 
                 // Home and library load themselves from HomeViewModel.init / LibraryViewModel.init.
 
-                val userApi = User(sess)
-                val me = userApi.getCurrentUser()
-                username = me.username
-                SessionHolder.username = me.username
-                val isPremium = userApi.hasPremium()
-                // Get public profile (display name + avatar) from user-profile-view API
-                val pubProfile = userApi.getProfile(username)
-                val displayName = pubProfile.displayName.ifEmpty { username }
-                val userId = username
-                val imageUrl = pubProfile.imageUrl
-                LokiLogger.i(TAG, "Profile: display=$displayName, user=$username, image=${imageUrl?.take(40)}")
-                _account.value = AccountInfo(
-                    username = username,
-                    displayName = displayName,
-                    isPremium = isPremium,
-                    profileImageUrl = imageUrl,
-                    userId = username,
-                    followers = pubProfile.followers,
-                    playlistCount = pubProfile.publicPlaylists
-                )
-                LokiLogger.i(TAG, "User: $username ($displayName), premium: $isPremium")
+                loadAccount(sess)
 
                 isInitialized.value = true
                 initRetryCount = 0
@@ -470,6 +512,10 @@ class PlaybackViewModel : ViewModel() {
                         resolveCurrentTrack(state)
                     }
                 }
+            } catch (e: CancellationException) {
+                // Not a failure and not ours to report: swallowing it surfaced a torn-down scope as
+                // "Init failed: Job was cancelled", which reads as a network fault and is not one.
+                throw e
             } catch (e: Exception) {
                 LokiLogger.e(TAG, "Init failed", e)
                 val msg = e.message ?: "Unknown error"
@@ -505,6 +551,7 @@ class PlaybackViewModel : ViewModel() {
                         val ctx = MusicPlaybackService.instance as? android.content.Context ?: return@launch
                         val savedCookies = ch.snepilatch.app.util.loadCookies(ctx)
                         if (savedCookies != null) {
+                            initJob = null
                             initialize(savedCookies)
                         } else {
                             needsLogin.value = true
@@ -3327,6 +3374,13 @@ class PlaybackViewModel : ViewModel() {
     }
 
     companion object {
+        // Init outlives the Activity that starts it. In viewModelScope a teardown mid-init abandoned
+        // the session, and the next ViewModel cleared the holder and re-ran the whole cascade, so a
+        // slow init could never finish (issue #612).
+        private val initScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+        @Volatile private var initJob: Job? = null
+
         /** SharedPreferences file name for all persisted settings. */
 
         /** Delay before re-reading true state to repaint the notification after a button command. */

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -375,14 +375,33 @@ class PlaybackViewModel : ViewModel() {
     }
 
     /** [_account] is ViewModel state, not holder state, so an adopting ViewModel has to refetch it. */
-    private suspend fun loadAccount(sess: Session) {
+    /**
+     * Not a startup gate. The reference client fetches the profile as a query and renders around it,
+     * which is why its avatar is briefly blank on a cold load. Waiting for it cost 302ms of loading
+     * screen for data only the avatar and the account tab need.
+     */
+    private fun loadAccountInBackground(sess: Session) {
+        initScope.launch {
+            try {
+                loadAccount(sess)
+            } catch (e: Exception) {
+                LokiLogger.e(TAG, "Profile load failed", e)
+            }
+        }
+    }
+
+    private suspend fun loadAccount(sess: Session) = coroutineScope {
         val userApi = User(sess)
         val me = userApi.getCurrentUser()
         username = me.username
         SessionHolder.username = me.username
-        val isPremium = userApi.hasPremium()
+        // Only getCurrentUser has to come first, because the other two need the username. Those two
+        // do not depend on each other, so they go together.
+        val premium = async { userApi.hasPremium() }
         // Get public profile (display name + avatar) from user-profile-view API
-        val pubProfile = userApi.getProfile(username)
+        val profile = async { userApi.getProfile(username) }
+        val isPremium = premium.await()
+        val pubProfile = profile.await()
         val displayName = pubProfile.displayName.ifEmpty { username }
         val imageUrl = pubProfile.imageUrl
         LokiLogger.i(TAG, "Profile: display=$displayName, user=$username, image=${imageUrl?.take(40)}")
@@ -465,11 +484,10 @@ class PlaybackViewModel : ViewModel() {
 
                 // Home and library load themselves from HomeViewModel.init / LibraryViewModel.init.
 
-                loadAccount(sess)
-
                 isInitialized.value = true
                 initRetryCount = 0
                 authRecovering = false
+                loadAccountInBackground(sess)
                 // Session is healthy again — dismiss any lingering "connection lost" alert.
                 MusicPlaybackService.instance?.clearError()
 

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/InitAdoptsRunningSessionTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/InitAdoptsRunningSessionTest.kt
@@ -1,0 +1,57 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.playback.SessionHolder
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * A recreated Activity gets a fresh ViewModel but the session is process-scoped (issue #612).
+ *
+ * initialize() used to clear the holder and re-run the whole network cascade regardless, so every
+ * teardown cost a full re-init and a slow one could never finish before the next teardown.
+ */
+class InitAdoptsRunningSessionTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() {
+        rig.install()
+        SessionHolder.session = mockk(relaxed = true)
+        SessionHolder.cdnResolver = mockk(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        SessionHolder.session = null
+        SessionHolder.cdnResolver = null
+        rig.uninstall()
+    }
+
+    @Test
+    fun initializeKeepsALiveSessionInsteadOfRebuildingIt() {
+        val live = SessionHolder.session
+        val livePlayer = SessionHolder.player
+
+        rig.vm.initialize(mapOf("sp_dc" to "cookie"))
+
+        assertSame("a ready session was torn down and re-created", live, SessionHolder.session)
+        assertSame("a ready player was torn down and re-created", livePlayer, SessionHolder.player)
+        assertTrue("adopting left the UI waiting on the connecting screen", rig.vm.isInitialized.value)
+    }
+
+    @Test
+    fun aHalfBuiltHolderIsNotAdopted() {
+        // isReady needs all three. With the resolver missing this must take the real init path
+        // rather than adopt a session that cannot resolve a stream.
+        SessionHolder.cdnResolver = null
+
+        rig.vm.initialize(mapOf("sp_dc" to "cookie"))
+
+        assertTrue("a half-built holder was adopted as if it were ready", !rig.vm.isInitialized.value)
+    }
+}


### PR DESCRIPTION
Init now runs in a process-scoped job rather than `viewModelScope`, so a ViewModel teardown mid-init no longer abandons the session. A ViewModel arriving while an init is in flight joins it instead of clearing the holder and starting over, and one arriving after a successful init adopts what is already there rather than re-running the network cascade. `CancellationException` is rethrown instead of being reported as `Init failed`.

Closes #612