### PR TITLE
Reorder the queue by dragging a row's handle

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/data/Models.kt
@@ -16,7 +16,12 @@ data class TrackInfo(
     val albumName: String? = null,
     val uid: String? = null,
     /** Queue identity: uid plus the repeat iteration, since uid alone recurs on the next pass. */
-    val qid: String? = null
+    val qid: String? = null,
+    /**
+     * Position in the server's unfiltered `next_tracks`. The queue we display hides the delimiter
+     * and anything flagged, so a row's position on screen is not the index a queue write wants.
+     */
+    val queueIndex: Int? = null
 )
 
 data class PlaybackUiState(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -2,6 +2,7 @@ package ch.snepilatch.app.ui.screens
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -9,10 +10,15 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.zIndex
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -23,6 +29,7 @@ import ch.snepilatch.app.ui.components.SheetNavBarFix
 import ch.snepilatch.app.ui.components.SpfyImage
 import ch.snepilatch.app.ui.theme.*
 import ch.snepilatch.app.viewmodel.PlaybackViewModel
+import kotlin.math.roundToInt
 
 /** The queue as a bottom drawer over whatever is showing; the full player stays open underneath. */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -68,36 +75,7 @@ fun QueueSheet(vm: PlaybackViewModel) {
                 }
                 return@Column
             }
-            // What you queued and what simply plays next are different things, so they get their own
-            // headers rather than one flat list that reads as if you had queued the whole album.
-            val upNext = queue.drop(queuedCount)
-            // Key by the entry, not its position: an index in the key means removing one row
-            // renames every row below it, so the list rebuilds and a swipe offset can be recycled
-            // onto a different track. Duplicate qids do happen in an autoplay queue, and a repeated
-            // key crashes the list, so the nth copy carries its own suffix.
-            val rowKeys = remember(queue) { queueRowKeys(queue) }
-            LazyColumn(Modifier.weight(1f), contentPadding = PaddingValues(bottom = 16.dp)) {
-                if (queuedCount > 0) {
-                    item(key = "header-queued") { SectionHeader(stringResource(R.string.queue_next_in_queue)) }
-                    itemsIndexed(queue.take(queuedCount), key = { i, _ -> rowKeys[i] }) { i, track ->
-                        SwipeableQueueRow(
-                            track,
-                            onClick = { vm.skipToQueueIndex(i) },
-                            onRemove = { vm.removeFromQueue(track) },
-                        )
-                    }
-                }
-                if (upNext.isNotEmpty()) {
-                    item(key = "header-upnext") { SectionHeader(stringResource(R.string.queue_next_up)) }
-                    itemsIndexed(upNext, key = { i, _ -> rowKeys[queuedCount + i] }) { i, track ->
-                        SwipeableQueueRow(
-                            track,
-                            onClick = { vm.skipToQueueIndex(queuedCount + i) },
-                            onRemove = { vm.removeFromQueue(track) },
-                        )
-                    }
-                }
-            }
+            QueueList(vm, queue, queuedCount, Modifier.weight(1f))
         }
     }
 }
@@ -126,16 +104,99 @@ internal fun queueRowKeys(queue: List<ch.snepilatch.app.data.TrackInfo>): List<S
     }
 }
 
