### PR TITLE
Cancel a running download

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DownloadsScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DownloadsScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.CloudDone
 import androidx.compose.material.icons.rounded.Downloading
 import androidx.compose.material3.*
@@ -107,7 +108,7 @@ fun DownloadsScreen(vm: PlaybackViewModel) {
             return@Column
         }
 
-        ActiveDownload(active)
+        ActiveDownload(active, onCancel = { vm.cancelDownloads() })
     }
 }
 
@@ -118,7 +119,7 @@ fun DownloadsScreen(vm: PlaybackViewModel) {
  * the current track.
  */
 @Composable
-private fun ActiveDownload(job: Downloads.ActiveJob) {
+private fun ActiveDownload(job: Downloads.ActiveJob, onCancel: () -> Unit) {
     // A re-encode keeps the recording that was just played; there is nothing to fetch, so it has no
     // percentage to report and spins rather than filling a ring stuck at zero.
     val reencode = job.type == Downloads.TYPE_REENCODE
@@ -143,14 +144,23 @@ private fun ActiveDownload(job: Downloads.ActiveJob) {
             )
         },
         trailingContent = {
-            if (reencode) {
-                CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
-            } else {
-                CircularProgressIndicator(
-                    progress = { job.trackPercent.coerceIn(0, 100) / 100f },
-                    strokeWidth = 2.dp,
-                    modifier = Modifier.size(18.dp),
-                )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                if (reencode) {
+                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
+                } else {
+                    CircularProgressIndicator(
+                        progress = { job.trackPercent.coerceIn(0, 100) / 100f },
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                // Only a batch can be stopped: a single track is done in seconds, and the auto-save
+                // runs on its own and would be cancelled out from under the listener.
+                if (job.total > 1) {
+                    IconButton(onClick = onCancel) {
+                        Icon(Icons.Rounded.Close, stringResource(R.string.cancel), tint = SpfyLightGray)
+                    }
+                }
             }
         },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent)

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -3205,6 +3205,14 @@ class PlaybackViewModel : ViewModel() {
      * Downloads a whole album or playlist, one track at a time so the per-track notifications are
      * replaced by a single count. Tracks already on disk are skipped by the downloader itself.
      */
+    /** The running download, kept so it can be stopped. Cancelling it stops the rest of the batch. */
+    private var downloadJob: Job? = null
+
+    /** Stops whatever is downloading. The batch clears its own notification and card on the way out. */
+    fun cancelDownloads() {
+        downloadJob?.cancel()
+    }
+
     fun downloadTracks(
         tracks: List<TrackInfo>,
         context: android.content.Context,
@@ -3214,7 +3222,7 @@ class PlaybackViewModel : ViewModel() {
     ) {
         if (tracks.isEmpty()) return
         val ctx = context.applicationContext
-        viewModelScope.launch(Dispatchers.IO) {
+        downloadJob = viewModelScope.launch(Dispatchers.IO) {
             val token = Downloads.startJob(
                 name = contextName ?: tracks.first().name,
                 type = contextType ?: "single",


### PR DESCRIPTION
Once a playlist or album download started there was no way to stop it short of force quitting.

The batch already unwound correctly when cancelled: it clears its ongoing notification and its job card on the way out. It just never kept a handle to cancel, so downloadTracks now holds its job and the Downloads tab offers an action next to the progress ring.

Scoped to batches. A single track is done in seconds, and the auto-save runs in the background with onlyIfIdle, so sharing the handle would let a save starting mid-batch steal it and stop the wrong thing.

Partial against the issue as written: there is no per-entry cancel because there is no queue yet, which is #642. This cancels the one active job the tab shows today, so #644 is worth revisiting once the queue lands.