### PR TITLE
Pause when headphones or Bluetooth disconnect

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/MusicPlaybackService.kt
@@ -286,6 +286,7 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
         player = ExoPlayer.Builder(this, renderersFactory)
             .setAudioAttributes(audioAttributes, true)
+            .setHandleAudioBecomingNoisy(true)
             .setLoadControl(loadControl)
             // Let ExoPlayer manage a wake/Wi-Fi lock for its OWN network needs (buffering). Note this
             // is scoped to the player — once a track is buffered ExoPlayer releases it and lets the
@@ -339,8 +340,9 @@ class MusicPlaybackService : MediaBrowserServiceCompat() {
 
                 // Permanent focus loss (a call answered, another app taking over): ExoPlayer clears
                 // playWhenReady and will not come back on its own, which is correct. Report it.
-                if (!playWhenReady && reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS) {
-                    LokiLogger.i(TAG, "Audio focus lost for good — reporting pause to Spfy")
+                if (!playWhenReady && (reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_FOCUS_LOSS ||
+                        reason == Player.PLAY_WHEN_READY_CHANGE_REASON_AUDIO_BECOMING_NOISY)) {
+                    LokiLogger.i(TAG, "Focus lost or output disconnected — reporting pause to Spfy")
                     onAudioFocusPaused?.invoke()
                 }
             }


### PR DESCRIPTION
ExoPlayer handles the audio-becoming-noisy broadcast, so an unplug or Bluetooth drop pauses instead of continuing on the speaker, and that pause is reported to Spfy like a focus loss.

Refs #672