### PR TITLE
Give single-entity home sections a card

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/ui/components/EntityMenuSheet.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/components/EntityMenuSheet.kt
@@ -1,0 +1,103 @@
+package ch.snepilatch.app.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ch.snepilatch.app.ui.theme.SpfyElevated
+import ch.snepilatch.app.ui.theme.SpfyLightGray
+import ch.snepilatch.app.ui.theme.SpfyWhite
+
+/**
+ * The action sheet for a whole entity (playlist, album, artist, show), wherever it is reached from:
+ * a detail header or a home card. The chrome and row layout live here so both open the same sheet
+ * rather than two that drift apart.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EntityMenuSheet(
+    imageUrl: String?,
+    title: String,
+    subtitle: String?,
+    actions: List<MenuAction>,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    )
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = SpfyElevated,
+    ) {
+        SheetNavBarFix()
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SpfyImage(url = imageUrl, modifier = Modifier.size(48.dp), shape = RoundedCornerShape(8.dp))
+            Spacer(Modifier.width(12.dp))
+            Column {
+                Text(
+                    title,
+                    color = SpfyWhite,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (subtitle != null) {
+                    Text(
+                        subtitle,
+                        color = SpfyLightGray,
+                        fontSize = 13.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        HorizontalDivider(color = SpfyLightGray.copy(alpha = 0.15f))
+        actions.forEach { action ->
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clickable { action.onClick() }
+                    .padding(horizontal = 20.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(action.icon, null, tint = SpfyWhite, modifier = Modifier.size(24.dp))
+                Spacer(Modifier.width(16.dp))
+                Text(action.label, color = SpfyWhite, fontSize = 15.sp)
+            }
+        }
+        Spacer(Modifier.navigationBarsPadding().height(12.dp))
+    }
+}
+
+/** One row of an [EntityMenuSheet]: what it looks like, what it says, what it does. */
+data class MenuAction(val icon: ImageVector, val label: String, val onClick: () -> Unit)

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/DetailScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.Pause
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Share
+import ch.snepilatch.app.ui.components.EntityMenuSheet
+import ch.snepilatch.app.ui.components.MenuAction
 import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material.icons.automirrored.rounded.QueueMusic
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -861,35 +863,6 @@ private fun AlbumTrackRow(
     }
 }
 
