### PR TITLE
Download queue with pause and cancel

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/download/DownloadQueue.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/download/DownloadQueue.kt
@@ -1,0 +1,97 @@
+package ch.snepilatch.app.download
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * What the app has been asked to download, as opposed to [Downloads], which indexes what is already
+ * on disk. Each entry carries its own progress and outcome: a single slot meant a batch, a tapped
+ * row and an auto-save fought over one card, and whichever finished first blanked it while the
+ * others were still running.
+ */
+object DownloadQueue {
+
+    /** One thing the user asked for: an album, a playlist, a tapped track, or an auto-save. */
+    data class QueueEntry(
+        val id: Int,
+        val name: String,
+        val type: String,
+        val imageUrl: String?,
+        val total: Int,
+        val done: Int = 1,
+        val trackPercent: Int = 0,
+        val state: State = State.Running,
+        val paused: Boolean = false,
+    ) {
+        enum class State { Running, Done, Failed, Cancelled }
+
+        val running: Boolean get() = state == State.Running
+    }
+
+    private val _queue = MutableStateFlow<List<QueueEntry>>(emptyList())
+
+    /** Everything asked for, oldest first. */
+    val queue: StateFlow<List<QueueEntry>> = _queue.asStateFlow()
+
+    private val nextJobId = java.util.concurrent.atomic.AtomicInteger(0)
+
+    private val gates = java.util.concurrent.ConcurrentHashMap<Int, CompletableDeferred<Unit>>()
+
+    /** [QueueEntry.type] for a track kept from what was played rather than fetched. */
+    const val TYPE_REENCODE = "reencode"
+
+    /** How many finished entries to keep, so an auto-save on every track cannot grow without bound. */
+    private const val KEEP_FINISHED = 10
+
+    /** @return the id to pass back to [updateJob] and [finishJob]. */
+    fun enqueue(name: String, type: String, imageUrl: String?, total: Int): Int {
+        val id = nextJobId.incrementAndGet()
+        _queue.update { list ->
+            val finished = list.filter { !it.running }
+            val trimmed = if (finished.size >= KEEP_FINISHED) {
+                list - finished.take(finished.size - KEEP_FINISHED + 1).toSet()
+            } else {
+                list
+            }
+            trimmed + QueueEntry(id, name, type, imageUrl, total)
+        }
+        return id
+    }
+
+    fun updateJob(id: Int, done: Int, trackPercent: Int) = _queue.update { list ->
+        list.map { if (it.id == id) it.copy(done = done, trackPercent = trackPercent) else it }
+    }
+
+    fun finishJob(id: Int, state: QueueEntry.State) {
+        // Release the gate first: an entry cancelled while paused is otherwise left awaiting a resume
+        // that will never come, and its coroutine never unwinds.
+        gates.remove(id)?.complete(Unit)
+        _queue.update { list ->
+            list.map { if (it.id == id) it.copy(state = state, paused = false) else it }
+        }
+    }
+
+    /**
+     * Holds an entry between tracks while it is paused. Suspends on a gate rather than polling a
+     * flag, so a paused download costs nothing and resumes the moment it is let go.
+     */
+    suspend fun awaitResume(id: Int) {
+        gates[id]?.await()
+    }
+
+    fun pause(id: Int) {
+        gates.putIfAbsent(id, CompletableDeferred())
+        _queue.update { list -> list.map { if (it.id == id) it.copy(paused = true) else it } }
+    }
+
+    fun resume(id: Int) {
+        gates.remove(id)?.complete(Unit)
+        _queue.update { list -> list.map { if (it.id == id) it.copy(paused = false) else it } }
+    }
+
+    /** Drop everything that is no longer running; anything in flight stays. */
+    fun clearFinished() = _queue.update { list -> list.filter { it.running } }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/download/Downloads.kt
@@ -66,54 +66,6 @@ object Downloads {
     /** Track URIs being fetched right now, so a row can show a spinner instead of a download icon. */
     val inProgress: StateFlow<Set<String>> = _inProgress.asStateFlow()
 
-    /** What is being fetched right now, as the album, playlist or single the user asked for. */
-    data class ActiveJob(
-        val name: String,
-        val type: String,
-        val imageUrl: String?,
-        val done: Int,
-        val total: Int,
-        val trackPercent: Int,
-    )
-
-    private val _activeJob = MutableStateFlow<ActiveJob?>(null)
-    val activeJob: StateFlow<ActiveJob?> = _activeJob.asStateFlow()
-
-    /**
-     * Which job owns the card. There is one slot and several things can download at once — a batch, a
-     * tapped row, an auto-save — so an update or a clear has to prove it is the current owner. Without
-     * that, whichever finished first blanked the card while the others were still running.
-     */
-    private val jobOwner = java.util.concurrent.atomic.AtomicInteger(0)
-
-    /** [ActiveJob.type] for a track kept from what was played rather than fetched. */
-    const val TYPE_REENCODE = "reencode"
-
-    /**
-     * @param onlyIfIdle leaves a running job's card alone and returns 0, which no update can match.
-     *   The auto-save uses it: it belongs on the list, but not at the price of blanking an album's
-     *   progress mid-batch.
-     * @return the token to pass back to [updateJob] and [clearJob].
-     */
-    fun startJob(name: String, type: String, imageUrl: String?, total: Int, onlyIfIdle: Boolean = false): Int {
-        // Safe to hand back 0: the card is only taken once jobOwner has passed 1, so a live job can
-        // never own that token.
-        if (onlyIfIdle && _activeJob.value != null) return 0
-        val token = jobOwner.incrementAndGet()
-        _activeJob.value = ActiveJob(name, type, imageUrl, done = 1, total = total, trackPercent = 0)
-        return token
-    }
-
-    fun updateJob(token: Int, done: Int, trackPercent: Int) {
-        if (token != jobOwner.get()) return
-        _activeJob.update { it?.copy(done = done, trackPercent = trackPercent) }
-    }
-
-    fun clearJob(token: Int) {
-        if (token != jobOwner.get()) return
-        _activeJob.value = null
-    }
-
     // update {} rather than value = value + x: several downloads run on independent IO coroutines,
     // and a lost remove would leave a row spinning for the rest of the process.
     fun markStarted(trackUri: String) {

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DownloadsScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DownloadsScreen.kt
@@ -2,11 +2,15 @@ package ch.snepilatch.app.ui.screens
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.CloudDone
 import androidx.compose.material.icons.rounded.Downloading
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -18,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.R
 import ch.snepilatch.app.download.DownloadFolder
+import ch.snepilatch.app.download.DownloadQueue
 import ch.snepilatch.app.download.Downloads
 import ch.snepilatch.app.ui.components.SpfyImage
 import ch.snepilatch.app.ui.theme.*
@@ -30,7 +35,7 @@ import ch.snepilatch.app.viewmodel.PlaybackViewModel
  */
 @Composable
 fun DownloadsScreen(vm: PlaybackViewModel) {
-    val job by Downloads.activeJob.collectAsState()
+    val queue by DownloadQueue.queue.collectAsState()
     val folder by DownloadFolder.folder.collectAsState()
     // Downloads.rows, not a query: a remember{} body runs on the composition thread, and every
     // finished track re-emits, so reading the table here put a full SELECT on the UI thread per track.
@@ -70,35 +75,28 @@ fun DownloadsScreen(vm: PlaybackViewModel) {
             }
         }
 
-        ListItem(
-            headlineContent = { Text(stringResource(R.string.download_folder), color = SpfyWhite) },
-            supportingContent = {
-                Text(
-                    folder?.let { readableFolder(it) } ?: stringResource(R.string.download_folder_none),
-                    color = SpfyLightGray
-                )
-            },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-        )
-        ListItem(
-            headlineContent = {
-                Text(stringResource(R.string.downloads_summary, stored.size, totalMb), color = SpfyWhite)
-            },
-            leadingContent = { Icon(Icons.Rounded.CloudDone, null, tint = SpfyLightGray) },
-            colors = ListItemDefaults.colors(containerColor = Color.Transparent)
-        )
+        StorageSummary(folder = folder, count = stored.size, totalMb = totalMb)
 
         HorizontalDivider(color = SpfyLightGray.copy(alpha = 0.15f))
-        Text(
-            stringResource(R.string.downloads_active),
-            color = SpfyLightGray,
-            fontSize = 13.sp,
-            fontWeight = FontWeight.SemiBold,
-            modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp)
-        )
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.downloads_active),
+                color = SpfyLightGray,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.weight(1f).padding(vertical = 12.dp)
+            )
+            if (queue.any { !it.running }) {
+                TextButton(onClick = { DownloadQueue.clearFinished() }) {
+                    Text(stringResource(R.string.downloads_clear_finished), color = SpfyLightGray)
+                }
+            }
+        }
 
