### PR TITLE
Resolve and license a downloaded track before playing it locally

### DIFF
--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpfyCdnResolver.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/SpfyCdnResolver.kt
@@ -36,8 +36,13 @@ class SpfyCdnResolver(
      * retry lands on a DIFFERENT CDN edge — hammering the same dead mirror is what left a bad edge
      * stuck in silence.
      */
+    /** Told what every resolve produced, so KotifyClient's playback telemetry carries the real stream. */
+    var onResolved: ((kotify.api.playerstatus.StreamInfo) -> Unit)? = null
+
     suspend fun resolveForFileId(fileId: String, mirrorIndex: Int = 0): SpfyStream {
+        val t0 = System.currentTimeMillis()
         val cdnUrls = spfyPlayback.getCdnUrls(fileId)
+        onResolved?.invoke(kotify.api.playerstatus.StreamInfo(fileId, cdnUrls, msResolveLatency = System.currentTimeMillis() - t0))
         if (cdnUrls.isEmpty()) throw IllegalStateException("No CDN mirrors for fileId=$fileId")
         val cdnUrl = cdnUrls[mirrorIndex.mod(cdnUrls.size)]
         return SpfyStream(
@@ -104,6 +109,10 @@ class SpfyCdnResolver(
             ?: spfyPlayback.findFile(meta, SpfyPlayback.AudioQuality.MP4_256)
         return mp4File?.fileId
     }
+
+    /** One license exchange for [stream] with no player, through the same browser-shaped client. */
+    suspend fun license(stream: SpfyStream): Long =
+        WidevineLicenser.license(session, stream.licenseUrl, stream.pssh ?: throw IllegalStateException("no pssh"))
 
     private fun buildLicenseHeaders(): Map<String, String> {
         val headers = mutableMapOf<String, String>()

--- a/src/app/src/main/java/ch/snepilatch/app/playback/engine/WidevineLicenser.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/playback/engine/WidevineLicenser.kt
@@ -1,0 +1,33 @@
+package ch.snepilatch.app.playback.engine
+
+import android.media.MediaDrm
+import android.util.Base64
+import androidx.media3.common.C
+import kotify.session.Session
+
+/**
+ * One Widevine license exchange without a player: what the web player does for every track it
+ * loads. Used when a downloaded copy plays, so the server sees the same resolve and license as for
+ * a stream. The request goes through KotifyClient's browser-shaped HTTP client like every other
+ * Spfy call. Returns the exchange time in ms.
+ */
+object WidevineLicenser {
+
+    suspend fun license(session: Session, licenseUrl: String, psshBase64: String): Long {
+        val t0 = System.currentTimeMillis()
+        val drm = MediaDrm(C.WIDEVINE_UUID)
+        val drmSession = drm.openSession()
+        try {
+            val request = drm.getKeyRequest(
+                drmSession, Base64.decode(psshBase64, Base64.DEFAULT), "audio/mp4", MediaDrm.KEY_TYPE_STREAMING, null
+            )
+            val response = session.getHttpClient()
+                .postBinary(licenseUrl, request.data, mapOf("Content-Type" to "application/octet-stream"))
+            drm.provideKeyResponse(drmSession, response)
+        } finally {
+            drm.closeSession(drmSession)
+            drm.release()
+        }
+        return System.currentTimeMillis() - t0
+    }
+}

--- a/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
+++ b/src/app/src/main/java/ch/snepilatch/app/viewmodel/PlaybackViewModel.kt
@@ -502,7 +502,9 @@ class PlaybackViewModel : ViewModel() {
                 session = sess
                 val sp = SpfyPlayback(sess)
                 spfyPlayback = sp
-                cdnResolver = SpfyCdnResolver(sess, sp)
+                cdnResolver = SpfyCdnResolver(sess, sp).also { r ->
+                    r.onResolved = { info -> player?.reportStreamResolved(info) }
+                }
                 LokiLogger.i(TAG, "Session loaded")
 
                 // Home and library load themselves from HomeViewModel.init / LibraryViewModel.init.
@@ -3030,6 +3032,26 @@ class PlaybackViewModel : ViewModel() {
      * Plays a downloaded copy. Runs before the Spfy branch, which returns without ever reaching the
      * resolver, so a downloaded track plays from disk whatever the selected source is.
      */
+    /**
+     * A downloaded copy still resolves and licenses like a stream (about 10 KB, no audio), so the
+     * server sees what it sees for the web player and the telemetry stays truthful.
+     */
+    private suspend fun licenseLocalCopy(trackUri: String) {
+        val resolver = cdnResolver ?: return
+        val fileId = fileIdForTrack(null, trackUri) ?: return
+        try {
+            val stream = resolver.resolveForFileId(fileId)
+            if (stream.pssh == null) return
+            val ms = resolver.license(stream)
+            player?.reportStreamResolved(kotify.api.playerstatus.StreamInfo(fileId, listOf(stream.cdnUrl), msLicenseLatency = ms))
+            LokiLogger.i(TAG, "Licensed downloaded copy of $trackUri in ${ms}ms")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            LokiLogger.w(TAG, "Licensing downloaded copy of $trackUri failed: ${e.message}")
+        }
+    }
+
     private suspend fun playDownloaded(trackUri: String, title: String, artist: String, art: String?): Boolean {
         val local = AudioSourceResolver.localOrNull(trackUri, title, artist) as? StreamResult.Success
             ?: return false
@@ -3045,6 +3067,7 @@ class PlaybackViewModel : ViewModel() {
         commitStream(trackUri, AudioSourceResolver.LOCAL_PROVIDER)
         isStreamLoading.value = false
         LokiLogger.i(TAG, "Playing downloaded copy of $trackUri")
+        viewModelScope.launch(Dispatchers.IO) { licenseLocalCopy(trackUri) }
         preResolveNextTrack()
         return true
     }


### PR DESCRIPTION
A downloaded copy now does what the web player does for every track it loads: storage-resolve, seektable and one Widevine license exchange (about 10 KB, no audio), all through KotifyClient's browser-shaped client. Every resolve, streamed or local, reports its stream facts to KotifyClient so the melody telemetry carries real urls and latencies.

Needs the KotifyClient release with #407 before CI can build it.

Refs #678