-/**
- * Bottom-sheet menu opened from the 3-dot button on the detail header
- * (album, playlist, artist, Liked Songs). Each row is a single action that
- * KotifyClient actually supports — no Premium-gated entries, no UI-only
- * "show Spfy Code" filler. Action set adapts to the detail type.
- *
- * Skips "Remove from Library" because the like/save toggle already lives
- * elsewhere in the header.
- */
-@Composable
-private fun DetailHeaderMenuTitle(detail: ch.snepilatch.app.data.DetailData, type: String) {
-    Row(
-        Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        ch.snepilatch.app.ui.components.SpfyImage(
-            url = detail.imageUrl,
-            modifier = Modifier.size(48.dp),
-            shape = RoundedCornerShape(8.dp)
-        )
-        Spacer(Modifier.width(12.dp))
-        Column {
-            Text(detail.name, color = SpfyWhite, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            val subtitle = detail.artistName ?: detail.ownerName ?: type.replaceFirstChar { it.uppercase() }
-            Text(subtitle, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        }
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DetailHeaderMenu(
@@ -898,75 +871,53 @@ private fun DetailHeaderMenu(
     context: android.content.Context,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
-    )
     val trackUris = detail.tracks.map { it.uri }; val hasTracks = trackUris.isNotEmpty(); val type = detail.type
     val isAlbum = type == "album"; val isCollection = type == "collection"; val isArtist = type == "artist"
     val shareLabel = stringResource(R.string.share); val addToQueueLabel = stringResource(R.string.add_to_queue)
     val addToPlaylistLabel = stringResource(R.string.add_to_playlist); val visitArtistLabel = stringResource(R.string.visit_artist)
     val artistRadioLabel = stringResource(R.string.go_to_artist_radio)
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = sheetState,
-        containerColor = SpfyElevated,
-    ) {
-        ch.snepilatch.app.ui.components.SheetNavBarFix()
-        DetailHeaderMenuTitle(detail, type)
-        Spacer(Modifier.height(8.dp))
-        HorizontalDivider(color = SpfyLightGray.copy(alpha = 0.15f))
-        val items = buildList<Triple<androidx.compose.ui.graphics.vector.ImageVector, String, () -> Unit>> {
-            if (!isCollection) {
-                val id = detail.uri.substringAfterLast(":")
-                add(Triple(Icons.Rounded.Share, shareLabel) {
-                    onDismiss()
-                    val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
-                        this.type = "text/plain"
-                        putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/$type/$id")
-                    }
-                    context.startActivity(android.content.Intent.createChooser(intent, shareLabel))
-                })
-            }
-            if (hasTracks && !isArtist) {
-                add(Triple(Icons.AutoMirrored.Rounded.QueueMusic, addToQueueLabel) {
-                    onDismiss()
-                    vm.addAllToQueue(trackUris)
-                })
-                add(Triple(Icons.AutoMirrored.Rounded.PlaylistAdd, addToPlaylistLabel) {
-                    onDismiss()
-                    vm.showPlaylistPickerForTracks(trackUris)
-                })
-            }
-            if (isAlbum && detail.artistUri != null) {
-                add(Triple(Icons.Rounded.Person, visitArtistLabel) {
-                    onDismiss()
-                    val artistId = detail.artistUri.substringAfterLast(":")
-                    DetailRoutes.openArtist(artistId)
-                })
-            }
-            // An album seeds with its artist, same as the desktop client — hence "artist radio" there.
-            val radioSeed = if (isArtist) detail.uri else detail.artistUri?.takeIf { isAlbum }
-            if (radioSeed != null) {
-                add(Triple(Icons.Rounded.Radio, artistRadioLabel) {
-                    onDismiss()
-                    DetailRoutes.openRadio(radioSeed)
-                })
-            }
+    val actions = buildList {
+        if (!isCollection) {
+            val id = detail.uri.substringAfterLast(":")
+            add(MenuAction(Icons.Rounded.Share, shareLabel) {
+                onDismiss()
+                val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                    this.type = "text/plain"
+                    putExtra(android.content.Intent.EXTRA_TEXT, "https://open.spotify.com/$type/$id")
+                }
+                context.startActivity(android.content.Intent.createChooser(intent, shareLabel))
+            })
         }
-        items.forEach { (icon, label, onClick) ->
-            Row(
-                Modifier
-                    .fillMaxWidth()
-                    .clickable { onClick() }
-                    .padding(horizontal = 20.dp, vertical = 14.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(icon, null, tint = SpfyWhite, modifier = Modifier.size(24.dp))
-                Spacer(Modifier.width(16.dp))
-                Text(label, color = SpfyWhite, fontSize = 15.sp)
-            }
+        if (hasTracks && !isArtist) {
+            add(MenuAction(Icons.AutoMirrored.Rounded.QueueMusic, addToQueueLabel) {
+                onDismiss()
+                vm.addAllToQueue(trackUris)
+            })
+            add(MenuAction(Icons.AutoMirrored.Rounded.PlaylistAdd, addToPlaylistLabel) {
+                onDismiss()
+                vm.showPlaylistPickerForTracks(trackUris)
+            })
         }
-        Spacer(Modifier.navigationBarsPadding().height(12.dp))
+        if (isAlbum && detail.artistUri != null) {
+            add(MenuAction(Icons.Rounded.Person, visitArtistLabel) {
+                onDismiss()
+                DetailRoutes.openArtist(detail.artistUri.substringAfterLast(":"))
+            })
+        }
+        // An album seeds with its artist, same as the desktop client — hence "artist radio" there.
+        val radioSeed = if (isArtist) detail.uri else detail.artistUri?.takeIf { isAlbum }
+        if (radioSeed != null) {
+            add(MenuAction(Icons.Rounded.Radio, artistRadioLabel) {
+                onDismiss()
+                DetailRoutes.openRadio(radioSeed)
+            })
+        }
     }
+    EntityMenuSheet(
+        imageUrl = detail.imageUrl,
+        title = detail.name,
+        subtitle = detail.artistName ?: detail.ownerName ?: type.replaceFirstChar { it.uppercase() },
+        actions = actions,
+        onDismiss = onDismiss
+    )
 }

--- a/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/ui/screens/HomeScreen.kt
@@ -1,8 +1,21 @@
 package ch.snepilatch.app.ui.screens
 
+import androidx.compose.material.icons.rounded.AddCircleOutline
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.MoreVert
+import androidx.compose.material.icons.rounded.Pause
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import ch.snepilatch.app.R
 import ch.snepilatch.app.data.LIKED_SONGS_COVER_URL
 import ch.snepilatch.app.ui.theme.SpfyWhite
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloat
@@ -10,6 +23,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -26,6 +40,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
+import androidx.compose.material.icons.automirrored.rounded.QueueMusic
+import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.MusicNote
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material3.Card
@@ -34,22 +51,35 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ch.snepilatch.app.ui.components.ShimmerBox
+import ch.snepilatch.app.ui.components.EntityMenuSheet
+import ch.snepilatch.app.ui.components.MenuAction
 import ch.snepilatch.app.ui.components.SpfyImage
 import ch.snepilatch.app.ui.theme.SpfyCardBg
 import ch.snepilatch.app.ui.theme.SpfyLightGray
+import ch.snepilatch.app.util.CardColors
+import ch.snepilatch.app.util.extractCardColorsFromArt
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.snepilatch.app.viewmodel.DetailViewModel
 import ch.snepilatch.app.viewmodel.HomeViewModel
+import ch.snepilatch.app.viewmodel.LibraryViewModel
 import ch.snepilatch.app.viewmodel.PlaybackViewModel
 
 // --- Home Screen ---
@@ -97,6 +127,12 @@ fun HomeScreen(vm: PlaybackViewModel) {
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.padding(start = 16.dp, top = 20.dp, bottom = 10.dp)
                     )
+                }
+                // A section holding one thing reads as a lone tile in a row that goes nowhere, so it
+                // gets a card wide enough to say what it is instead.
+                if (section.items.size == 1) {
+                    item { HomeSingleCard(section.items.first(), vm) }
+                    return@forEach
                 }
                 item {
                     LazyRow(
@@ -218,6 +254,266 @@ fun HomeShimmer() {
                 }
             }
         }
+    }
+}
+
+/**
+ * The card's three colours, read off the cover. Until that read lands (and if it fails) the colour
+ * the feed states for the artwork stands in, so the card never flashes grey first.
+ */
+@Composable
+private fun homeCardColors(item: kotify.api.home.HomeSectionItem): CardColors {
+    val stated = remember(item.accentColor) {
+        item.accentColor
+            ?.let { hex -> runCatching { Color(android.graphics.Color.parseColor(hex)) }.getOrNull() }
+            ?.let { lerp(it, Color.Black, 0.3f) }
+    } ?: SpfyCardBg
+    val art = homeArt(item)
+    val context = LocalContext.current
+    val palette by produceState<CardColors?>(null, art) {
+        value = art?.let { runCatching { extractCardColorsFromArt(context, it) }.getOrNull() }
+    }
+    return palette ?: CardColors(
+        base = stated,
+        glow = lerp(stated, Color.White, 0.15f),
+        counterGlow = lerp(stated, Color.Black, 0.35f)
+    )
+}
+
+/**
+ * A section holding a single entity, given room to describe itself: cover, name, owner, how many
+ * tracks it holds, and a play button. Tinted with the colour the feed states for the artwork, so it
+ * matches the cover without sampling it.
+ */
+@Composable
+fun HomeSingleCard(item: kotify.api.home.HomeSectionItem, vm: PlaybackViewModel) {
+    val detailVm: DetailViewModel = viewModel()
+    val (base, glow, counterGlow) = homeCardColors(item)
+    val open = {
+        val id = item.uri.substringAfterLast(":")
+        when (item.type) {
+            "collection" -> detailVm.openLikedSongs()
+            "album" -> detailVm.openAlbum(id)
+            "artist" -> detailVm.openArtist(id)
+            "show" -> detailVm.openShow(id, item.owner, item.imageUrl)
+            else -> detailVm.openPlaylist(id)
+        }
+    }
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .clickable(onClick = open),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = base)
+    ) {
+        Column(
+            Modifier
+                // Light blooming out of the cover, not a ramp across the card: a wide glow anchored
+                // on the artwork, a cooler one thrown back from the far corner, and a scrim down the
+                // bottom so the white play button still reads against it.
+                .drawBehind {
+                    drawRect(
+                        Brush.radialGradient(
+                            listOf(glow.copy(alpha = 0.55f), glow.copy(alpha = 0f)),
+                            center = Offset(size.width * 0.16f, size.height * 0.26f),
+                            radius = size.width * 0.78f
+                        )
+                    )
+                    drawRect(
+                        Brush.radialGradient(
+                            listOf(counterGlow.copy(alpha = 0.5f), counterGlow.copy(alpha = 0f)),
+                            center = Offset(size.width, size.height * 1.05f),
+                            radius = size.width * 0.7f
+                        )
+                    )
+                    drawRect(
+                        Brush.verticalGradient(
+                            listOf(Color.Transparent, Color.Black.copy(alpha = 0.22f))
+                        )
+                    )
+                }
+                .padding(14.dp)
+        ) {
+            Row {
+                SpfyImage(
+                    url = homeArt(item),
+                    modifier = Modifier.size(80.dp),
+                    shape = RoundedCornerShape(6.dp)
+                )
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f).padding(top = 6.dp)) {
+                    Text(
+                        homeLabel(item),
+                        color = SpfyWhite,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    item.owner?.takeIf { it.isNotBlank() }?.let { owner ->
+                        Text(owner, color = SpfyLightGray, fontSize = 13.sp, maxLines = 1)
+                    }
+                }
+                HomeCardMenu(item, vm)
+            }
+            HomeCardMeta(item)
+            Spacer(Modifier.height(14.dp))
+            HomeCardActions(item, vm)
+        }
+    }
+}
+
+/**
+ * Play or pause this entity, and save it. The play button follows the transport: if this is what is
+ * playing, it offers to pause rather than restarting from the top.
+ */
+@Composable
+private fun HomeCardActions(item: kotify.api.home.HomeSectionItem, vm: PlaybackViewModel) {
+    val playing by vm.isPlayingFlow.collectAsState()
+    val context by vm.playingContext.collectAsState()
+    val isThis = context?.uri == item.uri && playing
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.End,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (item.type != "collection") {
+            HomeCardLike(item, vm)
+            Spacer(Modifier.width(12.dp))
+        }
+        Box(
+            Modifier
+                .size(44.dp)
+                .clip(CircleShape)
+                .background(SpfyWhite)
+                .clickable { if (isThis) vm.togglePlayPause() else vm.playTrack(item.uri) },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                if (isThis) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
+                stringResource(if (isThis) R.string.pause else R.string.play),
+                tint = Color.Black,
+                modifier = Modifier.size(32.dp)
+            )
+        }
+    }
+}
+
+/** The same action sheet the detail header opens, for an entity reached straight from the feed. */
+@Composable
+private fun HomeCardMenu(item: kotify.api.home.HomeSectionItem, vm: PlaybackViewModel) {
+    val detailVm: DetailViewModel = viewModel()
+    val context = LocalContext.current
+    var showMenu by remember { mutableStateOf(false) }
+    IconButton(onClick = { showMenu = true }, modifier = Modifier.size(40.dp)) {
+        Icon(Icons.Rounded.MoreVert, stringResource(R.string.more), tint = SpfyWhite, modifier = Modifier.size(26.dp))
+    }
+    if (!showMenu) return
+    val shareLabel = stringResource(R.string.share)
+    val actions = buildList {
+        if (item.type != "collection") {
+            add(
+                MenuAction(Icons.Rounded.AddCircleOutline, stringResource(R.string.save_to_library)) {
+                    showMenu = false
+                    vm.saveToLibrary(item.type, item.uri.substringAfterLast(":"))
+                }
+            )
+        }
+        if (item.type != "artist") {
+            add(
+                MenuAction(Icons.AutoMirrored.Rounded.QueueMusic, stringResource(R.string.add_to_queue)) {
+                    showMenu = false
+                    detailVm.fetchTrackUris(item.uri) { vm.addAllToQueue(it) }
+                }
+            )
+            add(
+                MenuAction(Icons.AutoMirrored.Rounded.PlaylistAdd, stringResource(R.string.add_to_playlist)) {
+                    showMenu = false
+                    detailVm.fetchTrackUris(item.uri) { vm.showPlaylistPickerForTracks(it) }
+                }
+            )
+        }
+        add(
+            MenuAction(Icons.Rounded.Share, shareLabel) {
+                showMenu = false
+                val parts = item.uri.split(":")
+                val link = "https://open.spotify.com/${parts.getOrNull(1)}/${parts.lastOrNull()}"
+                val intent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(android.content.Intent.EXTRA_TEXT, link)
+                }
+                context.startActivity(android.content.Intent.createChooser(intent, shareLabel))
+            }
+        )
+    }
+    EntityMenuSheet(
+        imageUrl = homeArt(item),
+        title = homeLabel(item),
+        subtitle = item.owner?.takeIf { it.isNotBlank() },
+        actions = actions,
+        onDismiss = { showMenu = false }
+    )
+}
+
+/** How many tracks the entity holds, then who is on it, in the card's own line under the cover. */
+@Composable
+private fun HomeCardMeta(item: kotify.api.home.HomeSectionItem) {
+    val count = item.trackCount?.let { stringResource(R.string.home_card_songs, it) }
+    // Playlists carry no artist list in the feed; a radio playlist names its artists in its
+    // description instead, which is the same line the reference client puts here. Descriptions are
+    // HTML and link their seed playlists, so the markup has to come off before it is shown. On an
+    // album the artist is also the owner, and saying it twice reads as a bug.
+    val artists = item.artists?.takeIf { it.isNotEmpty() }?.joinToString(", ")
+        ?: remember(item.description) {
+            item.description?.takeIf { it.isNotBlank() }?.let {
+                android.text.Html.fromHtml(it, android.text.Html.FROM_HTML_MODE_LEGACY).toString().trim()
+            }?.takeIf { it.isNotBlank() }
+        }
+    val shown = artists?.takeIf { !it.equals(item.owner, ignoreCase = true) }
+    if (count == null && shown == null) return
+    Spacer(Modifier.height(14.dp))
+    Text(
+        buildAnnotatedString {
+            if (count != null) {
+                withStyle(SpanStyle(color = SpfyWhite, fontWeight = FontWeight.Bold)) { append(count) }
+            }
+            if (count != null && shown != null) append(" • ")
+            if (shown != null) append(shown)
+        },
+        color = SpfyLightGray,
+        fontSize = 13.sp,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis
+    )
+}
+
+/**
+ * Saves the entity to the library. The save call does not refresh the library list, so the tap is
+ * also held locally, otherwise the heart stays hollow until the next load.
+ */
+@Composable
+private fun HomeCardLike(item: kotify.api.home.HomeSectionItem, vm: PlaybackViewModel) {
+    val libraryVm: LibraryViewModel = viewModel()
+    val library by libraryVm.library.collectAsState()
+    var tapped by remember(item.uri) { mutableStateOf<Boolean?>(null) }
+    val saved = library.any { it.uri == item.uri }
+    val liked = tapped ?: saved
+    IconButton(onClick = {
+        val id = item.uri.substringAfterLast(":")
+        if (liked) {
+            vm.removeFromLibrary(item.type, id) { libraryVm.loadLibrary() }
+        } else {
+            vm.saveToLibrary(item.type, id) { libraryVm.loadLibrary() }
+        }
+        tapped = !liked
+    }) {
+        Icon(
+            if (liked) Icons.Rounded.CheckCircle else Icons.Rounded.AddCircleOutline,
+            stringResource(R.string.save_to_library),
+            tint = SpfyWhite,
+            modifier = Modifier.size(30.dp)
+        )
     }
 }
 

