### PR TITLE
Give the app one configured image loader

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/KotifyApp.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/KotifyApp.kt
@@ -2,12 +2,47 @@ package ch.snepilatch.app
 
 import android.app.Application
 import android.provider.Settings
+import coil.ImageLoader
+import coil.ImageLoaderFactory
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
 import ch.snepilatch.app.util.LokiLogger
 import ch.snepilatch.app.viewmodel.AppSettings
 import kotify.utils.LogBackend
 import kotify.utils.Logger
 
-class KotifyApp : Application() {
+class KotifyApp : Application(), ImageLoaderFactory {
+    /**
+     * The one image loader the whole app uses (issue #611).
+     *
+     * Coil reads this off the Application, so every AsyncImage and every direct
+     * `Coil.imageLoader(context)` call gets it without any of them asking. That is the point: cover
+     * art is loaded from the queue, the player, the library, the lyrics screen, the notification and
+     * the palette extractor, and a cache that only some of them shared would keep re-fetching the
+     * same artwork.
+     *
+     * Both caches are sized here rather than left to the defaults so the numbers are a decision.
+     * Cache headers are ignored on purpose: cover art at a given url never changes, so revalidating
+     * it costs a round trip per image to be told nothing changed, which is exactly the stall that
+     * shows up as jank when scrolling back through a list.
+     */
+    override fun newImageLoader(): ImageLoader = ImageLoader.Builder(this)
+        .memoryCache {
+            MemoryCache.Builder(this)
+                .maxSizePercent(0.25)
+                .build()
+        }
+        .diskCache {
+            DiskCache.Builder()
+                .directory(cacheDir.resolve("image_cache"))
+                // Roughly a few thousand covers. Large enough that a scroll back through a library
+                // is free, small enough to stay a cache rather than a download of everything seen.
+                .maxSizeBytes(200L * 1024 * 1024)
+                .build()
+        }
+        .respectCacheHeaders(false)
+        .build()
+
     override fun onCreate() {
         super.onCreate()
 


### PR DESCRIPTION
Cover art is loaded from the queue, the player, the library, the lyrics screen, the notification and the palette extractor, each building its own request against Coil's unconfigured default. This puts one deliberately configured loader on the Application, which Coil hands to every call site without any of them asking.

Honest scope: a disk cache already existed, because Coil's default uses the same directory. What changes is that both cache sizes are now decisions rather than defaults (200MB disk, 25% memory) and cache headers are ignored, so artwork at a given url is not revalidated on every load. That saves a round trip per image, not a decode.

It does not claim to fix scroll jank. That needs measuring, and rows currently decode roughly 300px artwork into roughly 130px views, which is a separate thing.

Closes #611