### PR TITLE
Fixed cover image on song change

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -504,46 +504,60 @@ fun SlidingCoverImage(
     url: String?,
     modifier: Modifier = Modifier,
     shape: androidx.compose.ui.graphics.Shape = RoundedCornerShape(8.dp),
-    trackKey: Any? = url
+    trackKey: Any? = url,
+    /** False when the change came from going back, which reverses the entrance. */
+    forward: Boolean = true
 ) {
     var currentUrl by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(url) }
     var currentKey by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(trackKey) }
     var previousUrl by androidx.compose.runtime.remember {
         androidx.compose.runtime.mutableStateOf<String?>(null)
     }
+    var back by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
     val anim = androidx.compose.runtime.remember { androidx.compose.animation.core.Animatable(1f) }
-    androidx.compose.runtime.LaunchedEffect(trackKey, url) {
-        if (trackKey != currentKey) {
-            previousUrl = currentUrl
-            currentKey = trackKey
-            currentUrl = url
+    // Keyed on the track alone. Keying on the url as well let a mid-animation artwork upgrade cancel
+    // the effect, leaving previousUrl set and the entrance frozen part-way: the old cover stayed on
+    // top of a new one parked off to the side, which reads as the cover never changing.
+    androidx.compose.runtime.LaunchedEffect(trackKey) {
+        if (trackKey == currentKey) return@LaunchedEffect
+        previousUrl = currentUrl
+        currentKey = trackKey
+        currentUrl = url
+        back = !forward
+        try {
             anim.snapTo(0f)
             anim.animateTo(
                 1f,
                 tween(750, easing = androidx.compose.animation.core.CubicBezierEasing(0.835f, -0.008f, 0.149f, 0.866f))
             )
+        } finally {
             previousUrl = null
-        } else if (url != currentUrl) {
-            // Same track, better artwork. An optimistic skip paints the queue entry's `imageUrl`,
-            // then the confirmed state upgrades it to `imageLargeUrl` — a different string for the
-            // same picture. Swap it in place; replaying the entrance would slide the identical
-            // cover in a second time, a beat after the first.
-            currentUrl = url
         }
+    }
+    // Same track, better artwork. An optimistic skip paints the queue entry's `imageUrl`, then the
+    // confirmed state upgrades it to `imageLargeUrl` — a different string for the same picture. Swap
+    // it in place; replaying the entrance would slide the identical cover in a second time.
+    androidx.compose.runtime.LaunchedEffect(url) {
+        if (trackKey == currentKey) currentUrl = url
     }
     // Clip to the cover frame (like spicy's `overflow: hidden` MediaImageContainer) so the incoming
     // cover slides in from the frame's own right edge, not from off-screen.
     Box(modifier.clip(shape)) {
-        previousUrl?.let { prev ->
-            SpfyImage(url = prev, modifier = Modifier.matchParentSize(), shape = shape)
-        }
         val sliding = previousUrl != null
+        // Forward, the arriving cover slides in over the one being left. Going back it is the other
+        // way round: the cover being left slides away and uncovers the one returning underneath.
+        val under = if (back) currentUrl else previousUrl
+        val over = if (back) previousUrl else currentUrl
+        under?.let { beneath ->
+            SpfyImage(url = beneath, modifier = Modifier.matchParentSize(), shape = shape)
+        }
         SpfyImage(
-            url = currentUrl,
+            url = over,
             modifier = Modifier
                 .matchParentSize()
                 .graphicsLayer {
-                    translationX = size.width * (1f - anim.value)
+                    translationX =
+                        if (back) -size.width * anim.value else size.width * (1f - anim.value)
                     if (sliding) {
                         shadowElevation = 24f
                         this.shape = shape

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/NowPlayingScreen.kt
@@ -373,6 +373,7 @@ fun NowPlayingScreen(
     val isAd by vm.isAdFlow.collectAsState()
     val isShuffling by vm.isShufflingFlow.collectAsState()
     val repeatMode by vm.repeatModeFlow.collectAsState()
+    val skippedBack by vm.skippedBack.collectAsState()
     // While an ad is being skipped we keep the CURRENT song frozen on screen (cover/title/progress)
     // and show a loading spinner (see spinnerActive) — so the ~2.5s ad skip reads as "loading the next
     // track", not an interruption. `track` is unchanged during an ad, so no blanking is needed.
@@ -446,7 +447,8 @@ fun NowPlayingScreen(
                                 .fillMaxHeight(0.85f)
                                 .aspectRatio(1f),
                             shape = RoundedCornerShape(16.dp),
-                            trackKey = track?.uri
+                            trackKey = track?.uri,
+                            forward = !skippedBack
                         )
                     }
 
@@ -688,14 +690,16 @@ fun NowPlayingScreen(
                         // Invisible placeholder — same size as album art to keep layout stable
                         Box(Modifier.fillMaxWidth().aspectRatio(1f))
                     } else {
-                        // Album art — large with rounded corners; slides in from the right on song change.
+                        // Album art — large with rounded corners; the arriving cover slides in from
+                        // the right, or the leaving one slides off left when going back.
                         ch.snepilatch.app.ui.components.SlidingCoverImage(
                             url = displayArtUrl,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .aspectRatio(1f),
                             shape = RoundedCornerShape(16.dp),
-                            trackKey = track?.uri
+                            trackKey = track?.uri,
+                            forward = !skippedBack
                         )
                     }
 

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -147,6 +147,9 @@ class PlaybackViewModel : ViewModel() {
     private var lastCommandTs: Long = 0L
     private var lastCommandName: String = ""
 
+    /** Which way the last track change went, so the cover animates towards where the track came from. */
+    val skippedBack = MutableStateFlow(false)
+
     // Diagnostic: wall-clock when the current ad-skip began (onAd). Milestones log deltas against it
     // so we can see exactly where a single-ad skip spends its ~3s (silent clip / advance / post-ad
     // resolve). Reset to 0 once the post-ad real track's audio is producing.
@@ -1758,6 +1761,7 @@ class PlaybackViewModel : ViewModel() {
 
     fun skipNext() {
         applyOptimisticSkip(nextTrackPreview.value)
+        skippedBack.value = false
         commandJob?.cancel()
         lastCommandTs = System.currentTimeMillis()
         lastCommandName = "skipNext"
@@ -1783,6 +1787,7 @@ class PlaybackViewModel : ViewModel() {
         }
         val pos = _playback.value.positionMs
         applyOptimisticSkip(prevTrackPreview.value)
+        skippedBack.value = true
         commandJob?.cancel()
         lastCommandTs = System.currentTimeMillis()
         lastCommandName = "skipPrevious"


### PR DESCRIPTION
SlidingCoverImage keyed its entrance on both the track and the url, so an artwork upgrade that arrived without a track change cancelled the running animation and re-ran the effect. That path only swaps the url and returns, which left previousUrl set and the animation frozen part-way: the old cover sat on top of a new one parked off to the side, reading as the cover never changing or sticking mid-slide.

The upgrade is exactly what the code already described — an optimistic skip paints the queue entry's imageUrl and the confirmed state replaces it with imageLargeUrl — and it lands mid-animation, which is why this turned up now and then without spam-skipping.

The entrance is now keyed on the track alone, the url upgrade swaps in place from its own effect, and the animation clears previousUrl in a finally so an interruption cannot strand it.

Going back also animates the other way round now: the cover being left slides off to the left and uncovers the one returning underneath, rather than the returning cover sliding in over it.

Closes #648