--- a/src/app/src/main/java/ch/snepilatch/app/util/AlbumArtPalette.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/util/AlbumArtPalette.kt
@@ -71,3 +71,83 @@ private fun isUsablePaletteColor(color: Int): Boolean {
     if (sat > 0.85f && brightness > 150) return false
     return true
 }
+
+/** The three colours a home card lights itself with: its ground, and two glows off the artwork. */
+data class CardColors(val base: Color, val glow: Color, val counterGlow: Color)
+
+/**
+ * Reads the cover and returns the colours to bloom the card with. The ground is the artwork's
+ * darkest muted shade so text stays readable on it, and the two glows are its most saturated
+ * shades, which is what gives the card light coming out of the cover rather than a flat ramp.
+ *
+ * Returns null if the image fails to load, and the caller falls back to the colour the feed states.
+ */
+suspend fun extractCardColorsFromArt(context: Context, imageUrl: String): CardColors? {
+    val loader = coil.Coil.imageLoader(context)
+    val request = ImageRequest.Builder(context)
+        .data(imageUrl)
+        .size(112)
+        .allowHardware(false)
+        .build()
+    val result = loader.execute(request)
+    if (result !is SuccessResult) return null
+    val bitmap = (result.drawable as? BitmapDrawable)?.bitmap ?: return null
+    val palette = Palette.from(bitmap).generate()
+    // The card takes its ground from the cover's outer ring, not from a swatch: these covers are
+    // built on a solid colour that runs to the edge, and that edge is the colour the card is meant
+    // to be. A swatch would pick something out of the photo in the middle instead.
+    val base = edgeColor(bitmap) ?: palette.darkMutedSwatch?.rgb ?: return null
+    val glow = palette.vibrantSwatch?.rgb
+        ?: palette.lightVibrantSwatch?.rgb
+        ?: palette.mutedSwatch?.rgb
+        ?: base
+    val counter = palette.darkVibrantSwatch?.rgb
+        ?: palette.mutedSwatch?.rgb
+        ?: palette.lightMutedSwatch?.rgb
+        ?: glow
+    return CardColors(Color(mutedGround(base)), Color(glow), Color(counter))
+}
+
+/** The average of the cover's outermost ring, which on a built cover is its background colour. */
+private fun edgeColor(bitmap: android.graphics.Bitmap): Int? {
+    val w = bitmap.width
+    val h = bitmap.height
+    val ring = maxOf(2, minOf(w, h) / 20)
+    if (w <= ring * 2 || h <= ring * 2) return null
+    var r = 0L
+    var g = 0L
+    var b = 0L
+    var n = 0
+    fun take(pixel: Int) {
+        r += (pixel shr 16) and 0xFF
+        g += (pixel shr 8) and 0xFF
+        b += pixel and 0xFF
+        n++
+    }
+    for (x in 0 until w) {
+        for (y in 0 until ring) {
+            take(bitmap.getPixel(x, y))
+            take(bitmap.getPixel(x, h - 1 - y))
+        }
+    }
+    for (y in ring until h - ring) {
+        for (x in 0 until ring) {
+            take(bitmap.getPixel(x, y))
+            take(bitmap.getPixel(w - 1 - x, y))
+        }
+    }
+    if (n == 0) return null
+    return (0xFF shl 24) or ((r / n).toInt() shl 16) or ((g / n).toInt() shl 8) or (b / n).toInt()
+}
+
+/**
+ * The dark, calm version of a colour. Covers are bright by design, and a card filled with the raw
+ * edge colour would glare and swallow its own text, so saturation and lightness are capped.
+ */
+private fun mutedGround(color: Int): Int {
+    val hsv = FloatArray(3)
+    android.graphics.Color.colorToHSV(color, hsv)
+    hsv[1] = minOf(hsv[1], 0.55f)
+    hsv[2] = minOf(hsv[2], 0.34f)
+    return android.graphics.Color.HSVToColor(hsv)
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/DetailViewModel.kt
@@ -278,6 +278,25 @@ class DetailViewModel : SessionViewModel("DetailVM") {
         }
     }
 