+/** One row's drag wiring, bundled so a row takes a drag contract rather than six loose callbacks. */
+private class RowDrag(
+    val dragging: Boolean,
+    val offsetY: Float,
+    val onMeasured: (Int) -> Unit,
+    val onStart: () -> Unit,
+    val onDrag: (Float) -> Unit,
+    val onEnd: () -> Unit,
+)
+
+/**
+ * The queue itself: what you queued, then what simply plays next, each under its own header.
+ *
+ * Rows are keyed by the entry rather than its position. An index in the key renames every row below
+ * a removed one, which rebuilds the list and can recycle a swipe offset onto a different track.
+ * Duplicate qids do occur in an autoplay queue and a repeated key throws, so the nth copy is suffixed.
+ */
+@Composable
+private fun QueueList(
+    vm: PlaybackViewModel,
+    queue: List<ch.snepilatch.app.data.TrackInfo>,
+    queuedCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    val rowKeys = remember(queue) { queueRowKeys(queue) }
+    // Row height is measured rather than assumed, so the drop lands on the row under the finger
+    // even if the row's padding changes later.
+    var dragKey by remember { mutableStateOf<String?>(null) }
+    var dragDy by remember { mutableFloatStateOf(0f) }
+    var rowHeight by remember { mutableIntStateOf(0) }
+
+    fun dragFor(key: String, track: ch.snepilatch.app.data.TrackInfo, displayIndex: Int) = RowDrag(
+        dragging = key == dragKey,
+        offsetY = if (key == dragKey) dragDy else 0f,
+        onMeasured = { rowHeight = it },
+        onStart = {
+            dragKey = key
+            dragDy = 0f
+        },
+        onDrag = { dragDy += it },
+        onEnd = {
+            val rows = if (rowHeight > 0) (dragDy / rowHeight).roundToInt() else 0
+            dragKey = null
+            dragDy = 0f
+            if (rows != 0) vm.moveQueueEntry(track, displayIndex + rows)
+        },
+    )
+
+    val upNext = queue.drop(queuedCount)
+    LazyColumn(modifier, contentPadding = PaddingValues(bottom = 16.dp)) {
+        if (queuedCount > 0) {
+            item(key = "header-queued") { SectionHeader(stringResource(R.string.queue_next_in_queue)) }
+            itemsIndexed(queue.take(queuedCount), key = { i, _ -> rowKeys[i] }) { i, track ->
+                SwipeableQueueRow(
+                    track,
+                    dragFor(rowKeys[i], track, i),
+                    onClick = { vm.skipToQueueIndex(i) },
+                    onRemove = { vm.removeFromQueue(track) },
+                )
+            }
+        }
+        if (upNext.isNotEmpty()) {
+            item(key = "header-upnext") { SectionHeader(stringResource(R.string.queue_next_up)) }
+            itemsIndexed(upNext, key = { i, _ -> rowKeys[queuedCount + i] }) { i, track ->
+                SwipeableQueueRow(
+                    track,
+                    dragFor(rowKeys[queuedCount + i], track, queuedCount + i),
+                    onClick = { vm.skipToQueueIndex(queuedCount + i) },
+                    onRemove = { vm.removeFromQueue(track) },
+                )
+            }
+        }
+    }
+}
+
 @Composable
 private fun SwipeableQueueRow(
     track: ch.snepilatch.app.data.TrackInfo,
+    drag: RowDrag,
     onClick: () -> Unit,
     onRemove: () -> Unit,
 ) {
     val state = rememberSwipeToDismissBoxState()
     SwipeToDismissBox(
         state = state,
+        modifier = Modifier
+            // The dragged row rides above the rest and follows the finger; everything else
+            // holds still until the drop, so the list cannot reflow under the gesture.
+            .zIndex(if (drag.dragging) 1f else 0f)
+            .offset { IntOffset(0, drag.offsetY.roundToInt()) },
         onDismiss = { value -> if (value == SwipeToDismissBoxValue.EndToStart) onRemove() },
+        // A vertical drag on the grip must not also read as a swipe to delete.
+        enableDismissFromEndToStart = !drag.dragging,
         enableDismissFromStartToEnd = false,
         backgroundContent = {
             Box(
@@ -149,7 +210,7 @@ private fun SwipeableQueueRow(
             }
         }
     ) {
-        QueueRow(track, onClick)
+        QueueRow(track, onClick, drag.onMeasured, drag.onStart, drag.onDrag, drag.onEnd)
     }
 }
 
@@ -165,10 +226,18 @@ private fun SectionHeader(title: String) {
 }
 
 @Composable
-private fun QueueRow(track: ch.snepilatch.app.data.TrackInfo, onClick: () -> Unit) {
+private fun QueueRow(
+    track: ch.snepilatch.app.data.TrackInfo,
+    onClick: () -> Unit,
+    onMeasured: (Int) -> Unit,
+    onDragStart: () -> Unit,
+    onDrag: (Float) -> Unit,
+    onDragEnd: () -> Unit,
+) {
     Row(
         Modifier
             .fillMaxWidth()
+            .onSizeChanged { onMeasured(it.height) }
             // Opaque on purpose: the delete panel sits behind every row, so a transparent row shows
             // it through and the whole list reads as though it were mid-swipe.
             .background(SpfyElevated)
@@ -181,6 +250,27 @@ private fun QueueRow(track: ch.snepilatch.app.data.TrackInfo, onClick: () -> Uni
             Text(track.name, color = SpfyWhite, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(track.artist, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
+        Icon(
+            Icons.Rounded.DragHandle,
+            stringResource(R.string.queue_reorder),
+            tint = SpfyLightGray,
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .size(24.dp)
+                // The grip starts the drag, not the row: a row-wide vertical drag would fight
+                // the list's own scrolling, which is why a touch queue needs a handle at all.
+                .pointerInput(track.qid) {
+                    detectDragGestures(
+                        onDragStart = { onDragStart() },
+                        onDrag = { change, amount ->
+                            change.consume()
+                            onDrag(amount.y)
+                        },
+                        onDragEnd = { onDragEnd() },
+                        onDragCancel = { onDragEnd() },
+                    )
+                }
+        )
     }
 }
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -128,51 +128,74 @@ private fun QueueList(
     queuedCount: Int,
     modifier: Modifier = Modifier,
 ) {
-    val rowKeys = remember(queue) { queueRowKeys(queue) }
-    // Row height is measured rather than assumed, so the drop lands on the row under the finger
-    // even if the row's padding changes later.
+    // Keys ride with their entry, so the preview below can reorder freely without a row's identity
+    // following its position. See queueRowKeys for why a positional key is not enough.
+    val keyed = remember(queue) { queueRowKeys(queue).zip(queue) }
     var dragKey by remember { mutableStateOf<String?>(null) }
+    var dragFrom by remember { mutableIntStateOf(-1) }
     var dragDy by remember { mutableFloatStateOf(0f) }
     var rowHeight by remember { mutableIntStateOf(0) }
 
-    fun dragFor(key: String, track: ch.snepilatch.app.data.TrackInfo, displayIndex: Int) = RowDrag(
+    fun sectionOf(index: Int): IntRange =
+        if (index < queuedCount) 0..(queuedCount - 1) else queuedCount..keyed.lastIndex
+
+    val steps = if (rowHeight > 0) (dragDy / rowHeight).roundToInt() else 0
+    val dragTo = if (dragFrom >= 0) (dragFrom + steps).coerceIn(sectionOf(dragFrom)) else -1
+    // Rows shift as the finger crosses them rather than only on release. Seeing where it will land
+    // is the point of dragging; without it the gesture gives nothing back until it is too late.
+    val shown = if (dragKey != null && dragTo >= 0 && dragTo != dragFrom) {
+        keyed.toMutableList().apply { add(dragTo, removeAt(dragFrom)) }
+    } else {
+        keyed
+    }
+    // What is left after the row has snapped into its previewed slot, so it keeps tracking the
+    // finger instead of jumping a whole row at a time.
+    val carried = if (dragFrom >= 0) dragDy - (dragTo - dragFrom) * rowHeight else 0f
+
+    fun dragFor(key: String, displayIndex: Int) = RowDrag(
         dragging = key == dragKey,
-        offsetY = if (key == dragKey) dragDy else 0f,
+        offsetY = if (key == dragKey) carried else 0f,
         onMeasured = { rowHeight = it },
         onStart = {
             dragKey = key
+            dragFrom = displayIndex
             dragDy = 0f
         },
         onDrag = { dragDy += it },
         onEnd = {
-            val rows = if (rowHeight > 0) (dragDy / rowHeight).roundToInt() else 0
+            val to = dragTo
+            val landed = shown.getOrNull(to)?.second
+            val moved = to != dragFrom
             dragKey = null
+            dragFrom = -1
             dragDy = 0f
-            if (rows != 0) vm.moveQueueEntry(track, displayIndex + rows)
+            if (moved && landed != null) vm.moveQueueEntry(landed, to)
         },
     )
 
-    val upNext = queue.drop(queuedCount)
+    val upNext = shown.drop(queuedCount)
     LazyColumn(modifier, contentPadding = PaddingValues(bottom = 16.dp)) {
         if (queuedCount > 0) {
             item(key = "header-queued") { SectionHeader(stringResource(R.string.queue_next_in_queue)) }
-            itemsIndexed(queue.take(queuedCount), key = { i, _ -> rowKeys[i] }) { i, track ->
+            itemsIndexed(shown.take(queuedCount), key = { _, entry -> entry.first }) { i, entry ->
                 SwipeableQueueRow(
-                    track,
-                    dragFor(rowKeys[i], track, i),
+                    entry.second,
+                    dragFor(entry.first, i),
                     onClick = { vm.skipToQueueIndex(i) },
-                    onRemove = { vm.removeFromQueue(track) },
+                    onRemove = { vm.removeFromQueue(entry.second) },
                 )
             }
         }
         if (upNext.isNotEmpty()) {
             item(key = "header-upnext") { SectionHeader(stringResource(R.string.queue_next_up)) }
-            itemsIndexed(upNext, key = { i, _ -> rowKeys[queuedCount + i] }) { i, track ->
+            itemsIndexed(upNext, key = { _, entry -> entry.first }) { i, entry ->
                 SwipeableQueueRow(
-                    track,
-                    dragFor(rowKeys[queuedCount + i], track, queuedCount + i),
+                    entry.second,
+                    // No grip here: Next up is the context continuing, and the server rebuilds it
+                    // from the playlist, so a write to it is quietly recomputed away.
+                    null,
                     onClick = { vm.skipToQueueIndex(queuedCount + i) },
-                    onRemove = { vm.removeFromQueue(track) },
+                    onRemove = { vm.removeFromQueue(entry.second) },
                 )
             }
         }
@@ -182,7 +205,7 @@ private fun QueueList(
 @Composable
 private fun SwipeableQueueRow(
     track: ch.snepilatch.app.data.TrackInfo,
-    drag: RowDrag,
+    drag: RowDrag?,
     onClick: () -> Unit,
     onRemove: () -> Unit,
 ) {
@@ -192,11 +215,11 @@ private fun SwipeableQueueRow(
         modifier = Modifier
             // The dragged row rides above the rest and follows the finger; everything else
             // holds still until the drop, so the list cannot reflow under the gesture.
-            .zIndex(if (drag.dragging) 1f else 0f)
-            .offset { IntOffset(0, drag.offsetY.roundToInt()) },
+            .zIndex(if (drag?.dragging == true) 1f else 0f)
+            .offset { IntOffset(0, (drag?.offsetY ?: 0f).roundToInt()) },
         onDismiss = { value -> if (value == SwipeToDismissBoxValue.EndToStart) onRemove() },
         // A vertical drag on the grip must not also read as a swipe to delete.
-        enableDismissFromEndToStart = !drag.dragging,
+        enableDismissFromEndToStart = drag?.dragging != true,
         enableDismissFromStartToEnd = false,
         backgroundContent = {
             Box(
@@ -210,7 +233,7 @@ private fun SwipeableQueueRow(
             }
         }
     ) {
-        QueueRow(track, onClick, drag.onMeasured, drag.onStart, drag.onDrag, drag.onEnd)
+        QueueRow(track, onClick, drag)
     }
 }
 
@@ -229,15 +252,12 @@ private fun SectionHeader(title: String) {
 private fun QueueRow(
     track: ch.snepilatch.app.data.TrackInfo,
     onClick: () -> Unit,
-    onMeasured: (Int) -> Unit,
-    onDragStart: () -> Unit,
-    onDrag: (Float) -> Unit,
-    onDragEnd: () -> Unit,
+    drag: RowDrag?,
 ) {
     Row(
         Modifier
             .fillMaxWidth()
-            .onSizeChanged { onMeasured(it.height) }
+            .onSizeChanged { drag?.onMeasured?.invoke(it.height) }
             // Opaque on purpose: the delete panel sits behind every row, so a transparent row shows
             // it through and the whole list reads as though it were mid-swipe.
             .background(SpfyElevated)
@@ -250,27 +270,29 @@ private fun QueueRow(
             Text(track.name, color = SpfyWhite, fontSize = 15.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(track.artist, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
-        Icon(
-            Icons.Rounded.DragHandle,
-            stringResource(R.string.queue_reorder),
-            tint = SpfyLightGray,
-            modifier = Modifier
-                .padding(start = 8.dp)
-                .size(24.dp)
-                // The grip starts the drag, not the row: a row-wide vertical drag would fight
-                // the list's own scrolling, which is why a touch queue needs a handle at all.
-                .pointerInput(track.qid) {
-                    detectDragGestures(
-                        onDragStart = { onDragStart() },
-                        onDrag = { change, amount ->
-                            change.consume()
-                            onDrag(amount.y)
-                        },
-                        onDragEnd = { onDragEnd() },
-                        onDragCancel = { onDragEnd() },
-                    )
-                }
-        )
+        if (drag != null) {
+            Icon(
+                Icons.Rounded.DragHandle,
+                stringResource(R.string.queue_reorder),
+                tint = SpfyLightGray,
+                modifier = Modifier
+                    .padding(start = 8.dp)
+                    .size(24.dp)
+                    // The grip starts the drag, not the row: a row-wide vertical drag would fight
+                    // the list's own scrolling, which is why a touch queue needs a handle at all.
+                    .pointerInput(track.qid) {
+                        detectDragGestures(
+                            onDragStart = { drag.onStart() },
+                            onDrag = { change, amount ->
+                                change.consume()
+                                drag.onDrag(amount.y)
+                            },
+                            onDragEnd = { drag.onEnd() },
+                            onDragCancel = { drag.onEnd() },
+                        )
+                    }
+            )
+        }
     }
 }
 

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/QueueSheet.kt
@@ -28,6 +28,7 @@ import ch.snepilatch.app.R
 import ch.snepilatch.app.ui.components.SheetNavBarFix
 import ch.snepilatch.app.ui.components.SpfyImage
 import ch.snepilatch.app.ui.theme.*
+import ch.snepilatch.app.util.LokiLogger
 import ch.snepilatch.app.viewmodel.PlaybackViewModel
 import kotlin.math.roundToInt
 
@@ -152,7 +153,7 @@ private fun QueueList(
     // finger instead of jumping a whole row at a time.
     val carried = if (dragFrom >= 0) dragDy - (dragTo - dragFrom) * rowHeight else 0f
 
-    fun dragFor(key: String, displayIndex: Int) = RowDrag(
+    fun dragFor(key: String, track: ch.snepilatch.app.data.TrackInfo, displayIndex: Int) = RowDrag(
         dragging = key == dragKey,
         offsetY = if (key == dragKey) carried else 0f,
         onMeasured = { rowHeight = it },
@@ -163,13 +164,20 @@ private fun QueueList(
         },
         onDrag = { dragDy += it },
         onEnd = {
-            val to = dragTo
-            val landed = shown.getOrNull(to)?.second
-            val moved = to != dragFrom
+            // Recomputed here rather than captured: pointerInput keeps the callbacks from the
+            // composition the gesture started in, where dragFrom was still -1, so a captured
+            // target is always the one from before the drag began.
+            val from = dragFrom
+            val travelled = if (rowHeight > 0) (dragDy / rowHeight).roundToInt() else 0
+            val to = if (from >= 0) (from + travelled).coerceIn(sectionOf(from)) else from
+            LokiLogger.i(
+                "QueueDrag",
+                "drop from=$from to=$to dy=$dragDy rowHeight=$rowHeight queued=$queuedCount"
+            )
             dragKey = null
             dragFrom = -1
             dragDy = 0f
-            if (moved && landed != null) vm.moveQueueEntry(landed, to)
+            if (from >= 0 && to != from) vm.moveQueueEntry(track, to)
         },
     )
 
@@ -180,7 +188,7 @@ private fun QueueList(
             itemsIndexed(shown.take(queuedCount), key = { _, entry -> entry.first }) { i, entry ->
                 SwipeableQueueRow(
                     entry.second,
-                    dragFor(entry.first, i),
+                    dragFor(entry.first, entry.second, i),
                     onClick = { vm.skipToQueueIndex(i) },
                     onRemove = { vm.removeFromQueue(entry.second) },
                 )
@@ -191,9 +199,7 @@ private fun QueueList(
             itemsIndexed(upNext, key = { _, entry -> entry.first }) { i, entry ->
                 SwipeableQueueRow(
                     entry.second,
-                    // No grip here: Next up is the context continuing, and the server rebuilds it
-                    // from the playlist, so a write to it is quietly recomputed away.
-                    null,
+                    dragFor(entry.first, entry.second, queuedCount + i),
                     onClick = { vm.skipToQueueIndex(queuedCount + i) },
                     onRemove = { vm.removeFromQueue(entry.second) },
                 )

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -2112,18 +2112,39 @@ class PlaybackViewModel : ViewModel() {
      * server does, so the local list cannot show an order the server would refuse to store.
      */
     fun moveQueueEntry(track: TrackInfo, toDisplayedIndex: Int) {
-        val qid = track.qid ?: return
+        // Every exit is logged: a move that quietly does nothing looks exactly like a broken drag.
+        val qid = track.qid ?: run {
+            LokiLogger.w(TAG, "Queue move: ${track.name} has no qid, nothing to address")
+            return
+        }
         val list = _queue.value
         val from = list.indexOfFirst { it.qid == qid }
-        if (from < 0) return
+        if (from < 0) {
+            LokiLogger.w(TAG, "Queue move: ${track.name} is no longer in the list")
+            return
+        }
 
         val queued = _queuedCount.value
         val section = if (from < queued) 0..(queued - 1) else queued..list.lastIndex
-        if (section.isEmpty()) return
+        if (section.isEmpty()) {
+            LokiLogger.w(TAG, "Queue move: ${track.name} sits in an empty section, from=$from queued=$queued")
+            return
+        }
         val target = toDisplayedIndex.coerceIn(section)
-        if (target == from) return
+        if (target == from) {
+            LokiLogger.i(
+                TAG,
+                "Queue move: ${track.name} asked for $toDisplayedIndex, clamped to $target inside " +
+                    "$section, so it is already there. queued=$queued size=${list.size}"
+            )
+            return
+        }
 
-        val rawTarget = list[target].queueIndex ?: return
+        val rawTarget = list[target].queueIndex ?: run {
+            LokiLogger.w(TAG, "Queue move: no server index on the row at $target")
+            return
+        }
+        LokiLogger.i(TAG, "Queue move: ${track.name} $from -> $target (server $rawTarget), queued=$queued")
         _queue.value = list.toMutableList().apply { add(target, removeAt(from)) }
 
         launchWithPlayer("moveQueueEntry") { pc ->

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -1984,8 +1984,13 @@ class PlaybackViewModel : ViewModel() {
      * removed as though they were tracks, and showed the rest of the album as though it were queued.
      */
     internal fun visibleQueue(next: List<kotify.api.playerstatus.QueueTrack>) =
-        next.takeWhile { !it.isDelimiter }
-            .filterNot { it.isHidden || it.isHiddenInQueue || it.removedReasons.isNotEmpty() }
+        visibleQueueIndexed(next).map { it.value }
+
+    /** As [visibleQueue], but keeping each entry's index in the server list so a write can address it. */
+    internal fun visibleQueueIndexed(next: List<kotify.api.playerstatus.QueueTrack>) =
+        next.withIndex()
+            .takeWhile { !it.value.isDelimiter }
+            .filterNot { it.value.isHidden || it.value.isHiddenInQueue || it.value.removedReasons.isNotEmpty() }
 
     fun skipToQueueIndex(index: Int) {
         viewModelScope.launch(Dispatchers.IO) {
@@ -2098,6 +2103,42 @@ class PlaybackViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Move a queue entry to [toDisplayedIndex], the position the drag ended on.
+     *
+     * Two translations happen here. The displayed list hides the delimiter and anything flagged, so
+     * the server's index comes from whichever entry currently occupies the target row rather than
+     * from the row number. And the move is clamped to the entry's own section, mirroring what the
+     * server does, so the local list cannot show an order the server would refuse to store.
+     */
+    fun moveQueueEntry(track: TrackInfo, toDisplayedIndex: Int) {
+        val qid = track.qid ?: return
+        val list = _queue.value
+        val from = list.indexOfFirst { it.qid == qid }
+        if (from < 0) return
+
+        val queued = _queuedCount.value
+        val section = if (from < queued) 0..(queued - 1) else queued..list.lastIndex
+        if (section.isEmpty()) return
+        val target = toDisplayedIndex.coerceIn(section)
+        if (target == from) return
+
+        val rawTarget = list[target].queueIndex ?: return
+        _queue.value = list.toMutableList().apply { add(target, removeAt(from)) }
+
+        launchWithPlayer("moveQueueEntry") { pc ->
+            val moved = try {
+                pc.moveInQueue(qid, rawTarget)
+            } catch (e: Exception) {
+                LokiLogger.e(TAG, "moveQueueEntry ${track.name}", e)
+                false
+            }
+            LokiLogger.i(TAG, "Queue move ${track.name} to $target (server $rawTarget): $moved")
+            // Only resync when the server disagrees, so a good drag does not rebuild the list.
+            if (!moved) refreshQueue()
+        }
+    }
+
     fun refreshQueue() {
         launchWithSession("refreshQueue") { sess ->
             val state = player?.getState() ?: return@launchWithSession
@@ -2109,9 +2150,9 @@ class PlaybackViewModel : ViewModel() {
                 val info: TrackInfo,
                 val needsFetch: Boolean
             )
-            val visible = visibleQueue(state.next_tracks)
-            _queuedCount.value = visible.takeWhile { it.isQueued }.size
-            val parsed = visible.map { qt ->
+            val visible = visibleQueueIndexed(state.next_tracks)
+            _queuedCount.value = visible.takeWhile { it.value.isQueued }.size
+            val parsed = visible.map { (rawIndex, qt) ->
                 val art = normalizeSpfyImageUrl(qt.imageUrl)
                 val needsFetch = qt.name.isNullOrEmpty() || qt.artistName.isNullOrEmpty() || art == null
                 val info = TrackInfo(
@@ -2122,6 +2163,7 @@ class PlaybackViewModel : ViewModel() {
                     durationMs = qt.durationMs,
                     uid = qt.uid,
                     qid = qt.qid,
+                    queueIndex = rawIndex,
                 )
                 ParsedTrack(qt.uri, info, needsFetch)
             }

--- a/src/app/src/main/res/values-b+gsw/strings.xml
+++ b/src/app/src/main/res/values-b+gsw/strings.xml
@@ -242,6 +242,7 @@
     <string name="queue_next_up">Als Nächschts</string>
     <string name="queue_next_in_queue">Als Nächschts i de Warteschlange</string>
     <string name="queue_remove">Us de Warteschlange neh</string>
+    <string name="queue_reorder">Verschiebe</string>
     <string name="queue_empty">D Wartelischte isch leer</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values-de/strings.xml
+++ b/src/app/src/main/res/values-de/strings.xml
@@ -232,6 +232,7 @@
     <string name="queue_next_up">Als Nächstes</string>
     <string name="queue_next_in_queue">Als Nächstes in der Warteschlange</string>
     <string name="queue_remove">Aus der Warteschlange entfernen</string>
+    <string name="queue_reorder">Verschieben</string>
     <string name="queue_empty">Warteschlange ist leer</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values-ru/strings.xml
+++ b/src/app/src/main/res/values-ru/strings.xml
@@ -231,6 +231,7 @@
     <string name="queue_next_up">Далее</string>
     <string name="queue_next_in_queue">Далее в очереди</string>
     <string name="queue_remove">Убрать из очереди</string>
+    <string name="queue_reorder">Переместить</string>
     <string name="queue_empty">Очередь пуста</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -234,6 +234,7 @@
     <string name="queue_next_up">Next up</string>
     <string name="queue_next_in_queue">Next in queue</string>
     <string name="queue_remove">Remove from queue</string>
+    <string name="queue_reorder">Reorder</string>
     <string name="queue_empty">Queue is empty</string>
 
     <!-- Lyrics Screen -->

--- a/src/app/src/test/java/ch/snepilatch/app/viewmodel/MoveQueueEntryTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/viewmodel/MoveQueueEntryTest.kt
@@ -1,0 +1,88 @@
+package ch.snepilatch.app.viewmodel
+
+import ch.snepilatch.app.data.TrackInfo
+import io.mockk.coVerify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Dragging a queue row to a new position (issue #587).
+ *
+ * The trap this pins: the sheet hides the delimiter and any flagged entry, so a row's position on
+ * screen is not the index the server wants. A live queue was observed carrying two hidden entries,
+ * so passing the displayed index straight through would drop tracks in the wrong slot.
+ */
+class MoveQueueEntryTest {
+
+    private val rig = PlaybackTestRig()
+
+    @Before
+    fun setUp() = rig.install()
+
+    @After
+    fun tearDown() = rig.uninstall()
+
+    private fun row(qid: String, rawIndex: Int) = TrackInfo(
+        uri = "spotify:track:$qid",
+        name = qid,
+        artist = "artist",
+        albumArt = null,
+        qid = qid,
+        queueIndex = rawIndex,
+    )
+
+    @Test
+    fun `sends the server index of the row landed on, not the row number`() {
+        // Displayed rows 0,1,2 sit at server indices 0,3,4 because hidden entries fall between them.
+        rig.vm._queue.value = listOf(row("a", 0), row("b", 3), row("c", 4))
+        rig.vm._queuedCount.value = 3
+
+        rig.vm.moveQueueEntry(rig.vm.queue.value[0], 2)
+
+        coVerify { rig.player.moveInQueue("a", 4) }
+    }
+
+    @Test
+    fun `reorders the list straight away`() {
+        rig.vm._queue.value = listOf(row("a", 0), row("b", 1), row("c", 2))
+        rig.vm._queuedCount.value = 3
+
+        rig.vm.moveQueueEntry(rig.vm.queue.value[0], 2)
+
+        assertEquals(listOf("b", "c", "a"), rig.vm.queue.value.map { it.qid })
+    }
+
+    /** The server refuses to move a queued entry into the context, so the local list must not either. */
+    @Test
+    fun `a queued row cannot be dragged past its section`() {
+        rig.vm._queue.value = listOf(row("q1", 0), row("q2", 1), row("c1", 2), row("c2", 3))
+        rig.vm._queuedCount.value = 2
+
+        rig.vm.moveQueueEntry(rig.vm.queue.value[0], 3)
+
+        assertEquals(listOf("q2", "q1", "c1", "c2"), rig.vm.queue.value.map { it.qid })
+    }
+
+    @Test
+    fun `a context row cannot be dragged into the queued block`() {
+        rig.vm._queue.value = listOf(row("q1", 0), row("c1", 1), row("c2", 2))
+        rig.vm._queuedCount.value = 1
+
+        rig.vm.moveQueueEntry(rig.vm.queue.value[2], 0)
+
+        assertEquals(listOf("q1", "c2", "c1"), rig.vm.queue.value.map { it.qid })
+    }
+
+    @Test
+    fun `dropping a row where it already sits writes nothing`() {
+        rig.vm._queue.value = listOf(row("a", 0), row("b", 1))
+        rig.vm._queuedCount.value = 2
+
+        rig.vm.moveQueueEntry(rig.vm.queue.value[0], 0)
+
+        assertEquals(listOf("a", "b"), rig.vm.queue.value.map { it.qid })
+        coVerify(exactly = 0) { rig.player.moveInQueue(any(), any()) }
+    }
+}


### PR DESCRIPTION
Adds a grip on the right of each queue row that drags it to a new position. The grip starts the drag rather than the row, because a row-wide vertical drag fights the list's own scrolling, which is why a touch queue needs a handle at all. The dragged row lifts and follows the finger while the rest hold still, and the move commits on release.

The important part is not the gesture. A displayed row's position is not the index a queue write wants: the sheet hides the delimiter and anything the server flagged, and a live queue was observed carrying two hidden entries. Rows now carry their index in the server's list, and a drop is translated through whichever entry occupies the target row. The move is also clamped to the entry's own section, mirroring what the server does, so the local list cannot show an order the server would refuse to store.

moveInQueue itself is now verified against the real server: the entry landed at the requested index, the revision advanced, and a drag past the queued block clamped to the block edge with the entry still flagged as queued.

Closes #587