### PR TITLE
Index downloaded tracks so long playlists scroll smoothly

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
@@ -56,6 +56,11 @@ object Downloads {
     /** Track URIs with a local copy, for the UI to tint rows without querying per item. */
     val downloaded: StateFlow<Set<String>> = _downloaded.asStateFlow()
 
+    private val _index = MutableStateFlow<Set<String>>(emptySet())
+
+    /** Uri and title/artist keys of every row, so a list row costs a hash lookup, not a scan. */
+    val index: StateFlow<Set<String>> = _index.asStateFlow()
+
     private val _inProgress = MutableStateFlow<Set<String>>(emptySet())
 
     /** Track URIs being fetched right now, so a row can show a spinner instead of a download icon. */
@@ -211,12 +216,25 @@ object Downloads {
      * resolve playback. Without this, a track that only matches through the fallback plays from
      * disk correctly but every checkmark in the UI still called it not downloaded.
      *
-     * Pure over [rows], like [matchByMetadata]: callers pass whatever [rows] StateFlow snapshot
-     * they already collected, so this stays cheap enough to call per row in a list.
+     * Pure over [index]: callers pass the snapshot they already collected, so a row costs a
+     * hash lookup rather than a scan of every downloaded row.
      */
-    fun isDownloaded(rows: List<DownloadedTrack>, trackUri: String, title: String? = null, artist: String? = null): Boolean =
-        rows.any { it.trackUri == trackUri } ||
-            (!title.isNullOrBlank() && matchByMetadata(rows, title, artist.orEmpty()) != null)
+    fun isDownloaded(index: Set<String>, trackUri: String, title: String? = null, artist: String? = null): Boolean {
+        if (trackUri in index) return true
+        if (title.isNullOrBlank()) return false
+        val key = normalize(title)
+        val artists = artistSet(artist.orEmpty())
+        return if (artists.isEmpty()) "$key$SEP" in index else artists.any { "$key$SEP$it" in index }
+    }
+
+    internal fun indexOf(rows: List<DownloadedTrack>): Set<String> = rows.flatMapTo(mutableSetOf(), ::keysOf)
+
+    private fun keysOf(row: DownloadedTrack): List<String> {
+        val key = normalize(row.title)
+        return listOf(row.trackUri, "$key$SEP") + artistSet(row.artist).map { "$key$SEP$it" }
+    }
+
+    private val SEP = 0.toChar()
 
     /** Case- and width-insensitive: half- and full-width forms of a title are the same song. */
     private fun normalize(value: String): String =
@@ -303,6 +321,7 @@ object Downloads {
         val loaded = all()
         _rows.value = loaded
         _downloaded.value = loaded.mapTo(mutableSetOf()) { it.trackUri }
+        _index.value = indexOf(loaded)
     }
 
     private fun DownloadedTrack.toValues() = ContentValues().apply {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -152,11 +152,9 @@ fun SpfyImage(
     ) {
         Icon(icon, null, tint = SpfyLightGray.copy(alpha = 0.5f), modifier = Modifier.size(32.dp))
         if (!url.isNullOrEmpty()) {
+            val ctx = androidx.compose.ui.platform.LocalContext.current
             AsyncImage(
-                model = coil.request.ImageRequest.Builder(androidx.compose.ui.platform.LocalContext.current)
-                    .data(url)
-                    .crossfade(300)
-                    .build(),
+                model = remember(url) { coil.request.ImageRequest.Builder(ctx).data(url).crossfade(300).build() },
                 contentDescription = contentDescription,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop
@@ -242,9 +240,9 @@ fun TrackRow(
     val accent = theme.primary
     // One list for the whole screen, so a row costs a scan rather than a query. Falls back to
     // title/artist like playback does, so a relinked track's checkmark agrees with what plays.
-    val downloadedRows by Downloads.rows.collectAsState()
+    val downloadedIndex by Downloads.index.collectAsState()
     val inFlight by Downloads.inProgress.collectAsState()
-    val isDownloaded = Downloads.isDownloaded(downloadedRows, track.uri, track.name, track.artist)
+    val isDownloaded = Downloads.isDownloaded(downloadedIndex, track.uri, track.name, track.artist)
     val isDownloading = track.uri in inFlight
 
     Row(

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -269,7 +269,7 @@ fun DetailScreen(vm: PlaybackViewModel) {
                 // Flips to a tick once every track is on disk, and then removes them instead. Falls
                 // back to title/artist per track like playback does, so a relinked track that only
                 // matches that way still counts toward "all downloaded".
-                val downloadedRows by Downloads.rows.collectAsState()
+                val downloadedIndex by Downloads.index.collectAsState()
                 val inFlight by Downloads.inProgress.collectAsState()
                 val downloading = detail.tracks.any { it.uri in inFlight }
                 // detail.tracks is one loaded page. Downloading it would silently cover the first 50 of
@@ -279,7 +279,7 @@ fun DetailScreen(vm: PlaybackViewModel) {
                 // with no confirmation while the rest stayed downloaded.
                 val loadingAll by detailVm.isLoadingAll.collectAsState()
                 val allDownloaded = !hasMore && detail.tracks.isNotEmpty() &&
-                    detail.tracks.all { Downloads.isDownloaded(downloadedRows, it.uri, it.name, it.artist) }
+                    detail.tracks.all { Downloads.isDownloaded(downloadedIndex, it.uri, it.name, it.artist) }
                 if (downloadable) {
                     IconButton(
                         onClick = {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -1191,12 +1191,12 @@ private fun NowPlayingMenu(
             val downloadCtx = androidx.compose.ui.platform.LocalContext.current
             // Falls back to title/artist like playback does, so a relinked track's menu label
             // agrees with what's actually on disk.
-            val downloadedRows by Downloads.rows.collectAsState()
+            val downloadedIndex by Downloads.index.collectAsState()
             // In-flight as well as downloaded, like every track row: isDownloaded is still false while
             // the fetch runs, so without this the entry looked untouched and a second tap started a
             // second download of the same track.
             val inFlight by Downloads.inProgress.collectAsState()
-            val isDownloaded = track?.let { Downloads.isDownloaded(downloadedRows, it.uri, it.name, it.artist) } == true
+            val isDownloaded = track?.let { Downloads.isDownloaded(downloadedIndex, it.uri, it.name, it.artist) } == true
             val isDownloading = track?.uri?.let { it in inFlight } == true
             val downloadLabel = when {
                 isDownloading -> stringResource(R.string.downloading)

--- a/src/app/src/test/java/ch/snepilatch/app/download/DownloadedIndexTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/download/DownloadedIndexTest.kt
@@ -1,0 +1,55 @@
+package ch.snepilatch.app.download
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Scanning every downloaded row per list row cost 12ms a frame on a long playlist. The index keeps
+ * the relinked-track fallback of [FindByMetadataTest] while costing a hash lookup instead.
+ */
+class DownloadedIndexTest {
+
+    private val row = DownloadedTrack(
+        trackUri = "spotify:track:7gJD9BarjoFwL2BNQ0rpWT",
+        documentUri = "content://tree/Music/fatal.opus",
+        source = "ytm",
+        provider = "YouTube Music",
+        mimeType = "audio/ogg",
+        coverUrl = null,
+        contextUri = null,
+        contextName = null,
+        contextType = null,
+        sizeBytes = 1,
+        title = "ファタール - Fatal",
+        artist = "GEMN, Kento Nakajima, Tatsuya Kitani",
+        downloadedAt = 0,
+    )
+
+    private val index = Downloads.indexOf(listOf(row))
+
+    @Test
+    fun theDownloadedUriIsFound() {
+        assertTrue(Downloads.isDownloaded(index, row.trackUri))
+    }
+
+    @Test
+    fun theOtherReleaseOfTheSameSongIsFound() {
+        assertTrue(Downloads.isDownloaded(index, "spotify:track:other", row.title, "Kento Nakajima"))
+    }
+
+    @Test
+    fun aTitleWithNoArtistStillMatches() {
+        assertTrue(Downloads.isDownloaded(index, "spotify:track:other", row.title, ""))
+    }
+
+    @Test
+    fun anotherSongByTheSameArtistIsNotDownloaded() {
+        assertFalse(Downloads.isDownloaded(index, "spotify:track:other", "Different Song", "GEMN"))
+    }
+
+    @Test
+    fun theSameTitleByAnotherArtistIsNotDownloaded() {
+        assertFalse(Downloads.isDownloaded(index, "spotify:track:other", row.title, "Someone Else"))
+    }
+}

--- a/src/app/src/test/java/ch/snepilatch/app/download/FindByMetadataTest.kt
+++ b/src/app/src/test/java/ch/snepilatch/app/download/FindByMetadataTest.kt
@@ -71,14 +71,14 @@ class FindByMetadataTest {
 
     @Test
     fun isDownloadedMatchesByExactUriRegardlessOfMetadata() {
-        assertTrue(Downloads.isDownloaded(listOf(row), row.trackUri, title = "Some Other Title", artist = "Someone Else"))
+        assertTrue(Downloads.isDownloaded(Downloads.indexOf(listOf(row)), row.trackUri, title = "Some Other Title", artist = "Someone Else"))
     }
 
     @Test
     fun isDownloadedFallsBackToMetadataWhenTheUriDiffers() {
         assertTrue(
             Downloads.isDownloaded(
-                listOf(row),
+                Downloads.indexOf(listOf(row)),
                 trackUri = "spotify:track:relinkedIdNotInTheIndex",
                 title = "ファタール - Fatal",
                 artist = "GEMN, Kento Nakajima, Tatsuya Kitani",
@@ -88,11 +88,11 @@ class FindByMetadataTest {
 
     @Test
     fun isDownloadedIsFalseWhenNeitherUriNorMetadataMatch() {
-        assertFalse(Downloads.isDownloaded(listOf(row), "spotify:track:notDownloaded", "Another Song", "Nobody"))
+        assertFalse(Downloads.isDownloaded(Downloads.indexOf(listOf(row)), "spotify:track:notDownloaded", "Another Song", "Nobody"))
     }
 
     @Test
     fun isDownloadedIsFalseForAMissingUriAndNoMetadataToFallBackOn() {
-        assertFalse(Downloads.isDownloaded(listOf(row), "spotify:track:notDownloaded"))
+        assertFalse(Downloads.isDownloaded(Downloads.indexOf(listOf(row)), "spotify:track:notDownloaded"))
     }
 }


### PR DESCRIPTION
Every track row called isDownloaded, which scanned the whole downloads table and NFKC-normalized each row, so a 2503-track playlist spent 12ms a frame on the UI thread while the GPU sat at 2ms. The uri and title/artist keys are now built once when the table changes, and a row does a hash lookup. The relinked-track fallback is unchanged, and the existing matcher tests now run through the index.

Measured on device over the same eight-swipe fling: 26.4% janky frames and a 12ms median before, 2.8% and 7ms after, with the 95th percentile down from 22ms to 12ms.

Closes #632