+    /**
+     * One page of an entity's tracks, fetched without touching the open detail, for acting on
+     * something straight from the feed.
+     *
+     * ponytail: one page, same as opening it would have loaded. A 700 track playlist hands over its
+     * first 50; page it here if "add the whole thing to the queue" ever needs to mean all of it.
+     */
+    fun fetchTrackUris(uri: String, onReady: (List<String>) -> Unit) {
+        launchWithSession("fetchTrackUris") { sess ->
+            val id = uri.substringAfterLast(":")
+            val tracks = when {
+                uri.contains(":collection") -> Playlist(sess).getLikedSongs(limit = 50).toDetailData(offset = 0)
+                uri.contains(":album:") -> Album(sess).getAlbum(id, limit = 50).toDetailData(id)
+                else -> Playlist(sess).getPlaylist(id, 50, 0).toDetailData(id)
+            }
+            onReady(tracks.tracks.map { it.uri })
+        }
+    }
+
     fun checkDetailSaved(type: String, id: String) {
         viewModelScope.launch(Dispatchers.IO) {
             try {

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -3612,17 +3612,47 @@ class PlaybackViewModel : ViewModel() {
 
     // --- Playlist Management ---
 
-    fun followArtist(artistId: String) {
-        launchWithSession("followArtist", R.string.error_follow) { sess ->
-            Artist(sess).follow(artistId)
+    /**
+     * Save any entity to the library by its type. Albums, artists and playlists each land somewhere
+     * different, and a caller holding a feed item should not have to know which.
+     */
+    fun saveToLibrary(type: String, id: String, onSaved: (() -> Unit)? = null) {
+        when (type) {
+            "artist" -> followArtist(id, onSaved)
+            "album" -> launchWithSession("saveAlbum", R.string.error_save_library) { sess ->
+                kotify.api.album.Album(sess).saveToLibrary(id)
+                onSaved?.invoke()
+            }
+            else -> savePlaylist(id, onSaved)
         }
     }
 
-    fun savePlaylist(playlistId: String) {
+    /** The mirror of [saveToLibrary], so a caller can undo a save without holding the library list. */
+    fun removeFromLibrary(type: String, id: String, onDone: (() -> Unit)? = null) {
+        launchWithSession("removeFromLibrary", R.string.error_save_library) { sess ->
+            when (type) {
+                "artist" -> Artist(sess).unfollow(id)
+                "album" -> kotify.api.album.Album(sess).removeFromLibrary(id)
+                else -> kotify.api.playlist.Playlist(sess).deletePlaylist(id, username)
+            }
+            onDone?.invoke()
+        }
+    }
+
+    /** [onSaved] runs once the server has taken it, for a caller that shows the library. */
+    fun followArtist(artistId: String, onSaved: (() -> Unit)? = null) {
+        launchWithSession("followArtist", R.string.error_follow) { sess ->
+            Artist(sess).follow(artistId)
+            onSaved?.invoke()
+        }
+    }
+
+    fun savePlaylist(playlistId: String, onSaved: (() -> Unit)? = null) {
         launchWithSession("savePlaylist", R.string.error_save_library) { sess ->
             // Playlists live in the rootlist, not the generic library (which rejects PLAYLIST uris),
             // so saveToLibrary needs the current username.
             kotify.api.playlist.Playlist(sess).saveToLibrary(playlistId, username)
+            onSaved?.invoke()
         }
     }
 

--- a/src/app/src/main/res/values/strings.xml
+++ b/src/app/src/main/res/values/strings.xml
@@ -358,6 +358,7 @@
     <string name="downloads_cancelled">Cancelled</string>
     <string name="downloads_clear_finished">Clear finished</string>
     <string name="liked_songs">Liked Songs</string>
+    <string name="home_card_songs">%1$d Songs</string>
     <string name="downloads_paused">Paused at %1$d of %2$d</string>
     <string name="pause">Pause</string>
     <string name="resume">Resume</string>


### PR DESCRIPTION
A home section holding one thing rendered as a lone tile in a row that went nowhere. It now gets a card: cover, name, owner, how many tracks it holds, the artists on it, a save button, a play button that follows the transport, and the same action sheet the detail header opens.

The card takes its colour from the cover's outer ring, since these covers are built on a solid colour that runs to the edge, and blooms it out of the artwork rather than running a flat ramp across the card.

Closes #550