### PR TITLE
Per-song download progress on the track row

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/download/DownloadQueue.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/download/DownloadQueue.kt
@@ -36,6 +36,18 @@ object DownloadQueue {
     /** Everything asked for, oldest first. */
     val queue: StateFlow<List<QueueEntry>> = _queue.asStateFlow()
 
+    private val _progress = MutableStateFlow<Map<String, Int>>(emptyMap())
+
+    /**
+     * How far along each track being fetched is, by uri. A queue entry knows the album or playlist
+     * the user asked for, so a track row cannot tell whether an entry's percentage is its own.
+     */
+    val progress: StateFlow<Map<String, Int>> = _progress.asStateFlow()
+
+    fun reportTrack(uri: String, percent: Int) = _progress.update { it + (uri to percent) }
+
+    fun clearTrack(uri: String) = _progress.update { it - uri }
+
     private val nextJobId = java.util.concurrent.atomic.AtomicInteger(0)
 
     private val gates = java.util.concurrent.ConcurrentHashMap<Int, CompletableDeferred<Unit>>()

--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/SharedComponents.kt
@@ -3,6 +3,7 @@
 package ch.snepilatch.app.ui.components
 
 import ch.snepilatch.app.R
+import ch.snepilatch.app.download.DownloadQueue
 import ch.snepilatch.app.download.Downloads
 import ch.snepilatch.app.ui.theme.SpfyWhite
 import androidx.compose.animation.core.tween
@@ -244,6 +245,10 @@ fun TrackRow(
     val inFlight by Downloads.inProgress.collectAsState()
     val isDownloaded = Downloads.isDownloaded(downloadedIndex, track.uri, track.name, track.artist)
     val isDownloading = track.uri in inFlight
+    // Keyed by uri so a row costs a lookup rather than a scan of the queue. Absent until the first
+    // progress lands, which is why a row that has started still falls back to the spinner.
+    val percent by DownloadQueue.progress.collectAsState()
+    val trackPercent = percent[track.uri]
 
     Row(
         Modifier
@@ -265,7 +270,16 @@ fun TrackRow(
                 maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
         if (isDownloading) {
-            CircularProgressIndicator(color = accent, strokeWidth = 2.dp, modifier = Modifier.size(14.dp))
+            if (trackPercent == null) {
+                CircularProgressIndicator(color = accent, strokeWidth = 2.dp, modifier = Modifier.size(14.dp))
+            } else {
+                CircularProgressIndicator(
+                    progress = { trackPercent.coerceIn(0, 100) / 100f },
+                    color = accent,
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(14.dp),
+                )
+            }
             Spacer(Modifier.width(6.dp))
         } else if (isDownloaded) {
             Icon(

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -3186,7 +3186,10 @@ class PlaybackViewModel : ViewModel() {
             val progress: ((Int) -> Unit)? = if (localOnly) {
                 null
             } else {
-                { percent -> DownloadQueue.updateJob(id, done = 1, trackPercent = percent) }
+                { percent ->
+                    DownloadQueue.updateJob(id, done = 1, trackPercent = percent)
+                    DownloadQueue.reportTrack(track.uri, percent)
+                }
             }
             var state = DownloadQueue.QueueEntry.State.Failed
             try {
@@ -3199,6 +3202,7 @@ class PlaybackViewModel : ViewModel() {
                 state = DownloadQueue.QueueEntry.State.Cancelled
                 throw e
             } finally {
+                DownloadQueue.clearTrack(track.uri)
                 // In a finally because cancellation (backing out of the app) has to settle the entry
                 // too; it used to be left running, so the tab claimed a download that had stopped.
                 DownloadQueue.finishJob(id, state)
@@ -3250,17 +3254,24 @@ class PlaybackViewModel : ViewModel() {
                     // rather than abandoning bytes already fetched.
                     DownloadQueue.awaitResume(id)
                     DownloadNotifier.batch(ctx, track.name, index + 1, tracks.size)
-                    val outcome = TrackDownloader.download(
-                        track.toRequest(
-                            contextUri = contextUri,
-                            contextName = contextName,
-                            contextType = contextType,
-                        ),
-                        ctx,
-                        notify = false,
-                    ) { percent ->
-                        DownloadQueue.updateJob(id, index + 1, percent)
-                        DownloadNotifier.batch(ctx, track.name, index + 1, tracks.size, percent)
+                    // Cleared in a finally: a cancelled batch unwinds before the call returns, and a
+                    // percentage left behind would freeze that row's ring for the rest of the process.
+                    val outcome = try {
+                        TrackDownloader.download(
+                            track.toRequest(
+                                contextUri = contextUri,
+                                contextName = contextName,
+                                contextType = contextType,
+                            ),
+                            ctx,
+                            notify = false,
+                        ) { percent ->
+                            DownloadQueue.updateJob(id, index + 1, percent)
+                            DownloadQueue.reportTrack(track.uri, percent)
+                            DownloadNotifier.batch(ctx, track.name, index + 1, tracks.size, percent)
+                        }
+                    } finally {
+                        DownloadQueue.clearTrack(track.uri)
                     }
                     if (outcome !is DownloadOutcome.Done) failed++
                     if (outcome is DownloadOutcome.NoFolder) {


### PR DESCRIPTION
A downloading row spun an indeterminate ring, so a song gave no sense of how far along it was.

The issue assumed the active job only needed a track uri attached to it. The queue changed that shape: an entry names the album or playlist the user asked for, so a row still could not tell whether a percentage was its own. Progress is now published per track uri instead, which also keeps a row to a lookup rather than a scan of the queue, the shape that made scrolling jank in #633.

A row still spins until the first progress callback lands, since the uri has no entry yet. The uri is cleared in a finally, so cancelling mid-track cannot leave a percentage behind and freeze that row's ring.

Both the batch and a single tapped download feed it.

Closes #641