### PR TITLE
Remove a track from the queue by swiping the row

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
@@ -14,7 +14,9 @@ data class TrackInfo(
     val albumArt: String?,
     val durationMs: Long = 0,
     val albumName: String? = null,
-    val uid: String? = null
+    val uid: String? = null,
+    /** Queue identity: uid plus the repeat iteration, since uid alone recurs on the next pass. */
+    val qid: String? = null
 )
 
 data class PlaybackUiState(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -147,6 +147,9 @@ private fun QueueRow(track: ch.snepilatch.app.data.TrackInfo, onClick: () -> Uni
     Row(
         Modifier
             .fillMaxWidth()
+            // Opaque on purpose: the delete panel sits behind every row, so a transparent row shows
+            // it through and the whole list reads as though it were mid-swipe.
+            .background(SpfyElevated)
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -73,17 +75,59 @@ fun QueueSheet(vm: PlaybackViewModel) {
                 if (queuedCount > 0) {
                     item(key = "header-queued") { SectionHeader(stringResource(R.string.queue_next_in_queue)) }
                     itemsIndexed(queue.take(queuedCount), key = { i, t -> "q-$i-${t.uri}" }) { i, track ->
-                        QueueRow(track) { vm.skipToQueueIndex(i) }
+                        SwipeableQueueRow(
+                            track,
+                            onClick = { vm.skipToQueueIndex(i) },
+                            onRemove = { vm.removeFromQueue(track) },
+                        )
                     }
                 }
                 if (upNext.isNotEmpty()) {
                     item(key = "header-upnext") { SectionHeader(stringResource(R.string.queue_next_up)) }
                     itemsIndexed(upNext, key = { i, t -> "n-$i-${t.uri}" }) { i, track ->
-                        QueueRow(track) { vm.skipToQueueIndex(queuedCount + i) }
+                        SwipeableQueueRow(
+                            track,
+                            onClick = { vm.skipToQueueIndex(queuedCount + i) },
+                            onRemove = { vm.removeFromQueue(track) },
+                        )
                     }
                 }
             }
         }
+    }
+}
+
+/**
+ * A queue row you can swipe away, which is the primary way out of a track added by mistake.
+ *
+ * One direction only: a row also responds to a tap, and a two way swipe on top of that turns an
+ * imprecise gesture into a coin flip between playing something and deleting it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SwipeableQueueRow(
+    track: ch.snepilatch.app.data.TrackInfo,
+    onClick: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    val state = rememberSwipeToDismissBoxState()
+    SwipeToDismissBox(
+        state = state,
+        onDismiss = { value -> if (value == SwipeToDismissBoxValue.EndToStart) onRemove() },
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .background(SpfyError)
+                    .padding(horizontal = 24.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Icon(Icons.Rounded.Delete, stringResource(R.string.queue_remove), tint = SpfyWhite)
+            }
+        }
+    ) {
+        QueueRow(track, onClick)
     }
 }
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -71,10 +71,22 @@ fun QueueSheet(vm: PlaybackViewModel) {
             // What you queued and what simply plays next are different things, so they get their own
             // headers rather than one flat list that reads as if you had queued the whole album.
             val upNext = queue.drop(queuedCount)
+            // Key by the entry, not its position: an index in the key means removing one row
+            // renames every row below it, so the list rebuilds and a swipe offset can be recycled
+            // onto a different track. Duplicate qids do happen in an autoplay queue, and a repeated
+            // key crashes the list, so the nth copy carries its own suffix.
+            val rowKeys = remember(queue) {
+                val seen = mutableMapOf<String, Int>()
+                queue.map { track ->
+                    val base = track.qid ?: track.uri
+                    val nth = seen.merge(base, 1, Int::plus) ?: 1
+                    if (nth == 1) base else "$base#$nth"
+                }
+            }
             LazyColumn(Modifier.weight(1f), contentPadding = PaddingValues(bottom = 16.dp)) {
                 if (queuedCount > 0) {
                     item(key = "header-queued") { SectionHeader(stringResource(R.string.queue_next_in_queue)) }
-                    itemsIndexed(queue.take(queuedCount), key = { i, t -> "q-$i-${t.uri}" }) { i, track ->
+                    itemsIndexed(queue.take(queuedCount), key = { i, _ -> rowKeys[i] }) { i, track ->
                         SwipeableQueueRow(
                             track,
                             onClick = { vm.skipToQueueIndex(i) },
@@ -84,7 +96,7 @@ fun QueueSheet(vm: PlaybackViewModel) {
                 }
                 if (upNext.isNotEmpty()) {
                     item(key = "header-upnext") { SectionHeader(stringResource(R.string.queue_next_up)) }
-                    itemsIndexed(upNext, key = { i, t -> "n-$i-${t.uri}" }) { i, track ->
+                    itemsIndexed(upNext, key = { i, _ -> rowKeys[queuedCount + i] }) { i, track ->
                         SwipeableQueueRow(
                             track,
                             onClick = { vm.skipToQueueIndex(queuedCount + i) },

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -75,14 +75,7 @@ fun QueueSheet(vm: PlaybackViewModel) {
             // renames every row below it, so the list rebuilds and a swipe offset can be recycled
             // onto a different track. Duplicate qids do happen in an autoplay queue, and a repeated
             // key crashes the list, so the nth copy carries its own suffix.
-            val rowKeys = remember(queue) {
-                val seen = mutableMapOf<String, Int>()
-                queue.map { track ->
-                    val base = track.qid ?: track.uri
-                    val nth = seen.merge(base, 1, Int::plus) ?: 1
-                    if (nth == 1) base else "$base#$nth"
-                }
-            }
+            val rowKeys = remember(queue) { queueRowKeys(queue) }
             LazyColumn(Modifier.weight(1f), contentPadding = PaddingValues(bottom = 16.dp)) {
                 if (queuedCount > 0) {
                     item(key = "header-queued") { SectionHeader(stringResource(R.string.queue_next_in_queue)) }
@@ -116,6 +109,23 @@ fun QueueSheet(vm: PlaybackViewModel) {
  * imprecise gesture into a coin flip between playing something and deleting it.
  */
 @OptIn(ExperimentalMaterial3Api::class)
