### PR TITLE
A pressed skip walks skip_next, as the web player's forward button does

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -1779,7 +1779,10 @@ class PlaybackViewModel : ViewModel() {
             try {
                 val t0 = System.currentTimeMillis()
                 // Local advance (state report, never skip-capped) — the new track loads via onPlaybackId.
-                player?.localNext()
+                // A pressed button walks the machine's skip_next edge, as the web player's forward button
+                // does; the default reason walks advance, which is the natural end and lands elsewhere on
+                // graphs where the two differ (radio, autoplay, smart shuffle).
+                player?.localNext(kotify.api.playerstatus.AdvanceReason.USER_SKIP)
                 LokiLogger.i(TAG, "[Timing] CMD skipNext API done in ${System.currentTimeMillis() - t0}ms")
             }
             catch (e: CancellationException) { throw e }


### PR DESCRIPTION
Pass USER_SKIP from skipNext() so a manual skip follows the state machine's skip_next edge rather than advance.

Closes #670