### PR TITLE
Read playlists through the store and refresh them when they change

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/SessionHolder.kt
@@ -2,6 +2,7 @@ package ch.snepilatch.app.playback
 
 import ch.snepilatch.app.playback.engine.SpfyCdnResolver
 import kotify.api.playerconnect.PlayerConnect
+import kotify.api.playlist.PlaylistStore
 import kotify.cdn.SpfyPlayback
 import kotify.session.Session
 
@@ -26,6 +27,12 @@ object SessionHolder {
     @Volatile var spfyPlayback: SpfyPlayback? = null
     @Volatile var cdnResolver: SpfyCdnResolver? = null
 
+    /**
+     * Playlist pages, kept until the dealer says they are stale. Process scoped like the session so
+     * a playlist read once stays read across screens rather than per ViewModel.
+     */
+    @Volatile var playlistStore: PlaylistStore? = null
+
     /** The signed-in user's Spfy username. Set during initialize once the profile loads; read by
      *  library mutations (create/delete/save playlist) that need it. */
     @Volatile var username: String = ""
@@ -49,6 +56,8 @@ object SessionHolder {
 
     /** Called on teardown — clears all references without disconnecting. */
     fun clear() {
+        playlistStore?.clear()
+        playlistStore = null
         session = null
         player = null
         spfyPlayback = null

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
@@ -7,6 +7,7 @@ import ch.snepilatch.app.util.LokiLogger
 import kotify.api.album.Album
 import kotify.api.artist.Artist
 import kotify.api.playlist.Playlist
+import kotify.api.playlist.PlaylistInfo
 import kotify.api.podcast.Podcast
 import kotify.api.radio.Radio
 import kotify.api.song.Song
@@ -62,7 +63,49 @@ class DetailViewModel : SessionViewModel("DetailVM") {
     }
 
     fun openPlaylist(playlistId: String) = openDetail(Screen.PLAYLIST_DETAIL, "openPlaylist") { sess ->
-        Playlist(sess).getPlaylist(playlistId, limit = 50).toDetailData(playlistId)
+        playlistPage(sess, playlistId, limit = 50, offset = 0).toDetailData(playlistId)
+    }
+
+    /**
+     * A playlist page from the store, which keeps it until the dealer says it changed. Falls back to
+     * a direct read if the store is not up yet, so opening a playlist never depends on init order.
+     */
+    private suspend fun playlistPage(sess: Session, playlistId: String, limit: Int, offset: Int): PlaylistInfo {
+        val store = SessionHolder.playlistStore?.also { watchForInvalidations(it) }
+        val started = System.currentTimeMillis()
+        val page = store?.page(playlistId, limit, offset)
+            ?: Playlist(sess).getPlaylist(playlistId, limit, offset)
+        // A cached page returns in about no time; a fetched one does not. Worth a line, because
+        // "did that cost a request" is otherwise invisible.
+        LokiLogger.i(
+            logTag,
+            "Playlist $playlistId offset $offset: ${page.tracks.size} tracks in " +
+                "${System.currentTimeMillis() - started}ms${if (store == null) " (no store)" else ""}"
+        )
+        return page
+    }
+
+    private var watchingInvalidations = false
+
+    /**
+     * Refresh the playlist on screen when it changes somewhere else.
+     *
+     * Attached on first use rather than in an init block, because the store is created with the
+     * session and this ViewModel can exist before that. A playlist that is not on screen needs
+     * nothing: its pages are already dropped, so opening it reads fresh.
+     */
+    private fun watchForInvalidations(store: kotify.api.playlist.PlaylistStore) {
+        if (watchingInvalidations) return
+        watchingInvalidations = true
+        store.onInvalidated { playlistId ->
+            val open = _detail.value
+            if (open.type != "playlist" || !open.uri.endsWith(playlistId)) return@onInvalidated
+            launchWithSession("reloadInvalidatedPlaylist") { sess ->
+                val fresh = playlistPage(sess, playlistId, limit = 50, offset = 0).toDetailData(playlistId)
+                // The user may have navigated on while this was in flight.
+                if (_detail.value.uri == open.uri) _detail.value = fresh
+            }
+        }
     }
 
     fun openAlbum(albumId: String) = openDetail(Screen.ALBUM_DETAIL, "openAlbum") { sess ->
@@ -141,7 +184,7 @@ class DetailViewModel : SessionViewModel("DetailVM") {
                     )
                 } else if (uri.startsWith("spotify:playlist:")) {
                     val id = uri.removePrefix("spotify:playlist:")
-                    val info = Playlist(sess).getPlaylist(id, limit = DETAIL_PAGE_SIZE, offset = offset)
+                    val info = playlistPage(sess, id, limit = DETAIL_PAGE_SIZE, offset = offset)
                     val more = info.tracks.map { it.toTrackInfo() }
                     val newSize = current.tracks.size + more.size
                     // Server-reported totalTracks is unreliable (PlaylistMapper
@@ -293,6 +336,9 @@ class DetailViewModel : SessionViewModel("DetailVM") {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 Playlist(sess).removeFromPlaylist(playlistId, listOf(uid))
+                // Our own write leaves the cached pages describing a playlist that no longer exists
+                // in that shape, and the dealer does not necessarily tell us about our own change.
+                SessionHolder.playlistStore?.invalidate(playlistId)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -514,6 +514,9 @@ class PlaybackViewModel : ViewModel() {
                 // SessionHolder — session/spfyPlayback/cdnResolver are already
                 // live there from the initialization block above.
                 player = pc
+                // Handed the client so it hears the dealer's playlist-changed signal itself; a store
+                // nobody wired up is a cache that never expires.
+                SessionHolder.playlistStore = kotify.api.playlist.PlaylistStore(sess, pc)
                 LokiLogger.i(TAG, "Player ready, device: ${pc.ourDeviceId()}")
                 loadDevices()
 


### PR DESCRIPTION
Playlist pages now come from the KotifyClient store rather than a fresh fetch each time, so reopening a playlist costs nothing for the pages already read. There is a fallback to a direct read when the store is not up yet, so opening a playlist never depends on init order.

Two things beyond caching. Our own writes invalidate the playlist, because after removing a track the cached page describes a shape that no longer exists and the dealer does not necessarily report our own change back to us. And a playlist open on screen refreshes itself when it changes elsewhere, attached on first use rather than in an init block since the store is created with the session.

Measured on device. Before: reopening cost 422ms and 508ms to refetch pages already seen. After:

    offset   0: 50 tracks in   0ms
    offset  50: 50 tracks in   0ms
    offset 100: 50 tracks in 399ms

Cached pages return instantly, a genuinely new page still fetches.