### PR TITLE
Classify the queue instead of rendering the raw next_tracks list

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -27,6 +27,7 @@ import ch.snepilatch.app.viewmodel.PlaybackViewModel
 @Composable
 fun QueueSheet(vm: PlaybackViewModel) {
     val queue by vm.queue.collectAsState()
+    val queuedCount by vm.queuedCount.collectAsState()
     val playback by vm.playback.collectAsState()
     val sheetState = rememberBottomSheetState(
         initialValue = SheetValue.Hidden,
@@ -59,39 +60,57 @@ fun QueueSheet(vm: PlaybackViewModel) {
 
             playback.track?.let { NowPlayingRow(it) }
 
-            if (queue.isNotEmpty()) {
-                Text(
-                    stringResource(R.string.queue_next_up),
-                    color = SpfyLightGray,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                )
-            }
-
             if (queue.isEmpty() && playback.track == null) {
                 Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
                     Text(stringResource(R.string.queue_empty), color = SpfyLightGray, fontSize = 16.sp)
                 }
                 return@Column
             }
+            // What you queued and what simply plays next are different things, so they get their own
+            // headers rather than one flat list that reads as if you had queued the whole album.
+            val upNext = queue.drop(queuedCount)
             LazyColumn(Modifier.weight(1f), contentPadding = PaddingValues(bottom = 16.dp)) {
-                itemsIndexed(queue, key = { index, track -> "$index-${track.uri}" }) { index, track ->
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .clickable { vm.skipToQueueIndex(index) }
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        SpfyImage(track.albumArt, Modifier.size(48.dp).clip(RoundedCornerShape(4.dp)))
-                        Column(Modifier.padding(start = 12.dp).weight(1f)) {
-                            Text(track.name, color = SpfyWhite, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                            Text(track.artist, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        }
+                if (queuedCount > 0) {
+                    item(key = "header-queued") { SectionHeader(stringResource(R.string.queue_next_in_queue)) }
+                    itemsIndexed(queue.take(queuedCount), key = { i, t -> "q-$i-${t.uri}" }) { i, track ->
+                        QueueRow(track) { vm.skipToQueueIndex(i) }
+                    }
+                }
+                if (upNext.isNotEmpty()) {
+                    item(key = "header-upnext") { SectionHeader(stringResource(R.string.queue_next_up)) }
+                    itemsIndexed(upNext, key = { i, t -> "n-$i-${t.uri}" }) { i, track ->
+                        QueueRow(track) { vm.skipToQueueIndex(queuedCount + i) }
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun SectionHeader(title: String) {
+    Text(
+        title,
+        color = SpfyLightGray,
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Bold,
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+    )
+}
+
+@Composable
+private fun QueueRow(track: ch.snepilatch.app.data.TrackInfo, onClick: () -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        SpfyImage(track.albumArt, Modifier.size(48.dp).clip(RoundedCornerShape(4.dp)))
+        Column(Modifier.padding(start = 12.dp).weight(1f)) {
+            Text(track.name, color = SpfyWhite, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(track.artist, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -269,6 +269,10 @@ class PlaybackViewModel : ViewModel() {
     private val _queue = MutableStateFlow<List<TrackInfo>>(emptyList())
     val queue: StateFlow<List<TrackInfo>> = _queue
 
+    /** How many leading entries of [queue] the user queued, so the sheet can break the two apart. */
+    private val _queuedCount = MutableStateFlow(0)
+    val queuedCount: StateFlow<Int> = _queuedCount
+
     private val _queueSheetVisible = MutableStateFlow(false)
     val queueSheetVisible: StateFlow<Boolean> = _queueSheetVisible
     // Next track info (always available from WebSocket state for mini player swipe)
@@ -1905,6 +1909,17 @@ class PlaybackViewModel : ViewModel() {
         showPlaylistPicker.value = true
     }
 
+    /**
+     * The part of `next_tracks` that is actually the queue.
+     *
+     * The list is the queued block, then a boundary, then the rest of whatever context is playing.
+     * Rendering it raw showed the boundary marker and entries the server had flagged as hidden or
+     * removed as though they were tracks, and showed the rest of the album as though it were queued.
+     */
+    internal fun visibleQueue(next: List<kotify.api.playerstatus.QueueTrack>) =
+        next.takeWhile { !it.isDelimiter }
+            .filterNot { it.isHidden || it.isHiddenInQueue || it.removedReasons.isNotEmpty() }
+
     fun skipToQueueIndex(index: Int) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
@@ -1995,7 +2010,9 @@ class PlaybackViewModel : ViewModel() {
                 val info: TrackInfo,
                 val needsFetch: Boolean
             )
-            val parsed = state.next_tracks.map { qt ->
+            val visible = visibleQueue(state.next_tracks)
+            _queuedCount.value = visible.takeWhile { it.isQueued }.size
+            val parsed = visible.map { qt ->
                 val art = normalizeSpfyImageUrl(qt.imageUrl)
                 val needsFetch = qt.name.isNullOrEmpty() || qt.artistName.isNullOrEmpty() || art == null
                 val info = TrackInfo(

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -240,6 +240,7 @@
 
     <!-- Queue Screen -->
     <string name="queue_next_up">Als Nächschts</string>
+    <string name="queue_next_in_queue">Als Nächschts i de Warteschlange</string>
     <string name="queue_empty">D Wartelischte isch leer</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -230,6 +230,7 @@
 
     <!-- Queue Screen -->
     <string name="queue_next_up">Als Nächstes</string>
+    <string name="queue_next_in_queue">Als Nächstes in der Warteschlange</string>
     <string name="queue_empty">Warteschlange ist leer</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -229,6 +229,7 @@
 
     <!-- Queue Screen -->
     <string name="queue_next_up">Далее</string>
+    <string name="queue_next_in_queue">Далее в очереди</string>
     <string name="queue_empty">Очередь пуста</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -232,6 +232,7 @@
 
     <!-- Queue Screen -->
     <string name="queue_next_up">Next up</string>
+    <string name="queue_next_in_queue">Next in queue</string>
     <string name="queue_empty">Queue is empty</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/VisibleQueueTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/VisibleQueueTest.kt
@@ -1,0 +1,70 @@
+package ch.snepilatch.app.viewmodel
+
+import kotify.api.playerstatus.QueueTrack
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * `next_tracks` is not the queue (issue #614). It is the queued block, a boundary, then the rest of
+ * the context, and the sheet used to render all of it, markers and hidden entries included.
+ */
+class VisibleQueueTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() = rig.install()
+
+    @After
+    fun tearDown() = rig.uninstall()
+
+    private fun track(
+        uri: String = "spotify:track:a",
+        metadata: Map<String, String> = emptyMap(),
+        removed: List<String> = emptyList(),
+    ) = QueueTrack(
+        uri = uri, uid = "u", name = null, artistName = null, artistUri = null,
+        albumName = null, albumUri = null, durationMs = 0L, imageUrl = null,
+        metadata = metadata, removedReasons = removed,
+    )
+
+    @Test
+    fun stopsAtTheBoundary() {
+        val out = rig.vm.visibleQueue(
+            listOf(track("spotify:track:1"), track(QueueTrack.DELIMITER_URI), track("spotify:track:2"))
+        )
+
+        assertEquals(listOf("spotify:track:1"), out.map { it.uri })
+    }
+
+    @Test
+    fun metaEntriesAreABoundaryToo() {
+        val out = rig.vm.visibleQueue(listOf(track("spotify:track:1"), track("spotify:meta:page:2"), track("spotify:track:2")))
+
+        assertEquals(1, out.size)
+    }
+
+    @Test
+    fun dropsWhatTheServerFlaggedAsNotDisplayable() {
+        val out = rig.vm.visibleQueue(
+            listOf(
+                track("spotify:track:keep"),
+                track("spotify:track:hidden", metadata = mapOf("hidden" to "true")),
+                track("spotify:track:hiddenq", metadata = mapOf("hidden_in_queue" to "true")),
+                track("spotify:track:removed", removed = listOf("banned")),
+            )
+        )
+
+        assertEquals(listOf("spotify:track:keep"), out.map { it.uri })
+    }
+
+    /** Nothing to cut is the common case, and it must not lose entries. */
+    @Test
+    fun aPlainQueueSurvivesIntact() {
+        val plain = listOf(track("spotify:track:1"), track("spotify:track:2"), track("spotify:track:3"))
+
+        assertEquals(3, rig.vm.visibleQueue(plain).size)
+    }
+}


### PR DESCRIPTION
Cuts `next_tracks` at the boundary marker, drops entries the server flagged hidden or removed, and splits what is left into Next in queue and Next up so the sheet stops presenting the rest of the current album as though it had been queued. Needs the fields added in KotifyClient #347, so it also needs a KotifyClient release before it can build in CI.

Closes #614