+/**
+ * A stable, unique key per queue row.
+ *
+ * Stable because an index in the key renames every row below a removed one, which rebuilds the list
+ * and lets a swipe offset land on a different track. Unique because a repeated key throws inside a
+ * LazyColumn, and qid is not guaranteed unique: an autoplay queue can hold two entries with the same
+ * uid and iteration. The first occurrence keeps the plain key, later ones carry their count.
+ */
+internal fun queueRowKeys(queue: List<ch.snepilatch.app.data.TrackInfo>): List<String> {
+    val seen = mutableMapOf<String, Int>()
+    return queue.map { track ->
+        val base = track.qid ?: track.uri
+        val nth = seen.merge(base, 1, Int::plus) ?: 1
+        if (nth == 1) base else "$base#$nth"
+    }
+}
+
 @Composable
 private fun SwipeableQueueRow(
     track: ch.snepilatch.app.data.TrackInfo,

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -267,11 +267,14 @@ class PlaybackViewModel : ViewModel() {
     // add-to-playlist picker stay here (snackbar + non-composable callers).
 
     // Queue
-    private val _queue = MutableStateFlow<List<TrackInfo>>(emptyList())
+    // internal so tests can seed a queue without a live PlayerConnect, same reason as _playback.
+    @Suppress("VariableNaming")
+    internal val _queue = MutableStateFlow<List<TrackInfo>>(emptyList())
     val queue: StateFlow<List<TrackInfo>> = _queue
 
     /** How many leading entries of [queue] the user queued, so the sheet can break the two apart. */
-    private val _queuedCount = MutableStateFlow(0)
+    @Suppress("VariableNaming")
+    internal val _queuedCount = MutableStateFlow(0)
     val queuedCount: StateFlow<Int> = _queuedCount
 
     private val _queueSheetVisible = MutableStateFlow(false)
@@ -2063,6 +2066,30 @@ class PlaybackViewModel : ViewModel() {
         navigateTo(Screen.LYRICS)
     }
 
+    /**
+     * Drop one entry from the queue.
+     *
+     * Addressed by qid, not uri: a queue legitimately holds the same track twice, and with repeat on
+     * the same uid comes back on the next pass. The row goes immediately so the swipe feels like it
+     * did something, and a refresh follows to reconcile with whatever the server actually did.
+     */
+    fun removeFromQueue(track: TrackInfo) {
+        val qid = track.qid ?: run {
+            LokiLogger.w(TAG, "No qid on ${track.name}, cannot address it for removal")
+            return
+        }
+        val before = _queue.value
+        _queue.value = before.filterNot { it.qid == qid }
+        if (_queuedCount.value > 0 && before.take(_queuedCount.value).any { it.qid == qid }) {
+            _queuedCount.value -= 1
+        }
+        launchWithPlayer("removeFromQueue") { pc ->
+            val removed = pc.removeFromQueue(qid)
+            LokiLogger.i(TAG, "Queue remove ${track.name}: ${if (removed) "accepted" else "already gone"}")
+            refreshQueue()
+        }
+    }
+
     fun refreshQueue() {
         launchWithSession("refreshQueue") { sess ->
             val state = player?.getState() ?: return@launchWithSession
@@ -2086,6 +2113,7 @@ class PlaybackViewModel : ViewModel() {
                     albumArt = art,
                     durationMs = qt.durationMs,
                     uid = qt.uid,
+                    qid = qt.qid,
                 )
                 ParsedTrack(qt.uri, info, needsFetch)
             }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -2084,9 +2084,17 @@ class PlaybackViewModel : ViewModel() {
             _queuedCount.value -= 1
         }
         launchWithPlayer("removeFromQueue") { pc ->
-            val removed = pc.removeFromQueue(qid)
-            LokiLogger.i(TAG, "Queue remove ${track.name}: ${if (removed) "accepted" else "already gone"}")
-            refreshQueue()
+            val removed = try {
+                pc.removeFromQueue(qid)
+            } catch (e: Exception) {
+                LokiLogger.e(TAG, "removeFromQueue ${track.name}", e)
+                false
+            }
+            LokiLogger.i(TAG, "Queue remove ${track.name}: ${if (removed) "accepted" else "not found"}")
+            // Only refetch when the local edit and the server disagree. Refreshing after every swipe
+            // cost a getState plus a decorate round trip per row and rebuilt the list mid-gesture,
+            // which is what made it feel like the sheet was fighting the finger.
+            if (!removed) refreshQueue()
         }
     }
 

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -241,6 +241,7 @@
     <!-- Queue Screen -->
     <string name="queue_next_up">Als Nächschts</string>
     <string name="queue_next_in_queue">Als Nächschts i de Warteschlange</string>
+    <string name="queue_remove">Us de Warteschlange neh</string>
     <string name="queue_empty">D Wartelischte isch leer</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -231,6 +231,7 @@
     <!-- Queue Screen -->
     <string name="queue_next_up">Als Nächstes</string>
     <string name="queue_next_in_queue">Als Nächstes in der Warteschlange</string>
+    <string name="queue_remove">Aus der Warteschlange entfernen</string>
     <string name="queue_empty">Warteschlange ist leer</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -230,6 +230,7 @@
     <!-- Queue Screen -->
     <string name="queue_next_up">Далее</string>
     <string name="queue_next_in_queue">Далее в очереди</string>
+    <string name="queue_remove">Убрать из очереди</string>
     <string name="queue_empty">Очередь пуста</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -233,6 +233,7 @@
     <!-- Queue Screen -->
     <string name="queue_next_up">Next up</string>
     <string name="queue_next_in_queue">Next in queue</string>
+    <string name="queue_remove">Remove from queue</string>
     <string name="queue_empty">Queue is empty</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/test/java/ch/snepilatch/app/ui/screens/QueueRowKeysTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/ui/screens/QueueRowKeysTest.kt
@@ -1,0 +1,59 @@
+package ch.snepilatch.app.ui.screens
+
+import ch.snepilatch.app.data.TrackInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A repeated key throws inside a LazyColumn, which is how the Home feed crashed once already.
+ * The queue can genuinely hold duplicates: a live autoplay queue was observed with two entries
+ * sharing a uid and an iteration, so qid alone is not an identity.
+ */
+class QueueRowKeysTest {
+
+    private fun track(qid: String?, uri: String = "spotify:track:x") =
+        TrackInfo(uri = uri, name = "n", artist = "a", albumArt = null, qid = qid)
+
+    @Test
+    fun `distinct entries keep their qid`() {
+        val keys = queueRowKeys(listOf(track("a:::0"), track("b:::0")))
+
+        assertEquals(listOf("a:::0", "b:::0"), keys)
+    }
+
+    @Test
+    fun `duplicate qids do not collide`() {
+        val keys = queueRowKeys(listOf(track("a:::0"), track("a:::0"), track("a:::0")))
+
+        assertEquals(keys.size, keys.toSet().size)
+        assertEquals("a:::0", keys.first())
+    }
+
+    /** Entries with no qid still need a key, and blank or repeated uris were the Home crash. */
+    @Test
+    fun `entries without a qid fall back to uri and still stay unique`() {
+        val keys = queueRowKeys(listOf(track(null, "spotify:track:same"), track(null, "spotify:track:same")))
+
+        assertEquals(keys.size, keys.toSet().size)
+    }
+
+    @Test
+    fun `a long queue of identical entries stays unique`() {
+        val keys = queueRowKeys(List(50) { track("dup:::0") })
+
+        assertEquals(50, keys.toSet().size)
+    }
+
+    /** A key must not move when rows above it are untouched, or the list rebuilds on every edit. */
+    @Test
+    fun `removing a row leaves the remaining keys unchanged`() {
+        val queue = listOf(track("a:::0"), track("b:::0"), track("c:::0"))
+
+        val before = queueRowKeys(queue)
+        val after = queueRowKeys(queue.filterNot { it.qid == "a:::0" })
+
+        assertTrue(after.all { it in before })
+        assertEquals(listOf("b:::0", "c:::0"), after)
+    }
+}

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/RemoveFromQueueTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/RemoveFromQueueTest.kt
@@ -1,0 +1,80 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.data.TrackInfo
+import io.mockk.coVerify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Swiping a queue row away (issue #586).
+ *
+ * The row goes immediately so the gesture feels like it did something, and the entry is addressed by
+ * qid rather than uri because a queue legitimately holds the same track twice.
+ */
+class RemoveFromQueueTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() = rig.install()
+
+    @After
+    fun tearDown() = rig.uninstall()
+
+    private fun track(qid: String?, name: String) =
+        TrackInfo(uri = "spotify:track:$name", name = name, artist = "artist", albumArt = null, qid = qid)
+
+    @Test
+    fun dropsTheRowAndAddressesItByQid() {
+        rig.vm._queue.value = listOf(track("a:::0", "one"), track("b:::0", "two"))
+
+        rig.vm.removeFromQueue(rig.vm.queue.value.first())
+
+        assertEquals(listOf("two"), rig.vm.queue.value.map { it.name })
+        coVerify { rig.player.removeFromQueue("a:::0") }
+    }
+
+    /** Same uid on the next repeat pass, so a uri or uid match would take the wrong row. */
+    @Test
+    fun removesOnlyTheSwipedIterationOfADuplicate() {
+        rig.vm._queue.value = listOf(track("a:::0", "dup"), track("a:::1", "dup"))
+
+        rig.vm.removeFromQueue(rig.vm.queue.value.first())
+
+        assertEquals(listOf("a:::1"), rig.vm.queue.value.map { it.qid })
+    }
+
+    /** The header split is driven by this count, so removing a queued row has to move it too. */
+    @Test
+    fun removingAQueuedRowShrinksTheQueuedSection() {
+        rig.vm._queue.value = listOf(track("q:::0", "queued"), track("c:::0", "context"))
+        rig.vm._queuedCount.value = 1
+
+        rig.vm.removeFromQueue(rig.vm.queue.value.first())
+
+        assertEquals(0, rig.vm.queuedCount.value)
+    }
+
+    @Test
+    fun removingAContextRowLeavesTheQueuedCountAlone() {
+        rig.vm._queue.value = listOf(track("q:::0", "queued"), track("c:::0", "context"))
+        rig.vm._queuedCount.value = 1
+
+        rig.vm.removeFromQueue(rig.vm.queue.value[1])
+
+        assertEquals(1, rig.vm.queuedCount.value)
+    }
+
+    /** Without a qid there is nothing to address, so the row stays rather than vanishing locally. */
+    @Test
+    fun anEntryWithoutAQidIsLeftAlone() {
+        rig.vm._queue.value = listOf(track(null, "orphan"))
+
+        rig.vm.removeFromQueue(rig.vm.queue.value.first())
+
+        assertEquals(1, rig.vm.queue.value.size)
+        coVerify(exactly = 0) { rig.player.removeFromQueue(any()) }
+    }
+}


### PR DESCRIPTION
Adds a right-to-left swipe on a queue row that removes the entry, with a delete panel behind it. One direction only: the row also responds to a tap, and a two way swipe on top of that makes an imprecise gesture a coin flip between playing something and deleting it.

Entries are addressed by qid rather than uri, so removing one copy of a duplicated track takes the copy that was swiped, and a repeat pass reusing the same uid does not confuse it. The row goes immediately so the gesture feels like it did something, then a refresh reconciles with what the server actually did.

Closes #586