-        val active = job
-        if (active == null) {
+        if (queue.isEmpty()) {
             Text(
                 stringResource(R.string.downloads_idle),
                 color = SpfyLightGray,
@@ -108,26 +106,53 @@ fun DownloadsScreen(vm: PlaybackViewModel) {
             return@Column
         }
 
-        ActiveDownload(active, onCancel = { vm.cancelDownloads() })
+        LazyColumn {
+            items(queue, key = { it.id }) { entry ->
+                QueuedDownload(entry, onCancel = { vm.cancelDownload(entry.id) })
+            }
+        }
     }
 }
 
-/**
- * What is downloading, named and with its artwork. The in-flight uri set cannot say more than
- * "something is downloading": it carries no title, so this read the base62 id off the uri. The job
- * knows the album or track the user asked for, how far through the list it is, and how far through
- * the current track.
- */
+/** Where the files go and how much room they take. */
 @Composable
-private fun ActiveDownload(job: Downloads.ActiveJob, onCancel: () -> Unit) {
+private fun StorageSummary(folder: android.net.Uri?, count: Int, totalMb: Int) {
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.download_folder), color = SpfyWhite) },
+        supportingContent = {
+            Text(
+                folder?.let { readableFolder(it) } ?: stringResource(R.string.download_folder_none),
+                color = SpfyLightGray
+            )
+        },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+    )
+    ListItem(
+        headlineContent = {
+            Text(stringResource(R.string.downloads_summary, count, totalMb), color = SpfyWhite)
+        },
+        leadingContent = { Icon(Icons.Rounded.CloudDone, null, tint = SpfyLightGray) },
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+    )
+}
+
+@Composable
+private fun QueuedDownload(job: DownloadQueue.QueueEntry, onCancel: () -> Unit) {
     // A re-encode keeps the recording that was just played; there is nothing to fetch, so it has no
     // percentage to report and spins rather than filling a ring stuck at zero.
-    val reencode = job.type == Downloads.TYPE_REENCODE
+    val reencode = job.type == DownloadQueue.TYPE_REENCODE
     ListItem(
         headlineContent = { Text(job.name, color = SpfyWhite, maxLines = 1) },
         supportingContent = {
             Text(
                 when {
+                    job.state == DownloadQueue.QueueEntry.State.Done ->
+                        stringResource(R.string.downloads_finished)
+                    job.state == DownloadQueue.QueueEntry.State.Failed ->
+                        stringResource(R.string.downloads_failed)
+                    job.state == DownloadQueue.QueueEntry.State.Cancelled ->
+                        stringResource(R.string.downloads_cancelled)
+                    job.paused -> stringResource(R.string.downloads_paused, job.done, job.total)
                     reencode -> stringResource(R.string.saving_listened)
                     job.total > 1 -> stringResource(R.string.downloading_count, job.done, job.total)
                     else -> stringResource(R.string.downloading)
@@ -145,18 +170,30 @@ private fun ActiveDownload(job: Downloads.ActiveJob, onCancel: () -> Unit) {
         },
         trailingContent = {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                if (reencode) {
-                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
-                } else {
-                    CircularProgressIndicator(
+                when {
+                    !job.running || job.paused -> Unit
+                    reencode -> CircularProgressIndicator(
+                        strokeWidth = 2.dp,
+                        modifier = Modifier.padding(end = 12.dp).size(18.dp),
+                    )
+                    else -> CircularProgressIndicator(
                         progress = { job.trackPercent.coerceIn(0, 100) / 100f },
                         strokeWidth = 2.dp,
-                        modifier = Modifier.size(18.dp),
+                        modifier = Modifier.padding(end = 12.dp).size(18.dp),
                     )
                 }
-                // Only a batch can be stopped: a single track is done in seconds, and the auto-save
-                // runs on its own and would be cancelled out from under the listener.
-                if (job.total > 1) {
+                // Only a batch pauses: it takes effect between tracks, so a single track has nothing
+                // to hold back.
+                if (job.running && job.total > 1) {
+                    IconButton(onClick = { if (job.paused) DownloadQueue.resume(job.id) else DownloadQueue.pause(job.id) }) {
+                        Icon(
+                            if (job.paused) Icons.Rounded.PlayArrow else Icons.Rounded.Pause,
+                            stringResource(if (job.paused) R.string.resume else R.string.pause),
+                            tint = SpfyLightGray,
+                        )
+                    }
+                }
+                if (job.running) {
                     IconButton(onClick = onCancel) {
                         Icon(Icons.Rounded.Close, stringResource(R.string.cancel), tint = SpfyLightGray)
                     }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -19,6 +19,7 @@ import ch.snepilatch.app.playback.PositionInterpolator
 import ch.snepilatch.app.playback.SessionHolder
 import ch.snepilatch.app.download.DownloadFolder
 import ch.snepilatch.app.download.DownloadNotifier
+import ch.snepilatch.app.download.DownloadQueue
 import ch.snepilatch.app.download.Downloads
 import ch.snepilatch.app.download.DownloadOutcome
 import ch.snepilatch.app.download.DownloadRequest
@@ -3172,45 +3173,59 @@ class PlaybackViewModel : ViewModel() {
         // applicationContext, or a batch outlives the Activity that started it and pins it — and its
         // whole Compose tree — for the minutes the download runs. Nothing here needs an Activity.
         val ctx = context.applicationContext
-        viewModelScope.launch(Dispatchers.IO) {
-            // A localOnly save is the auto-save path: it re-encodes what was played rather than
-            // fetching, so it shows as its own kind of job. onlyIfIdle because taking the slot
-            // mid-batch would blank an album's progress for no reason.
-            val token = Downloads.startJob(
-                name = track.name,
-                type = if (localOnly) Downloads.TYPE_REENCODE else "single",
-                imageUrl = track.albumArt,
-                total = 1,
-                onlyIfIdle = localOnly,
-            )
+        // A localOnly save is the auto-save path: it re-encodes what was played rather than fetching,
+        // so it shows as its own kind of entry. It no longer has to wait for an idle slot — every
+        // entry carries its own progress now.
+        val id = DownloadQueue.enqueue(
+            name = track.name,
+            type = if (localOnly) DownloadQueue.TYPE_REENCODE else "single",
+            imageUrl = track.albumArt,
+            total = 1,
+        )
+        // initScope, not viewModelScope: a download outlives the screen that started it, and backing
+        // out of the app used to cancel it and leave the entry reading as cancelled on the next launch.
+        val job = initScope.launch {
             val progress: ((Int) -> Unit)? = if (localOnly) {
                 null
             } else {
-                { percent -> Downloads.updateJob(token, done = 1, trackPercent = percent) }
+                { percent -> DownloadQueue.updateJob(id, done = 1, trackPercent = percent) }
             }
+            var state = DownloadQueue.QueueEntry.State.Failed
             try {
                 val outcome = TrackDownloader.download(
                     track.toRequest(capture, localOnly), ctx, onProgress = progress
                 )
+                if (outcome is DownloadOutcome.Done) state = DownloadQueue.QueueEntry.State.Done
                 warnNoFolder(ctx, outcome, track.name)
+            } catch (e: CancellationException) {
+                state = DownloadQueue.QueueEntry.State.Cancelled
+                throw e
             } finally {
-                // In a finally because cancellation (backing out of the app) has to clear the card too;
-                // it used to be left set, so the manager claimed a download was running forever.
-                Downloads.clearJob(token)
+                // In a finally because cancellation (backing out of the app) has to settle the entry
+                // too; it used to be left running, so the tab claimed a download that had stopped.
+                DownloadQueue.finishJob(id, state)
             }
         }
+        keep(id, job)
     }
 
     /**
      * Downloads a whole album or playlist, one track at a time so the per-track notifications are
      * replaced by a single count. Tracks already on disk are skipped by the downloader itself.
      */
-    /** The running download, kept so it can be stopped. Cancelling it stops the rest of the batch. */
-    private var downloadJob: Job? = null
+    /** Every running download by queue id, so one entry can be stopped without touching the others. */
+    private val downloadJobs = java.util.concurrent.ConcurrentHashMap<Int, Job>()
 
-    /** Stops whatever is downloading. The batch clears its own notification and card on the way out. */
-    fun cancelDownloads() {
-        downloadJob?.cancel()
+    private fun keep(id: Int, job: Job) {
+        // Prune here rather than when a download ends: removing from inside the job races the put
+        // that registered it, and a job that removed itself first would linger for good.
+        downloadJobs.values.removeAll { it.isCompleted }
+        downloadJobs[id] = job
+    }
+
+    /** Stops one queue entry. It settles its own notification and state on the way out. */
+    fun cancelDownload(id: Int) {
+        downloadJobs[id]?.cancel()
     }
 
     fun downloadTracks(
@@ -3222,16 +3237,20 @@ class PlaybackViewModel : ViewModel() {
     ) {
         if (tracks.isEmpty()) return
         val ctx = context.applicationContext
-        downloadJob = viewModelScope.launch(Dispatchers.IO) {
-            val token = Downloads.startJob(
-                name = contextName ?: tracks.first().name,
-                type = contextType ?: "single",
-                imageUrl = tracks.first().albumArt,
-                total = tracks.size,
-            )
+        val id = DownloadQueue.enqueue(
+            name = contextName ?: tracks.first().name,
+            type = contextType ?: "single",
+            imageUrl = tracks.first().albumArt,
+            total = tracks.size,
+        )
+        val job = initScope.launch {
             var failed = 0
+            var state = DownloadQueue.QueueEntry.State.Done
             try {
                 tracks.forEachIndexed { index, track ->
+                    // Between tracks, not mid-file: a paused entry stops before starting the next one
+                    // rather than abandoning bytes already fetched.
+                    DownloadQueue.awaitResume(id)
                     DownloadNotifier.batch(ctx, track.name, index + 1, tracks.size)
                     val outcome = TrackDownloader.download(
                         track.toRequest(
@@ -3242,15 +3261,17 @@ class PlaybackViewModel : ViewModel() {
                         ctx,
                         notify = false,
                     ) { percent ->
-                        Downloads.updateJob(token, index + 1, percent)
+                        DownloadQueue.updateJob(id, index + 1, percent)
                         DownloadNotifier.batch(ctx, track.name, index + 1, tracks.size, percent)
                     }
                     if (outcome !is DownloadOutcome.Done) failed++
                     if (outcome is DownloadOutcome.NoFolder) {
                         warnNoFolder(ctx, outcome, track.name)
+                        state = DownloadQueue.QueueEntry.State.Failed
                         return@launch
                     }
                 }
+                if (failed == tracks.size) state = DownloadQueue.QueueEntry.State.Failed
                 DownloadNotifier.batchFinished(ctx, tracks.size, failed)
             } catch (e: CancellationException) {
                 // The batch posts its own ongoing notification, so notify=false keeps TrackDownloader
@@ -3258,11 +3279,13 @@ class PlaybackViewModel : ViewModel() {
                 // cancelled with the Activity would leave "Downloading 7 of 30" posted for a download
                 // that is not running.
                 DownloadNotifier.clear(ctx)
+                state = DownloadQueue.QueueEntry.State.Cancelled
                 throw e
             } finally {
-                Downloads.clearJob(token)
+                DownloadQueue.finishJob(id, state)
             }
         }
+        keep(id, job)
     }
 
     fun removeDownload(trackUri: String) {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -3182,9 +3182,7 @@ class PlaybackViewModel : ViewModel() {
             imageUrl = track.albumArt,
             total = 1,
         )
-        // initScope, not viewModelScope: a download outlives the screen that started it, and backing
-        // out of the app used to cancel it and leave the entry reading as cancelled on the next launch.
-        val job = initScope.launch {
+        val job = viewModelScope.launch(Dispatchers.IO) {
             val progress: ((Int) -> Unit)? = if (localOnly) {
                 null
             } else {
@@ -3243,7 +3241,7 @@ class PlaybackViewModel : ViewModel() {
             imageUrl = tracks.first().albumArt,
             total = tracks.size,
         )
-        val job = initScope.launch {
+        val job = viewModelScope.launch(Dispatchers.IO) {
             var failed = 0
             var state = DownloadQueue.QueueEntry.State.Done
             try {

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -353,6 +353,13 @@
     <string name="downloaded_indicator">Downloaded</string>
     <string name="downloads_active">Active</string>
     <string name="downloads_idle">Nothing downloading right now</string>
+    <string name="downloads_finished">Finished</string>
+    <string name="downloads_failed">Failed</string>
+    <string name="downloads_cancelled">Cancelled</string>
+    <string name="downloads_clear_finished">Clear finished</string>
+    <string name="downloads_paused">Paused at %1$d of %2$d</string>
+    <string name="pause">Pause</string>
+    <string name="resume">Resume</string>
     <plurals name="remove_download_message">
         <item quantity="one">Delete the downloaded file for %1$s? (%2$d track)</item>
         <item quantity="other">Delete the downloaded files for %1$s? (%2$d tracks)</item>


### PR DESCRIPTION
Downloads kept a single active slot, so a batch, a tapped row and an auto-save fought over one card and whichever finished first blanked it while the others were still running.

The Downloads tab now shows a real queue. Each entry carries its own progress and outcome — running, done, failed or cancelled — and finished entries stay visible until cleared, capped so an auto-save on every track cannot grow without bound. onlyIfIdle is gone along with the slot it protected.

Cancel is per entry rather than the single handle added in #653, backed by a job per queue id. Pause is new: an entry suspends on a gate between tracks rather than polling a flag, so holding one costs nothing and it resumes the moment it is let go. Both are batch-only, since a single track has nothing to hold back.

Downloads is now what is on disk and DownloadQueue is what is in flight; they had grown into two jobs in one object.

Closes #642
Closes #644