### PR TITLE
Let the state machine own the track boundary for downloaded tracks

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -1046,15 +1046,10 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
         }
     }
 
+    /** The next track's metadata, so the notification can name it before it starts. */
     @OptIn(UnstableApi::class)
-    fun setNextUrl(
-        url: String,
-        title: String,
-        artist: String,
-        albumArtUrl: String?,
-        headers: Map<String, String> = emptyMap()
-    ) {
-        LokiLogger.i(TAG, "Next: $title by $artist (headers=${headers.keys})")
+    fun setNextMetadata(title: String, artist: String, albumArtUrl: String?) {
+        LokiLogger.i(TAG, "Next: $title by $artist")
         val meta = TrackMetadata(title, artist, albumArtUrl)
 
         // Keep only the current track's metadata, replace any queued next
@@ -1068,16 +1063,15 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
             meta.art = albumArtUrl?.let { loadBitmap(it) }
         }
 
+        // Metadata only. Enqueuing the next track as a second media item let ExoPlayer perform the
+        // boundary itself, on the local file's clock — and only ever for a non-DRM next track, since a
+        // Widevine one needs its own license session and was never enqueued. Spfy then received an
+        // advance that did not line up with the track it believed was playing, refused it, and its
+        // state_conflict reply put us back on the previous track, forever (#636). The state machine
+        // owns the boundary; playPreResolved loads this url through the normal path when we get there.
         mainHandler.post {
             staleQueueStart(player.currentMediaItemIndex, player.mediaItemCount)?.let { from ->
                 player.removeMediaItems(from, player.mediaItemCount)
-            }
-            // Header-gated sources (anandserver Qobuz) must be enqueued as a
-            // header-injecting MediaSource, or the gapless advance hits a 401.
-            if (headers.isEmpty()) {
-                player.addMediaItem(buildMediaItem(url))
-            } else {
-                player.addMediaSource(buildHeaderedSource(url, headers))
             }
         }
     }

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -3591,7 +3591,7 @@ class PlaybackViewModel : ViewModel() {
                     nextStreamHeaders = headers
                     nextTrackInfo = TrackInfo(uri = nextUri, name = title, artist = artist, albumArt = art)
                     nextStreamProvider = info.provider
-                    MusicPlaybackService.instance?.setNextUrl(playable, title, artist, art, headers)
+                    MusicPlaybackService.instance?.setNextMetadata(title, artist, art)
                     isNextReady.value = true
                     LokiLogger.i(TAG, "Next track pre-resolved: ${info.provider}")
                 }


### PR DESCRIPTION
A downloaded next track was enqueued as a second ExoPlayer media item, so ExoPlayer performed the boundary itself on the local file''s clock and `STATE_ENDED` never fired. That only ever happened for a non-DRM next track — a Widevine one needs its own license session and was never enqueued — which is why pure CDN playback was fine and a downloaded next track jumped back every time.

`setNextUrl` becomes `setNextMetadata`: notification metadata only. `playPreResolved` still loads the same url, still local-first, when we actually reach the track.

Verified on device: the transition that previously looped every three minutes now plays through and advances normally.

Closes #664